### PR TITLE
CORE-7446: migrate /secured/fileio/upload

### DIFF
--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -7,6 +7,7 @@
             [data-info.services.rename :as rename]
             [data-info.services.metadata :as meta]
             [data-info.services.entry :as entry]
+            [data-info.services.write :as write]
             [data-info.services.page-file :as page-file]
             [data-info.services.page-tabular :as page-tabular]
             [data-info.util.config :as cfg]
@@ -85,6 +86,17 @@
   "ERR_BAD_PATH_LENGTH, ERR_BAD_DIRNAME_LENGTH, ERR_BAD_BASENAME_LENGTH"
   "ERR_BAD_QUERY_PARAMETER, ERR_MISSING_QUERY_PARAMETER"))
       {:status 501})
+
+    (POST* "/" [:as {uri :uri}]
+      :query [params FileUploadQueryParams]
+      :multipart-params [file :- String]
+      :middlewares [write/wrap-multipart]
+      :return FileStat
+      :summary "Upload a file"
+      :description (str
+"Uploads a file into a directory as a user, given the directory exists and is writeable but the file does not exist."
+(get-error-code-block "ERR_NOT_A_USER, ERR_EXISTS, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE"))
+      (svc/trap uri write/do-upload params file))
 
     (POST* "/directories" [:as {uri :uri}]
       :tags ["bulk"]

--- a/services/data-info/src/data_info/routes/domain/data.clj
+++ b/services/data-info/src/data_info/routes/domain/data.clj
@@ -9,6 +9,10 @@
         [heuristomancer.core :as info])
   (:require [schema.core :as s]))
 
+(s/defschema FileUploadQueryParams
+  (assoc StandardUserQueryParams
+         :dest (describe NonBlankString "The destination directory for the uploaded file.")))
+
 (s/defschema AVUMap
   {:attr  (describe String "The attribute name")
    :value (describe String "The value associated with this attribute")

--- a/services/data-info/src/data_info/services/create.clj
+++ b/services/data-info/src/data_info/services/create.clj
@@ -14,9 +14,7 @@
 
 (defn- sort-existing
   [cm path]
-  (when-not (validators/good-string? path)
-    (throw+ {:error_code ERR_BAD_OR_MISSING_FIELD
-             :path path}))
+  (validators/good-pathname path)
   (validators/path-not-exists cm path)
 
   (let [path-stack (take-while (complement nil?) (iterate ft/dirname path))

--- a/services/data-info/src/data_info/services/write.clj
+++ b/services/data-info/src/data_info/services/write.clj
@@ -1,0 +1,59 @@
+(ns data-info.services.write
+  (:use [clj-jargon.init :only [with-jargon]])
+  (:require [clojure-commons.file-utils :as ft]
+            [clojure-commons.error-codes :as ce]
+            [clj-jargon.item-info :as info]
+            [clj-jargon.item-ops :as ops]
+            [ring.middleware.multipart-params :as multipart]
+            [data-info.services.stat :as stat]
+            [data-info.util.config :as cfg]
+            [data-info.util.validators :as validators]))
+
+(defn- save-file-contents
+  "Save an istream to a destination. Relies on upstream functions to validate."
+  [cm istream user dest-path]
+  (ops/copy-stream cm istream user dest-path)
+  dest-path)
+
+(defn- create-at-path
+  "Create a new file at dest-path from istream.
+
+   Error if the path exists or if the destination directory does not exist or is not writeable."
+  [cm istream user dest-path]
+  (let [dest-dir (ft/dirname dest-path)]
+    (validators/user-exists cm user)
+    (validators/path-not-exists cm dest-path)
+    (validators/path-exists cm dest-dir)
+    (validators/path-writeable cm user dest-dir)
+    (save-file-contents cm istream user dest-path)))
+
+(defn- overwrite-path
+  "Save new contents for the file at dest-path from istream.
+
+   Error if there is no file at that path or the user lacks write permissions thereupon."
+  [cm istream user dest-path]
+  (validators/user-exists cm user)
+  (validators/path-exists cm dest-path)
+  (validators/path-writeable cm user dest-path)
+  (save-file-contents cm istream user dest-path))
+
+(defn- multipart-handler
+  "When partially applied, creates a storage handler for
+   ring.middleware.multipart-params/multipart-params-request which stores the file in iRODS."
+  [user dest-dir {istream :stream filename :filename}]
+  (validators/good-pathname filename)
+  (with-jargon (cfg/jargon-cfg) [cm]
+    (let [dest-path (ft/path-join dest-dir filename)]
+      (create-at-path cm istream user dest-path))))
+
+(defn wrap-multipart
+  "Middleware which saves a file from a multipart request."
+  [handler]
+  (fn [{{:keys [user dest]} :params :as request}]
+    (handler (multipart/multipart-params-request request {:store (partial multipart-handler user dest)}))))
+
+(defn do-upload
+  "Returns a path stat after a file has been uploaded. Intended to only be used with wrap-multipart."
+  [{:keys [user]} file]
+  (with-jargon (cfg/jargon-cfg) [cm]
+    {:file (stat/path-stat cm user file)}))

--- a/services/data-info/src/data_info/util/validators.clj
+++ b/services/data-info/src/data_info/util/validators.clj
@@ -28,6 +28,10 @@
     (let [chars-to-check (set (seq to-check))]
       (empty? (set/intersection (set bad-chars) chars-to-check)))))
 
+(defn good-pathname
+  [^String to-check]
+  (when-not (good-string? to-check)
+    (throw+ {:error_code error/ERR_BAD_OR_MISSING_FIELD :path to-check})))
 
 (defn valid-bool-param
   "Validates that a given value is a Boolean.

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -97,6 +97,15 @@
 
 ;; CREATE
 
+(defn upload-file
+  [user dest-path filename content-type istream]
+  (http/post (str (url/url (cfg/data-info-base) "data"))
+             {:query-params {:user user
+                             :dest dest-path}
+              :multipart [{:part-name "file"
+                           :name filename
+                           :mime-type content-type
+                           :content istream}]}))
 (defn create-dirs
   "Uses the data-info directories endpoint to create several directories."
   [user paths]

--- a/services/terrain/src/terrain/services/fileio/actions.clj
+++ b/services/terrain/src/terrain/services/fileio/actions.clj
@@ -42,27 +42,6 @@
   dest-path)
 
 
-(defn upload
-  "This function uploads the contents of a stream to a data object in iRODS. If the data object
-   exists, it will first be moved to the trash. The parent collection must exist and must be
-   writeable by the user.
-
-   Params:
-     irods-cfg - the irods configuration parameter map
-     user      - the who will own the data object being uploaded
-     dest-path - the absolute path to the data object after it has been uploaded
-     istream   - an input stream containing the contents of the data object."
-  [^IPersistentMap irods-cfg ^String user ^String dest-path ^InputStream istream]
-  (with-jargon irods-cfg :client-user user [cm]
-    (let [dest-dir (ft/dirname dest-path)]
-      (when-not (info/exists? cm dest-dir)
-        (throw+ {:error_code ERR_DOES_NOT_EXIST :path dest-dir}))
-      (if (info/exists? cm dest-path)
-        (ops/delete cm dest-path))
-      (store cm istream user dest-path)
-      nil)))
-
-
 (defn- url-encoded?
   [string-to-check]
   (re-seq #"\%[A-Fa-f0-9]{2}" string-to-check))


### PR DESCRIPTION
This also lays the groundwork for migrating save and saveas, which in turn will lay the groundwork for anything else that wants to save files into iRODS (e.g. re-migrating the metadata save stuff partly out of data-info to remove its dependency on the metadata service).