### PR TITLE
Update pb hosts to prevent action on parasitic env

### DIFF
--- a/ansible/db-migrations.yaml
+++ b/ansible/db-migrations.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Database migrations
-  hosts: db-proxy
+  hosts: db-proxy:&systems
   tags:
       - databases
   sudo: False

--- a/ansible/playbooks/de-condor-submitter.yaml
+++ b/ansible/playbooks/de-condor-submitter.yaml
@@ -1,4 +1,4 @@
-- hosts: condor-submission
+- hosts: condor-submission:&systems
   sudo: True
   roles:
       - de-condor-submitter

--- a/ansible/playbooks/de-jex.yaml
+++ b/ansible/playbooks/de-jex.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Configure JEX
-  hosts: jex
+  hosts: jex:&systems
   sudo: yes
   tags:
       - jex

--- a/ansible/playbooks/de-porklock.yaml
+++ b/ansible/playbooks/de-porklock.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy porklock
-  hosts: condor
+  hosts: condor:&systems
   sudo: True
   gather_facts: false
   tags:

--- a/ansible/playbooks/de-pull-images.yaml
+++ b/ansible/playbooks/de-pull-images.yaml
@@ -1,6 +1,6 @@
 ---
 # - name: Update iplant-data
-#   hosts: docker-ready
+#   hosts: docker-ready:&systems
 #   sudo: true
 #   gather_facts: false
 #   tags:
@@ -12,7 +12,7 @@
 #       service_name_short: "{{data_container.service_name_short}}"
 
 - name: Update anon-files
-  hosts: anon-files
+  hosts: anon-files:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -28,7 +28,7 @@
       service_name_short: "{{anon_files.service_name_short}}"
 
 - name: Update apps
-  hosts: apps
+  hosts: apps:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -43,7 +43,7 @@
       service_name_short: "{{apps.service_name_short}}"
 
 - name: Update iplant-data-apps
-  hosts: docker-ready
+  hosts: docker-ready:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -55,7 +55,7 @@
       service_name_short: "iplant_data_{{apps.service_name_short}}"
 
 - name: Update clockwork
-  hosts: clockwork
+  hosts: clockwork:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -70,7 +70,7 @@
       service_name_short: "{{clockwork.service_name_short}}"
 
 - name: Update clm
-  hosts: condor-log-monitor
+  hosts: condor-log-monitor:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -85,7 +85,7 @@
       service_name_short: "{{condor_log_monitor.service_name_short}}"
 
 - name: Update data-info
-  hosts: data-info
+  hosts: data-info:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -100,7 +100,7 @@
       service_name_short: "{{data_info.service_name_short}}"
 
 - name: Update dewey
-  hosts: dewey
+  hosts: dewey:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -117,7 +117,7 @@
       service_name_short: "{{dewey.service_name_short}}"
 
 - name: Update de-ui
-  hosts: ui
+  hosts: ui:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -131,7 +131,7 @@
       service_name_short: "{{de.service_name_short}}"
 
 - name: Update iplant-data-de-ui
-  hosts: docker-ready
+  hosts: docker-ready:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -143,7 +143,7 @@
       service_name_short: "iplant_data_{{de.service_name_short}}"
 
 - name: Update de-ui-nginx
-  hosts: ui
+  hosts: ui:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -158,7 +158,7 @@
       service_name_short: "{{de.http_server.service_name_short}}"
 
 - name: Update iplant-data-de-ui-nginx
-  hosts: docker-ready
+  hosts: docker-ready:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -170,7 +170,7 @@
       service_name_short: "iplant_data_{{de.http_server.service_name_short}}"
 
 - name: Update exim-sender
-  hosts: exim-sender
+  hosts: exim-sender:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -182,7 +182,7 @@
       service_name_short: "{{exim.service_name_short}}"
 
 - name: Update info-typer
-  hosts: info-typer
+  hosts: info-typer:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -199,7 +199,7 @@
       service_name_short: "{{info_typer.service_name_short}}"
 
 - name: Update infosquito
-  hosts: infosquito
+  hosts: infosquito:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -216,7 +216,7 @@
       service_name_short: "{{infosquito.service_name_short}}"
 
 - name: Update iplant-email
-  hosts: iplant-email
+  hosts: iplant-email:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -231,7 +231,7 @@
       service_name_short: "{{iplant_email.service_name_short}}"
 
 - name: Update iplant-groups
-  hosts: iplant-groups
+  hosts: iplant-groups:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -246,7 +246,7 @@
       service_name_short: "{{iplant_groups.service_name_short}}"
 
 - name: Update jex-events
-  hosts: jexevents
+  hosts: jexevents:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -261,7 +261,7 @@
       service_name_short: "{{jexevents.service_name_short}}"
 
 - name: Update kifshare
-  hosts: kifshare
+  hosts: kifshare:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -276,7 +276,7 @@
       service_name_short: "{{kifshare.service_name_short}}"
 
 - name: Update metadata
-  hosts: metadata
+  hosts: metadata:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -291,7 +291,7 @@
       service_name_short: "{{metadata.service_name_short}}"
 
 - name: Update monkey
-  hosts: monkey
+  hosts: monkey:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -308,7 +308,7 @@
       service_name_short: "{{monkey.service_name_short}}"
 
 - name: Update notification-agent
-  hosts: notificationagent
+  hosts: notificationagent:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -323,7 +323,7 @@
       service_name_short: "{{notificationagent.service_name_short}}"
 
 - name: Update saved-searches
-  hosts: saved-searches
+  hosts: saved-searches:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -338,7 +338,7 @@
       service_name_short: "{{saved_searches.service_name_short}}"
 
 - name: Update terrain
-  hosts: terrain
+  hosts: terrain:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -353,7 +353,7 @@
       service_name_short: "{{terrain.service_name_short}}"
 
 - name: Update iplant-data-terrain
-  hosts: docker-ready
+  hosts: docker-ready:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -365,7 +365,7 @@
       service_name_short: "iplant_data_{{terrain.service_name_short}}"
 
 - name: Update tree-urls
-  hosts: tree-urls
+  hosts: tree-urls:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -380,7 +380,7 @@
       service_name_short: "{{tree_urls.service_name_short}}"
 
 - name: Update user-preferences
-  hosts: user-preferences
+  hosts: user-preferences:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -395,7 +395,7 @@
       service_name_short: "{{user_preferences.service_name_short}}"
 
 - name: Update user-sessions
-  hosts: user-sessions
+  hosts: user-sessions:&systems
   sudo: true
   gather_facts: false
   tags:

--- a/ansible/playbooks/de-rm-containers.yml
+++ b/ansible/playbooks/de-rm-containers.yml
@@ -1,6 +1,6 @@
 ---
 # - name: Remove iplant-data
-#   hosts: docker-ready
+#   hosts: docker-ready:&systems
 #   sudo: true
 #   gather_facts: false
 #   tags:
@@ -13,7 +13,7 @@
 #       service_name_short: "{{data_container.service_name_short}}"
 
 - name: Remove anon-files
-  hosts: anon-files
+  hosts: anon-files:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -35,7 +35,7 @@
       shell: docker rm -v {{anon_files.service_name_short}}
 
 - name: Remove apps
-  hosts: apps
+  hosts: apps:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -61,7 +61,7 @@
       shell: docker rm -v {{apps.service_name_short}}
 
 - name: Remove clockwork
-  hosts: clockwork
+  hosts: clockwork:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -83,7 +83,7 @@
       shell: docker rm -v {{clockwork.service_name_short}}
 
 - name: Remove clm
-  hosts: condor-log-monitor
+  hosts: condor-log-monitor:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -109,7 +109,7 @@
       shell: docker rm -v clm
 
 - name: Remove data-info
-  hosts: data-info
+  hosts: data-info:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -131,7 +131,7 @@
       shell: docker rm -v {{data_info.service_name_short}}
 
 - name: Remove dewey
-  hosts: dewey
+  hosts: dewey:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -153,7 +153,7 @@
       shell: docker rm -v {{dewey.service_name_short}}
 
 - name: Remove de-ui
-  hosts: ui
+  hosts: ui:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -178,7 +178,7 @@
       shell: docker rm -v {{de.service_name_short}}
 
 - name: Remove de-ui-nginx
-  hosts: ui
+  hosts: ui:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -204,7 +204,7 @@
       shell: docker rm -v {{de.http_server.service_name_short}}
 
 - name: Remove exim-sender
-  hosts: exim-sender
+  hosts: exim-sender:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -226,7 +226,7 @@
       shell: docker rm -v exim
 
 - name: Remove info-typer
-  hosts: info-typer
+  hosts: info-typer:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -248,7 +248,7 @@
       shell: docker rm -v {{info_typer.service_name_short}}
 
 - name: Remove infosquito
-  hosts: infosquito
+  hosts: infosquito:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -270,7 +270,7 @@
       shell: docker rm -v {{infosquito.service_name_short}}
 
 - name: Remove iplant-email
-  hosts: iplant-email
+  hosts: iplant-email:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -292,7 +292,7 @@
       shell: docker rm -v {{iplant_email.service_name_short}}
 
 - name: Remove iplant-groups
-  hosts: iplant-groups
+  hosts: iplant-groups:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -314,7 +314,7 @@
       shell: docker rm -v {{iplant_groups.service_name_short}}
 
 - name: Remove jex-events
-  hosts: jexevents
+  hosts: jexevents:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -340,7 +340,7 @@
       shell: docker rm -v jex-events
 
 - name: Remove kifshare
-  hosts: kifshare
+  hosts: kifshare:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -362,7 +362,7 @@
       shell: docker rm -v {{kifshare.service_name_short}}
 
 - name: Remove metadata
-  hosts: metadata
+  hosts: metadata:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -384,7 +384,7 @@
       shell: docker rm -v {{metadata.service_name_short}}
 
 - name: Remove monkey
-  hosts: monkey
+  hosts: monkey:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -406,7 +406,7 @@
       shell: docker rm -v {{monkey.service_name_short}}
 
 - name: Remove notification-agent
-  hosts: notificationagent
+  hosts: notificationagent:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -428,7 +428,7 @@
       shell: docker rm -v {{notificationagent.service_name_short}}
 
 - name: Remove saved-searches
-  hosts: saved-searches
+  hosts: saved-searches:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -450,7 +450,7 @@
       shell: docker rm -v {{saved_searches.service_name_short}}
 
 - name: Remove terrain
-  hosts: terrain
+  hosts: terrain:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -476,7 +476,7 @@
       shell: docker rm -v {{terrain.service_name_short}}
 
 - name: Remove tree-urls
-  hosts: tree-urls
+  hosts: tree-urls:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -498,7 +498,7 @@
       shell: docker rm -v {{tree_urls.service_name_short}}
 
 - name: Remove user-preferences
-  hosts: user-preferences
+  hosts: user-preferences:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -520,7 +520,7 @@
       shell: docker rm -v {{user_preferences.service_name_short}}
 
 - name: Remove user-sessions
-  hosts: user-sessions
+  hosts: user-sessions:&systems
   sudo: true
   gather_facts: false
   tags:

--- a/ansible/playbooks/de-start-containers.yml
+++ b/ansible/playbooks/de-start-containers.yml
@@ -1,6 +1,6 @@
 ---
 - name: Start anon-files
-  hosts: anon-files
+  hosts: anon-files:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -12,7 +12,7 @@
       service_name_short: "{{anon_files.service_name_short}}"
 
 - name: Start apps
-  hosts: apps
+  hosts: apps:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -24,7 +24,7 @@
       service_name_short: "{{apps.service_name_short}}"
 
 - name: Start clockwork
-  hosts: clockwork
+  hosts: clockwork:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -36,7 +36,7 @@
       service_name_short: "{{clockwork.service_name_short}}"
 
 - name: Start clm
-  hosts: condor-log-monitor
+  hosts: condor-log-monitor:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -48,7 +48,7 @@
       service_name_short: "{{condor_log_monitor.service_name_short}}"
 
 - name: Start data-info
-  hosts: data-info
+  hosts: data-info:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -60,7 +60,7 @@
       service_name_short: "{{data_info.service_name_short}}"
 
 - name: Start dewey
-  hosts: dewey
+  hosts: dewey:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -73,7 +73,7 @@
       service_name_short: "{{dewey.service_name_short}}"
 
 - name: Start de-ui
-  hosts: ui
+  hosts: ui:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -84,7 +84,7 @@
       service_name_short: "{{de.service_name_short}}"
 
 - name: Start de-ui-nginx
-  hosts: ui
+  hosts: ui:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -96,7 +96,7 @@
       service_name_short: "{{de.http_server.service_name_short}}"
 
 - name: Start exim-sender
-  hosts: exim-sender
+  hosts: exim-sender:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -108,7 +108,7 @@
       service_name_short: "{{exim.service_name_short}}"
 
 - name: Start info-typer
-  hosts: info-typer
+  hosts: info-typer:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -121,7 +121,7 @@
       service_name_short: "{{info_typer.service_name_short}}"
 
 - name: Start infosquito
-  hosts: infosquito
+  hosts: infosquito:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -134,7 +134,7 @@
       service_name_short: "{{infosquito.service_name_short}}"
 
 - name: Start iplant-email
-  hosts: iplant-email
+  hosts: iplant-email:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -146,7 +146,7 @@
       service_name_short: "{{iplant_email.service_name_short}}"
 
 - name: Start iplant-groups
-  hosts: iplant-groups
+  hosts: iplant-groups:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -158,7 +158,7 @@
       service_name_short: "{{iplant_groups.service_name_short}}"
 
 - name: Start jex-events
-  hosts: jexevents
+  hosts: jexevents:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -170,7 +170,7 @@
       service_name_short: "{{jexevents.service_name_short}}"
 
 - name: Start kifshare
-  hosts: kifshare
+  hosts: kifshare:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -182,7 +182,7 @@
       service_name_short: "{{kifshare.service_name_short}}"
 
 - name: Start metadata
-  hosts: metadata
+  hosts: metadata:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -194,7 +194,7 @@
       service_name_short: "{{metadata.service_name_short}}"
 
 - name: Start monkey
-  hosts: monkey
+  hosts: monkey:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -207,7 +207,7 @@
       service_name_short: "{{monkey.service_name_short}}"
 
 - name: Start notification-agent
-  hosts: notificationagent
+  hosts: notificationagent:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -219,7 +219,7 @@
       service_name_short: "{{notificationagent.service_name_short}}"
 
 - name: Start saved-searches
-  hosts: saved-searches
+  hosts: saved-searches:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -231,7 +231,7 @@
       service_name_short: "{{saved_searches.service_name_short}}"
 
 - name: Start terrain
-  hosts: terrain
+  hosts: terrain:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -243,7 +243,7 @@
       service_name_short: "{{terrain.service_name_short}}"
 
 - name: Start tree-urls
-  hosts: tree-urls
+  hosts: tree-urls:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -255,7 +255,7 @@
       service_name_short: "{{tree_urls.service_name_short}}"
 
 - name: Start user-preferences
-  hosts: user-preferences
+  hosts: user-preferences:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -267,7 +267,7 @@
       service_name_short: "{{user_preferences.service_name_short}}"
 
 - name: Start user-sessions
-  hosts: user-sessions
+  hosts: user-sessions:&systems
   sudo: true
   gather_facts: false
   tags:

--- a/ansible/playbooks/de-stop-containers.yml
+++ b/ansible/playbooks/de-stop-containers.yml
@@ -1,6 +1,6 @@
 ---
 - name: Stop anon-files
-  hosts: anon-files
+  hosts: anon-files:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -13,7 +13,7 @@
       service_name_short: "{{anon_files.service_name_short}}"
 
 - name: Stop apps
-  hosts: apps
+  hosts: apps:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -26,7 +26,7 @@
       service_name_short: "{{apps.service_name_short}}"
 
 - name: Stop clockwork
-  hosts: clockwork
+  hosts: clockwork:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -39,7 +39,7 @@
       service_name_short: "{{clockwork.service_name_short}}"
 
 - name: Stop clm
-  hosts: condor-log-monitor
+  hosts: condor-log-monitor:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -52,7 +52,7 @@
       service_name_short: "{{condor_log_monitor.service_name_short}}"
 
 - name: Stop data-info
-  hosts: data-info
+  hosts: data-info:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -65,7 +65,7 @@
       service_name_short: "{{data_info.service_name_short}}"
 
 - name: Stop dewey
-  hosts: dewey
+  hosts: dewey:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -78,7 +78,7 @@
       service_name_short: "{{dewey.service_name_short}}"
 
 - name: Stop de-ui
-  hosts: ui
+  hosts: ui:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -90,7 +90,7 @@
       service_name_short: "{{de.service_name_short}}"
 
 - name: Stop de-ui-nginx
-  hosts: ui
+  hosts: ui:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -103,7 +103,7 @@
       service_name_short: "{{de.http_server.service_name_short}}"
 
 - name: Stop exim-sender
-  hosts: exim-sender
+  hosts: exim-sender:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -116,7 +116,7 @@
       service_name_short: "{{exim.service_name_short}}"
 
 - name: Stop info-typer
-  hosts: info-typer
+  hosts: info-typer:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -129,7 +129,7 @@
       service_name_short: "{{info_typer.service_name_short}}"
 
 - name: Stop infosquito
-  hosts: infosquito
+  hosts: infosquito:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -142,7 +142,7 @@
       service_name_short: "{{infosquito.service_name_short}}"
 
 - name: Stop iplant-email
-  hosts: iplant-email
+  hosts: iplant-email:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -155,7 +155,7 @@
       service_name_short: "{{iplant_email.service_name_short}}"
 
 - name: Stop iplant-groups
-  hosts: iplant-groups
+  hosts: iplant-groups:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -168,7 +168,7 @@
       service_name_short: "{{iplant_groups.service_name_short}}"
 
 - name: Stop jex-events
-  hosts: jexevents
+  hosts: jexevents:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -181,7 +181,7 @@
       service_name_short: "{{jexevents.service_name_short}}"
 
 - name: Stop kifshare
-  hosts: kifshare
+  hosts: kifshare:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -194,7 +194,7 @@
       service_name_short: "{{kifshare.service_name_short}}"
 
 - name: Stop metadata
-  hosts: metadata
+  hosts: metadata:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -207,7 +207,7 @@
       service_name_short: "{{metadata.service_name_short}}"
 
 - name: Stop monkey
-  hosts: monkey
+  hosts: monkey:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -220,7 +220,7 @@
       service_name_short: "{{monkey.service_name_short}}"
 
 - name: Stop notification-agent
-  hosts: notificationagent
+  hosts: notificationagent:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -233,7 +233,7 @@
       service_name_short: "{{notificationagent.service_name_short}}"
 
 - name: Stop saved-searches
-  hosts: saved-searches
+  hosts: saved-searches:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -246,7 +246,7 @@
       service_name_short: "{{saved_searches.service_name_short}}"
 
 - name: Stop terrain
-  hosts: terrain
+  hosts: terrain:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -259,7 +259,7 @@
       service_name_short: "{{terrain.service_name_short}}"
 
 - name: Stop tree-urls
-  hosts: tree-urls
+  hosts: tree-urls:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -272,7 +272,7 @@
       service_name_short: "{{tree_urls.service_name_short}}"
 
 - name: Stop user-preferences
-  hosts: user-preferences
+  hosts: user-preferences:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -285,7 +285,7 @@
       service_name_short: "{{user_preferences.service_name_short}}"
 
 - name: Stop user-sessions
-  hosts: user-sessions
+  hosts: user-sessions:&systems
   sudo: true
   gather_facts: false
   tags:

--- a/ansible/playbooks/de-ui.yaml
+++ b/ansible/playbooks/de-ui.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Configure UI
-  hosts: ui
+  hosts: ui:&systems
   sudo: yes
   gather_facts: false
   tags: 


### PR DESCRIPTION
The intent is to create an intersection of host groups with the
`[systems]` host group. The purpose is to prevent the accidental
execution of playbooks against "non-managed" hosts in the inventory
(i.e. I don't want to accidentally install/re-configure elasticsearch
for my inventory).

CORE-7460