### PR TITLE
Core 6052

### DIFF
--- a/docker/de-backend-buildenv/Dockerfile
+++ b/docker/de-backend-buildenv/Dockerfile
@@ -53,5 +53,4 @@ RUN lein help
 RUN git clone https://github.com/cyverse/DE.git backend && \
     cd backend && \
     git checkout $git_commit && \
-    lein exec build-all.clj lein-plugins libs && \
-    for dir in $(find . -exec test -f {}/project.clj \; -print -prune); do pushd $dir; lein deps; popd; done
+    lein exec build-all.clj lein-plugins libs

--- a/services/terrain/project.clj
+++ b/services/terrain/project.clj
@@ -15,15 +15,15 @@
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "terrain-standalone.jar"
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/tools.nrepl "0.2.10"]
+                 [org.clojure/tools.nrepl "0.2.12"]
                  [cheshire "5.5.0"]
                  [clj-http "2.0.0"]
                  [clj-time "0.11.0"]
-                 [clojurewerkz/elastisch "2.1.0"]
+                 [clojurewerkz/elastisch "2.2.0"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
-                 [commons-net "3.3"]                               ; provides org.apache.commons.net
+                 [commons-net "3.4"]                               ; provides org.apache.commons.net
                  [compojure "1.4.0"]
-                 [metosin/compojure-api "0.24.2"]
+                 [metosin/compojure-api "0.24.3"]
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [dire "0.5.3"]
                  [me.raynes/fs "1.4.6"]

--- a/services/terrain/project.clj
+++ b/services/terrain/project.clj
@@ -23,7 +23,8 @@
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
                  [commons-net "3.4"]                               ; provides org.apache.commons.net
                  [compojure "1.4.0"]
-                 [metosin/compojure-api "0.24.3"]
+                 [metosin/compojure-api "0.24.2"]  ; should be held to the same version as the one 
+                                                   ; used by org.iplantc/clojure-commons
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [dire "0.5.3"]
                  [me.raynes/fs "1.4.6"]

--- a/services/terrain/src/terrain/routes/search.clj
+++ b/services/terrain/src/terrain/routes/search.clj
@@ -16,5 +16,5 @@
 
     (GET "/filesystem/index" [q tags & opts]
       (if (or q tags)
-        (search/search (search/qualify-name (:shortUsername user/current-user)) q tags opts)
+        (search/search (:shortUsername user/current-user) q tags opts)
         (missing-arg-response "`q` or `tags`")))))


### PR DESCRIPTION
See https://pods.cyverse.org/jira/browse/CORE-6052

In brief this is an API change to terrain's data search endpoint, `/secured/filesystem/index`.  A new optional query parameter has been added, `includeTrash`, that allows DE user's trash to be included or excluded in the search results. 

As part of this change, all search results unreachable from the DE, like those from /iplant and /iplant/trash have been excluded.