### PR TITLE
CORE-6211: migrate /secured/fileio/download 

### DIFF
--- a/services/terrain/src/terrain/routes/fileio.clj
+++ b/services/terrain/src/terrain/routes/fileio.clj
@@ -10,8 +10,8 @@
   []
   (util/optional-routes [config/data-routes-enabled]
 
-    (GET "/fileio/download" [:as {:keys [params]}]
-      (fio/download params))
+    (GET "/fileio/download" [:as req]
+      (util/controller req fio/download :params))
 
     (POST "/fileio/upload" [dest :as req]
       (fio/upload (get-in req [:user-info :user]) dest req))

--- a/services/terrain/src/terrain/services/fileio/actions.clj
+++ b/services/terrain/src/terrain/services/fileio/actions.clj
@@ -13,6 +13,7 @@
             [clj-jargon.permissions :as perm]
             [terrain.services.filesystem.icat :as icat]
             [terrain.services.filesystem.validators :as validators]
+            [terrain.services.filesystem.updown :as updown]
             [terrain.services.metadata.internal-jobs :as internal-jobs])
   (:import [java.io InputStream]
            [clojure.lang IPersistentMap]))
@@ -104,16 +105,11 @@
 
 (defn download
   "Returns a response map filled out with info that lets the client download
-   a file."
+   a file.
+
+   Forcibly set Content-Type to application/octet-stream to ensure the file
+   is downloaded rather than displayed."
   [user file-path]
   (log/debug "In download.")
-  (let [istream (get-istream user file-path)]
-    (-> {:status 200
-         :body istream}
-      (rsp-utils/header
-        "Content-Disposition"
-        (str "attachment; filename=\"" (ft/basename file-path) "\""))
-      (rsp-utils/header
-       "Content-Type"
-       "application/octet-stream")
-      success-response)))
+  (let [resp (updown/download-file-as-stream user file-path true)]
+    (assoc-in resp [:headers "Content-Type"] "application/octet-stream")))

--- a/services/terrain/src/terrain/services/filesystem/updown.clj
+++ b/services/terrain/src/terrain/services/filesystem/updown.clj
@@ -9,7 +9,7 @@
             [terrain.clients.data-info :as data]))
 
 
-(defn- download-file
+(defn download-file-as-stream
   [user file attachment]
   (let [url-path         (data/mk-data-path-url-path file)
         req-map          {:query-params {:user user :attachment attachment} :as :stream}
@@ -27,7 +27,7 @@
 
 (defn do-special-download
   [{user :user path :path :as params}]
-  (download-file user path (attachment? params)))
+  (download-file-as-stream user path (attachment? params)))
 
 (with-pre-hook! #'do-special-download
   (fn [params]


### PR DESCRIPTION
This makes it use the data-info logic already in services.filesystem.updown, for the display-download/special-download URL.

(This is a pretty small pull request, put up in the interest of continuing to make us use PRs better)