### PR TITLE
iRODS AVU endpoint migration

### DIFF
--- a/services/apps/src/apps/clients/data_info.clj
+++ b/services/apps/src/apps/clients/data_info.clj
@@ -15,6 +15,7 @@
   (str (apply curl/url (config/data-info-base-url)
               (map #(string/replace % #"^/+|/+$" "") components))))
 
+;; currently doesn't support passing UUIDs, but could be changed to
 (defn get-file-stats
   [user paths]
   (when (seq paths)

--- a/services/data-info/project.clj
+++ b/services/data-info/project.clj
@@ -54,4 +54,5 @@
          :init data-info.core/lein-ring-init
          :port 60000
          :auto-reload? false}
-  :uberjar-exclusions [#".*[.]SF" #"LICENSE" #"NOTICE"])
+  :uberjar-exclusions [#".*[.]SF" #"LICENSE" #"NOTICE"]
+  :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/data-info-logging.xml"])

--- a/services/data-info/project.clj
+++ b/services/data-info/project.clj
@@ -23,7 +23,6 @@
                  [com.cemerick/url "0.1.1"]
                  [dire "0.5.3"]
                  [me.raynes/fs "1.4.6"]
-                 [medley "0.7.0"]
                  [metosin/compojure-api "0.24.2"]
                  [net.sf.json-lib/json-lib "2.4" :classifier "jdk15"]
                  [org.apache.tika/tika-core "1.11"]

--- a/services/data-info/src/data_info/routes/domain/common.clj
+++ b/services/data-info/src/data_info/routes/domain/common.clj
@@ -11,11 +11,19 @@
 (def DataIdPathParam (describe UUID "The data item's UUID"))
 
 (s/defschema Paths
-  {:paths (describe [NonBlankString] "A list of IRODS paths")})
+  {:paths (describe [NonBlankString] "A list of iRODS paths")})
 
 (s/defschema OptionalPaths
   (-> Paths
     (->optional-param :paths)))
+
+(s/defschema DataIds
+  {:ids (describe [UUID] "A list of iRODS data-object UUIDs")})
+
+(s/defschema OptionalPathsOrDataIds
+  (-> (merge DataIds Paths)
+      (->optional-param :paths)
+      (->optional-param :ids)))
 
 (def ValidInfoTypesEnum (apply s/enum (hm/supported-formats)))
 (def ValidInfoTypesEnumPlusBlank (apply s/enum (conj (hm/supported-formats) "")))

--- a/services/data-info/src/data_info/routes/domain/data.clj
+++ b/services/data-info/src/data_info/routes/domain/data.clj
@@ -9,6 +9,34 @@
         [heuristomancer.core :as info])
   (:require [schema.core :as s]))
 
+(s/defschema AVUMap
+  {:attr  (describe String "The attribute name")
+   :value (describe String "The value associated with this attribute")
+   :unit  (describe String "The unit associated with this value")})
+
+(s/defschema AVUDeleteParams
+  (merge StandardUserQueryParams
+    (dissoc AVUMap :unit)))
+
+(s/defschema AVUListing
+  {:irods-avus (describe [AVUMap] "A list of AVUs on this object.")})
+
+(s/defschema AVUGetResult
+  (assoc AVUListing
+   :path
+   (describe NonBlankString "The iRODS path of the file whose AVUs are being listed.")))
+
+(s/defschema AVUChangeResult
+  {:path
+   (describe NonBlankString "The iRODS path of the file whose AVUs changed.")
+   :user
+   (describe NonBlankString "The effective user who performed the request.")})
+
+(s/defschema AVUSetResult
+  (assoc AVUChangeResult
+         :type
+         (describe (s/enum :dir :file) "Whether this data object is a directory or file.")))
+
 (s/defschema MetadataSaveRequest
   {:dest
    (describe NonBlankString "An IRODS path to a destination file where the metadata will be saved")

--- a/services/data-info/src/data_info/routes/domain/stats.clj
+++ b/services/data-info/src/data_info/routes/domain/stats.clj
@@ -62,8 +62,13 @@
   {(describe s/Keyword "The iRODS data item's path")
    (describe (s/conditional #(contains? % :file-size) FileStatInfo :else DirStatInfo) "The data item's info")})
 
+(s/defschema DataIdsMap
+  {(describe s/Keyword "The iRODS data item's ID")
+   (describe (s/conditional #(contains? % :file-size) FileStatInfo :else DirStatInfo) "The data item's info")})
+
 (s/defschema StatusInfo
-  {:paths (describe PathsMap "Paths info")})
+  {(s/optional-key :paths) (describe PathsMap "Paths info")
+   (s/optional-key :ids) (describe DataIdsMap "IDs info")})
 
 ;; Used only for display as documentation in Swagger UI
 (s/defschema StatResponsePathsMap
@@ -71,5 +76,11 @@
    :/path/from/request/to/a/file   (describe FileStatInfo "A file's info")})
 
 ;; Used only for display as documentation in Swagger UI
+(s/defschema StatResponseIdsMap
+  {:some-folder-uuid (describe DirStatInfo "A folder's info")
+   :some-file-uuid   (describe FileStatInfo "A file's info")})
+
+;; Used only for display as documentation in Swagger UI
 (s/defschema StatResponse
-  {:paths (describe StatResponsePathsMap "A map of paths from the request to their status info")})
+  {(s/optional-key :paths) (describe StatResponsePathsMap "A map of paths from the request to their status info")
+   (s/optional-key :ids) (describe StatResponseIdsMap "A map of ids from the request to their status info")})

--- a/services/data-info/src/data_info/routes/domain/stats.clj
+++ b/services/data-info/src/data_info/routes/domain/stats.clj
@@ -1,5 +1,5 @@
 (ns data-info.routes.domain.stats
-  (:use [common-swagger-api.schema :only [describe NonBlankString]]
+  (:use [common-swagger-api.schema :only [describe NonBlankString StandardUserQueryParams]]
         [data-info.routes.domain.common])
   (:require [schema.core :as s])
   (:import [java.util UUID]))
@@ -8,6 +8,11 @@
 (def PermissionEnum (s/enum :read :write :own))
 (def DataItemIdParam (describe UUID "The UUID of this data item"))
 (def DataItemPathParam (describe NonBlankString "The IRODS paths to this data item"))
+
+(s/defschema StatQueryParams
+  (assoc StandardUserQueryParams
+         (s/optional-key :validation-behavior)
+         (describe PermissionEnum "What level of permissions on the queried files should be validated?")))
 
 (s/defschema DataStatInfo
   {:id

--- a/services/data-info/src/data_info/routes/stats.clj
+++ b/services/data-info/src/data_info/routes/stats.clj
@@ -15,12 +15,12 @@
     :tags ["bulk"]
 
     (POST* "/" [:as {uri :uri}]
-      :query [params StandardUserQueryParams]
+      :query [params StatQueryParams]
       :body [body (describe OptionalPathsOrDataIds "The path or data ids of the data objects to gather status information on.")]
       :return (s/doc-only StatusInfo StatResponse)
       :summary "File and Folder Status Information"
       :description (str
-"This endpoint allows the caller to get information about many files and folders at once."
+"This endpoint allows the caller to get information about many files and folders at once, potentially also validating permissions on the files/folders for the user provided."
 (get-error-code-block
-  "ERR_DOES_NOT_EXIST, ERR_NOT_READABLE, ERR_NOT_A_USER, ERR_TOO_MANY_RESULTS"))
+  "ERR_DOES_NOT_EXIST, ERR_NOT_READABLE, ERR_NOT_WRITEABLE, ERR_NOT_OWNER, ERR_NOT_A_USER, ERR_TOO_MANY_RESULTS"))
       (svc/trap uri stat/do-stat params body))))

--- a/services/data-info/src/data_info/routes/stats.clj
+++ b/services/data-info/src/data_info/routes/stats.clj
@@ -16,7 +16,7 @@
 
     (POST* "/" [:as {uri :uri}]
       :query [params StandardUserQueryParams]
-      :body [body (describe Paths "The paths to gather status information on.")]
+      :body [body (describe OptionalPathsOrDataIds "The path or data ids of the data objects to gather status information on.")]
       :return (s/doc-only StatusInfo StatResponse)
       :summary "File and Folder Status Information"
       :description (str

--- a/services/data-info/src/data_info/services/stat.clj
+++ b/services/data-info/src/data_info/services/stat.clj
@@ -3,7 +3,6 @@
             [clojure.tools.logging :as log]
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [slingshot.slingshot :refer [throw+]]
-            [medley.core :only [remove-vals]]
             [clj-icat-direct.icat :as icat]
             [clj-jargon.by-uuid :as uuid]
             [clj-jargon.init :refer [with-jargon]]

--- a/services/terrain/project.clj
+++ b/services/terrain/project.clj
@@ -28,7 +28,6 @@
                  [dire "0.5.3"]
                  [me.raynes/fs "1.4.6"]
                  [medley "0.7.0"]
-                 [net.sf.opencsv/opencsv "2.3"]
                  [org.apache.tika/tika-core "1.11"]      ; provides org.apache.tika
                  [org.nexml.model/nexml "1.5-SNAPSHOT"]  ; provides org.nexml.model
                  [org/forester "1.005" ]

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -14,7 +14,6 @@
             [terrain.services.filesystem.common-paths :as cp]
             [terrain.services.filesystem.create :as cr]
             [terrain.services.filesystem.icat :as icat]
-            [terrain.services.filesystem.metadata :as mt]
             [terrain.services.filesystem.sharing :as sharing]
             [terrain.services.filesystem.stat :as st]
             [terrain.services.filesystem.users :as users]

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -62,7 +62,7 @@
   [^String user]
   (cp/user-trash-path user))
 
-(defn- uuid-for-path
+(defn uuid-for-path
   [^String user ^String path]
   (-> (raw/collect-stats user :paths [path])
       :body

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -235,18 +235,18 @@
 (defn get-tree-metaurl
   "Gets the URL used to get saved tree URLs."
   [user path]
-  (->> (mt/metadata-get user (uuid-for-path user path))
-    (:metadata)
+  (->> (raw/get-avus user (uuid-for-path user path))
+    :irods-avus
     (filter #(= (:attr %) "tree-urls"))
-    (first)
-    (:value)))
-
+    first
+    :value))
 
 (defn save-tree-metaurl
   "Saves the URL used to get saved tree URLs. The metaurl argument should contain the URL used to
    obtain the tree URLs."
-  [path metaurl]
-  (mt/admin-metadata-add path {:attr "tree-urls" :value metaurl :unit ""}))
+  [user path metaurl]
+  (let [path-uuid (uuid-for-path user path)]
+    (raw/admin-add-avus user path-uuid [{:attr "tree-urls" :value metaurl :unit ""}])))
 
 
 (defn ^ISeq list-user-groups

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -64,7 +64,7 @@
 
 (defn- uuid-for-path
   [^String user ^String path]
-  (-> (raw/collect-stats user [path])
+  (-> (raw/collect-stats user :paths [path])
       :body
       json/decode
       (get-in ["paths" path "id"])))

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -235,9 +235,9 @@
 (defn get-tree-metaurl
   "Gets the URL used to get saved tree URLs."
   [user path]
-  (->> (raw/get-avus user (uuid-for-path user path))
+  (->> (raw/admin-get-avus user (uuid-for-path user path))
     :irods-avus
-    (filter #(= (:attr %) "tree-urls"))
+    (filter #(= (:attr %) (cfg/tree-urls-attr)))
     first
     :value))
 
@@ -246,7 +246,7 @@
    obtain the tree URLs."
   [user path metaurl]
   (let [path-uuid (uuid-for-path user path)]
-    (raw/admin-add-avus user path-uuid [{:attr "tree-urls" :value metaurl :unit ""}])))
+    (raw/admin-add-avus user path-uuid [{:attr (cfg/tree-urls-attr) :value metaurl :unit ""}])))
 
 
 (defn ^ISeq list-user-groups

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -1,4 +1,5 @@
 (ns terrain.clients.data-info.raw
+  (:use [medley.core :only [remove-vals]])
   (:require [clojure.tools.logging :as log]
             [cemerick.url :as url]
             [me.raynes.fs :as fs]
@@ -212,9 +213,9 @@
 
 (defn collect-stats
   "Uses the data-info stat-gatherer endpoint to gather stat information for a set of files/folders."
-  [user paths]
+  [user & {:keys [paths ids]}]
   (request :post ["stat-gatherer"]
-           (mk-req-map user (json/encode {:paths paths}))))
+           (mk-req-map user (json/encode (remove-vals nil? {:paths paths :ids ids})))))
 
 (defn check-existence
   "Uses the data-info existence-marker endpoint to gather existence information for a set of files/folders."

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -160,6 +160,42 @@
 
 ;; METADATA
 
+(defn get-avus
+  "Get the set of iRODS AVUs for a data item."
+  [user path-uuid]
+  (request :get ["data" path-uuid "avus"]
+           (mk-req-map user)))
+
+(defn admin-get-avus
+  "Get the set of iRODS AVUs, including administrative AVUs, for a data-item."
+  [user path-uuid]
+  (request :get ["admin" "data" path-uuid "avus"]
+           (mk-req-map user)))
+
+(defn set-avus
+  "Set the iRODs AVUs to a specific set."
+  [user path-uuid avu-map]
+  (request :put ["data" path-uuid "avus"]
+           (mk-req-map user (json/encode {:irods-avus avu-map}))))
+
+(defn add-avus
+  "Add AVUs to a data item."
+  [user path-uuid avu-map]
+  (request :post ["data" path-uuid "avus"]
+           (mk-req-map user (json/encode {:irods-avus avu-map}))))
+
+(defn admin-add-avus
+  "Add AVUs, allowing administrative AVUs to be included, for a data item."
+  [user path-uuid avu-map]
+  (request :post ["admin" "data" path-uuid "avus"]
+           (mk-req-map user (json/encode {:irods-avus avu-map}))))
+
+(defn admin-delete-avu
+  "Delete an AVU for a data item by attr/value, allowing any AVU to be deleted."
+  [user path-uuid avu]
+  (request :delete ["admin" "data" path-uuid "avus"]
+           (mk-req-map user (select-keys avu [:attr :value]))))
+
 (defn save-metadata
   "Request that metadata be saved to a file."
   [user path-uuid dest recursive]

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -213,9 +213,11 @@
 
 (defn collect-stats
   "Uses the data-info stat-gatherer endpoint to gather stat information for a set of files/folders."
-  [user & {:keys [paths ids]}]
+  [user & {:keys [paths ids validation-behavior]}]
   (request :post ["stat-gatherer"]
-           (mk-req-map user (json/encode (remove-vals nil? {:paths paths :ids ids})))))
+           (mk-req-map user
+                       (json/encode (remove-vals nil? {:paths paths :ids ids}))
+                       (remove-vals nil? {:validation-behavior validation-behavior}))))
 
 (defn check-existence
   "Uses the data-info existence-marker endpoint to gather existence information for a set of files/folders."

--- a/services/terrain/src/terrain/routes/filesystem.clj
+++ b/services/terrain/src/terrain/routes/filesystem.clj
@@ -105,12 +105,6 @@
    [#(and (config/filesystem-routes-enabled)
           (config/metadata-routes-enabled))]
 
-    (POST "/filesystem/metadata" [data-id :as req]
-      (controller req meta/do-metadata-add :params :body))
-
-    (DELETE "/filesystem/metadata" [:as req]
-      (controller req meta/do-metadata-delete :params))
-
     (POST "/filesystem/metadata/csv-parser" [:as {:keys [user-info params] :as req}]
       (meta/parse-metadata-csv-file user-info params))
 

--- a/services/terrain/src/terrain/services/buggalo.clj
+++ b/services/terrain/src/terrain/services/buggalo.clj
@@ -75,9 +75,9 @@
 
 (defn- save-tree-metaurl
   "Saves the URL used to obtain the tree URLs in the AVUs for the file."
-  [path metaurl]
+  [user path metaurl]
   (try+
-   (di/save-tree-metaurl path metaurl)
+   (di/save-tree-metaurl user path metaurl)
    (catch [:error_code ce/ERR_REQUEST_FAILED] {:keys [body]}
      (log/warn "unable to save the tree metaurl for" path "-"
                (cheshire/generate-string (cheshire/parse-string body) {:pretty true})))
@@ -101,7 +101,7 @@
      (log/debug "searching for existing tree URLs for SHA1 hash" sha1)
      (let [metaurl (metaurl-for sha1)]
        (when-let [urls (get-tree-urls sha1)]
-         (save-tree-metaurl path metaurl)
+         (save-tree-metaurl user path metaurl)
          urls))))
 
 (defn- save-tree-file
@@ -156,7 +156,7 @@
      (let [urls    (get-tree-viewer-urls dir infile)
            metaurl (metaurl-for sha1)]
        (set-tree-urls sha1 urls)
-       (save-tree-metaurl path metaurl)
+       (save-tree-metaurl user path metaurl)
        (build-response-map urls))))
 
 (defn tree-urls-response

--- a/services/terrain/src/terrain/services/filesystem/manifest.clj
+++ b/services/terrain/src/terrain/services/filesystem/manifest.clj
@@ -20,8 +20,8 @@
 
 (defn- extract-tree-urls
   [cm fpath]
-  (if (attribute? cm fpath "tree-urls")
-    (-> (get-attribute cm fpath "tree-urls")
+  (if (attribute? cm fpath (cfg/tree-urls-attr))
+    (-> (get-attribute cm fpath (cfg/tree-urls-attr))
       first
       :value
       ft/basename

--- a/services/terrain/src/terrain/services/filesystem/metadata.clj
+++ b/services/terrain/src/terrain/services/filesystem/metadata.clj
@@ -265,7 +265,7 @@
   [cm user dest-dir force? template-id template-attrs attrs csv-filename-values]
   (let [format-path (partial format-csv-metadata-filename dest-dir)
         paths (map (comp format-path first) csv-filename-values)
-        path-info-map (-> (data-raw/collect-stats user paths) :body json/decode (get "paths"))
+        path-info-map (-> (data-raw/collect-stats user :paths paths) :body json/decode (get "paths"))
         value-lists (map rest csv-filename-values)
         irods-attrs (clojure.set/difference (set attrs) (set (keys template-attrs)))]
     (validators/all-paths-exist cm paths)

--- a/services/terrain/src/terrain/services/filesystem/metadata.clj
+++ b/services/terrain/src/terrain/services/filesystem/metadata.clj
@@ -211,7 +211,6 @@
         path-info-map (-> (data-raw/collect-stats user :paths paths) :body json/decode (get "paths"))
         value-lists (map rest csv-filename-values)
         irods-attrs (clojure.set/difference (set attrs) (set (keys template-attrs)))]
-    (validators/all-paths-exist cm paths)
     (validators/all-paths-writeable cm user paths)
     (if-not force?
       (validate-batch-add-attrs user (map #(get-in path-info-map [% "id"]) paths) irods-attrs))

--- a/services/terrain/src/terrain/services/filesystem/metadata.clj
+++ b/services/terrain/src/terrain/services/filesystem/metadata.clj
@@ -74,12 +74,10 @@
   "Returns the metadata for a path. Filters out system AVUs and replaces
    units set to ipc-reserved with an empty string."
   [user data-id]
-  (with-jargon (icat/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (let [path (get-readable-path cm user data-id)
-          template-avus (service-response->json (metadata-client/list-metadata-avus data-id))]
-      {:irods-avus (list-path-metadata cm path)
-       :metadata template-avus})))
+  (let [irods-avus (service-response->json (data-raw/get-avus user data-id))
+        template-avus (service-response->json (metadata-client/list-metadata-avus data-id))]
+    (assoc irods-avus
+           :metadata template-avus)))
 
 (defn- common-metadata-add
   "Adds an AVU to 'path'. The AVU is passed in as a map in the format:

--- a/services/terrain/src/terrain/services/filesystem/metadata.clj
+++ b/services/terrain/src/terrain/services/filesystem/metadata.clj
@@ -79,42 +79,6 @@
     (assoc irods-avus
            :metadata template-avus)))
 
-(defn- common-metadata-add
-  "Adds an AVU to 'path'. The AVU is passed in as a map in the format:
-   {
-      :attr attr-string
-      :value value-string
-      :unit unit-string
-   }
-   It's a no-op if an AVU with the same attribute and value is already
-   associated with the path."
-  [cm path avu-map]
-  (let [fixed-path (ft/rm-last-slash path)
-        new-unit   (reserved-unit avu-map)
-        attr       (:attr avu-map)
-        value      (:value avu-map)]
-    (log/warn "Fixed Path:" fixed-path)
-    (log/warn "check" (true? (attr-value? cm fixed-path attr value)))
-    (when-not (attr-value? cm fixed-path attr value)
-      (log/warn "Adding " attr value "to" fixed-path)
-      (add-metadata cm fixed-path attr value new-unit))
-    fixed-path))
-
-(defn- common-add-validate
-  [cm user path avu-map]
-  (when (= "failure" (:status avu-map))
-    (throw+ {:error_code ERR_INVALID_JSON}))
-  (validators/path-exists cm path)
-  (validators/path-writeable cm user path))
-
-(defn admin-metadata-add
-  "Adds the AVU to path, bypassing user permission checks. See (metadata-set)
-   for the AVU map format."
-  [path avu-map]
-  (with-jargon (icat/jargon-cfg) [cm]
-    (common-add-validate cm (cfg/irods-user) path avu-map)
-    (common-metadata-add cm path avu-map)))
-
 (defn- metadata-set
   "Allows user to set metadata on an item with the given data-id. The user must exist in iRODS and have
    write permissions on the data item. The request parameter is a map with :irods-avus and :metadata keys

--- a/services/terrain/src/terrain/services/filesystem/stat.clj
+++ b/services/terrain/src/terrain/services/filesystem/stat.clj
@@ -114,7 +114,7 @@
 
 (defn do-stat
   [{user :user} {paths :paths}]
-  (:body (data-raw/collect-stats user paths)))
+  (:body (data-raw/collect-stats user :paths paths)))
 
 (with-pre-hook! #'do-stat
   (fn [params body]

--- a/services/terrain/src/terrain/util/config.clj
+++ b/services/terrain/src/terrain/util/config.clj
@@ -502,6 +502,8 @@
        (cfg/env-setting "TREE_URLS_PORT")
        (tree-urls-base-url)))))
 
+(defn tree-urls-attr [] "ipc-tree-urls")
+
 (def get-allowed-groups
   (memoize
     (fn []


### PR DESCRIPTION
I'll include a variety of comments below, interleaved. In general, this is about removing the jargon-related calls from terrain.services.filesystem.metadata, but a variety of other things were added in order to allow terrain to continue coordinating things, since chunks of that code interact with the metadata service as well.