### PR TITLE
CORE-6212: migrate /secured/fileio/save (file overwrite)

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -547,8 +547,6 @@ kifshare:
   download_buffer_size: 100
   max_heap: "{{ max_heap.low }}"
 
-max_edit_file_size: 2147483647
-
 apps:
   host: "{{ groups['apps'][0] }}"
   port:

--- a/ansible/roles/util-cfg-service/templates/terrain.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/terrain.properties.j2
@@ -89,7 +89,6 @@ terrain.garnish.type-attribute = ipc-filetype
 
 # File IO settings
 terrain.fileio.url-import-app = 1E8F719B-0452-4D39-A2F3-8714793EE3E6
-terrain.fileio.max-edit-file-size = {{ max_edit_file_size }}
 
 # Filesystem settings
 terrain.data-info.base-url            = http://{{ data_info.host }}:{{ data_info.port }}

--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -90,7 +90,7 @@
     (POST* "/" [:as {uri :uri}]
       :query [params FileUploadQueryParams]
       :multipart-params [file :- String]
-      :middlewares [write/wrap-multipart]
+      :middlewares [write/wrap-multipart-create]
       :return FileStat
       :summary "Upload a file"
       :description (str
@@ -128,6 +128,17 @@ with characters in a runtime-configurable parameter. Currently, this parameter l
         :summary "Data Item Meta-Status"
         :description "Returns an HTTP status according to the user's access level to the data item."
         (ce/trap uri entry/id-entry data-id user))
+
+      (PUT* "/" [:as {uri :uri}]
+        :query [params StandardUserQueryParams]
+        :multipart-params [file :- String]
+        :middlewares [write/wrap-multipart-overwrite]
+        :return FileStat
+        :summary "Overwrite Contents"
+        :description (str
+"Overwrites a file as a user, given the user can write to it and the file already exists."
+(get-error-code-block "ERR_NOT_A_USER, ERR_DOES_NOT_EXIST, ERR_NOT_A_FILE, ERR_NOT_WRITEABLE"))
+        (svc/trap uri write/do-upload params file))
 
       (GET* "/avus" [:as {uri :uri}]
         :query [{:keys [user]} StandardUserQueryParams]

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -148,6 +148,12 @@
   (log/warn "checking to see if" path "can be created")
   (st/can-create-dir? user path))
 
+(defn overwrite-file
+  "Overwrite a file with a new file by path."
+  [user dest istream]
+  (let [path-uuid (uuid-for-path user dest)]
+    (raw/overwrite-file user path-uuid istream)))
+
 (defn rename
   "Uses the data-info set-name endpoint to rename a file within the same directory."
   [{:keys [user]} {:keys [source dest]}]

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -112,6 +112,15 @@
   (request :post ["data" "directories"]
            (mk-req-map user (json/encode {:paths paths}))))
 
+;; MODIFY
+
+(defn overwrite-file
+  [user path-uuid istream]
+  (http/put (str (url/url (cfg/data-info-base) "data" path-uuid))
+            {:query-params {:user user}
+             :multipart [{:name "file"
+                          :content istream}]}))
+
 ;; MOVE AND RENAME
 
 (defn rename

--- a/services/terrain/src/terrain/services/fileio/actions.clj
+++ b/services/terrain/src/terrain/services/fileio/actions.clj
@@ -1,33 +1,16 @@
 (ns terrain.services.fileio.actions
   (:use [clj-jargon.init :only [with-jargon]]
-        [clojure-commons.error-codes]
         [terrain.util.service :only [success-response]]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [cemerick.url :as url]
             [clojure-commons.file-utils :as ft]
             [clojure.tools.logging :as log]
-            [clojure.string :as string]
-            [ring.util.response :as rsp-utils]
-            [clj-jargon.item-info :as info]
-            [clj-jargon.item-ops :as ops]
-            [clj-jargon.permissions :as perm]
             [terrain.services.filesystem.icat :as icat]
             [terrain.services.filesystem.validators :as validators]
             [terrain.services.filesystem.updown :as updown]
             [terrain.services.metadata.internal-jobs :as internal-jobs])
   (:import [java.io InputStream]
            [clojure.lang IPersistentMap]))
-
-
-(defn save
-  [cm istream user dest-path]
-  (log/info "In save function for " user dest-path)
-  (let [ddir (ft/dirname dest-path)]
-    (when-not (info/exists? cm ddir)
-      (ops/mkdirs cm ddir))
-    (ops/copy-stream cm istream user dest-path)
-    (log/info "save function after copy.")
-    dest-path))
 
 
 (defn- url-encoded?

--- a/services/terrain/src/terrain/util/config.clj
+++ b/services/terrain/src/terrain/util/config.clj
@@ -303,11 +303,6 @@
   "The identifier of the internal app used for URL imports."
   [props config-valid configs fileio-routes-enabled]
   "terrain.fileio.url-import-app")
-
-(cc/defprop-int fileio-max-edit-file-size
-  "The old service name for fileio"
-  [props config-valid configs fileio-routes-enabled]
-  "terrain.fileio.max-edit-file-size")
 ;;; End File IO configuration
 
 ;;; Filesystem configuration (a.k.a. data-info).


### PR DESCRIPTION
This institutes another data-info endpoint which takes the file as a multipart request much like the upload (because that's a lot easier than trying to get compojure-api to let you use a non-json body, plus it's consistent) and overwrites it, at `PUT /data/:data-id`. It then uses it for `/secured/fileio/save` much like how `saveas` was done, turning the JSON input into a buffered input stream to send to the data-info endpoint.