### PR TITLE
Core 7441

### DIFF
--- a/libs/common-swagger-api/src/common_swagger_api/schema.clj
+++ b/libs/common-swagger-api/src/common_swagger_api/schema.clj
@@ -90,3 +90,7 @@
    :description (describe NonBlankString "The service description")
    :version     (describe NonBlankString "The service version")
    :docs-url    (describe NonBlankString "The service API docs")})
+
+(s/defschema ErrorResponse
+  {:error_code              (describe NonBlankString "The code identifying the type of error")
+   (s/optional-key :reason) (describe NonBlankString "A brief description of the reason for the error")})

--- a/services/apps/src/apps/clients/iplant_groups.clj
+++ b/services/apps/src/apps/clients/iplant_groups.clj
@@ -1,5 +1,6 @@
 (ns apps.clients.iplant-groups
-  (:use [medley.core :only [remove-vals]]
+  (:use [clojure-commons.error-codes :only clj-http-error?]
+        [medley.core :only [remove-vals]]
         [slingshot.slingshot :only [try+]])
   (:require [apps.util.config :as config]
             [apps.util.service :as service]
@@ -156,7 +157,7 @@
   [app-id subject-id level]
   (try+
    (share-app* app-id subject-id level)
-   (catch :status {:keys [body]}
+   (catch clj-http-error? {:keys [body]}
      (let [reason (:grouper_result_message (service/parse-json body))]
        (log/error (str "unable to share " app-id " with " subject-id ": " reason)))
      "the app sharing request failed")))

--- a/services/apps/src/apps/protocols.clj
+++ b/services/apps/src/apps/protocols.clj
@@ -61,4 +61,7 @@
   (ownerAddAppDocs [_ app-id body])
   (adminEditAppDocs [_ app-id body])
   (adminAddAppDocs [_ app-id body])
-  (listAppPermissions [_ app-ids]))
+  (listAppPermissions [_ app-ids])
+  (shareApps [_ sharing-requests])
+  (shareAppsWithUser [_ sharee user-app-sharing-requests])
+  (shareAppWithUser [_ sharee app-id level]))

--- a/services/apps/src/apps/routes/apps.clj
+++ b/services/apps/src/apps/routes/apps.clj
@@ -70,6 +70,19 @@
         endpoint to succeed."
         (ok (apps/list-app-permissions current-user (:apps body))))
 
+  (POST* "/sharing" []
+         :query [params SecuredQueryParams]
+         :body [body (describe perms/AppSharingRequest "The app sharing request.")]
+         :return perms/AppSharingResponse
+         :summary "Share one or more apps with one or more users."
+         :description "This endpoint allows the caller to share multiple apps with multiple users. The
+         authenticated user must have ownership permission to every app in the request body for this
+         endpoint to succeed. Note: this is a potentially slow operation and the response is returned
+         synchronously. The DE UI handles this by allowing the user to continue working while the request
+         is being processed. When calling this endpoint, please be sure that the response timeout is long
+         enough."
+         (ok (apps/share-apps current-user (:sharing body))))
+
   (GET* "/:app-id" []
         :path-params [app-id :- AppIdJobViewPathParam]
         :query [params SecuredQueryParams]

--- a/services/apps/src/apps/routes/apps.clj
+++ b/services/apps/src/apps/routes/apps.clj
@@ -80,7 +80,9 @@
          endpoint to succeed. Note: this is a potentially slow operation and the response is returned
          synchronously. The DE UI handles this by allowing the user to continue working while the request
          is being processed. When calling this endpoint, please be sure that the response timeout is long
-         enough."
+         enough. Using a response timeout that is too short will result in an exception on the client side.
+         On the server side, the result of the sharing operation when a connection is lost is undefined. It
+         may be worthwhile to repeat failed or timed out calls to this endpoint."
          (ok (apps/share-apps current-user (:sharing body))))
 
   (GET* "/:app-id" []

--- a/services/apps/src/apps/routes/domain/permission.clj
+++ b/services/apps/src/apps/routes/domain/permission.clj
@@ -6,13 +6,13 @@
 (defschema AppIdList
   {:apps (describe [NonBlankString] "A List of app identifiers")})
 
-(defschema UserPermission
+(defschema UserPermissionListElement
   {:user       (describe NonBlankString "The user ID")
    :permission (describe (enum "read" "write" "own" "") "The permission level assigned to the user")})
 
-(defschema AppPermissions
+(defschema AppPermissionListElement
   {:id          (describe NonBlankString "The app ID")
-   :permissions (describe [UserPermission] "The list of user permissions for the app")})
+   :permissions (describe [UserPermissionListElement] "The list of user permissions for the app")})
 
 (defschema AppPermissionListing
-  {:apps (describe [AppPermissions] "The list of app permissions")})
+  {:apps (describe [AppPermissionListElement] "The list of app permissions")})

--- a/services/apps/src/apps/routes/domain/permission.clj
+++ b/services/apps/src/apps/routes/domain/permission.clj
@@ -1,14 +1,16 @@
 (ns apps.routes.domain.permission
-  (:use [common-swagger-api.schema :only [describe NonBlankString]]
+  (:use [common-swagger-api.schema :only [describe ErrorResponse NonBlankString]]
         [schema.core :only [defschema optional-key enum]])
   (:import [java.util UUID]))
+
+(def PermissionEnum (enum "read" "write" "own" ""))
 
 (defschema AppIdList
   {:apps (describe [NonBlankString] "A List of app identifiers")})
 
 (defschema UserPermissionListElement
   {:user       (describe NonBlankString "The user ID")
-   :permission (describe (enum "read" "write" "own" "") "The permission level assigned to the user")})
+   :permission (describe PermissionEnum "The permission level assigned to the user")})
 
 (defschema AppPermissionListElement
   {:id          (describe NonBlankString "The app ID")
@@ -16,3 +18,26 @@
 
 (defschema AppPermissionListing
   {:apps (describe [AppPermissionListElement] "The list of app permissions")})
+
+(defschema AppSharingRequestElement
+  {:app_id     (describe NonBlankString "The app ID")
+   :permission (describe PermissionEnum "The requested permission level")})
+
+(defschema AppSharingResponseElement
+  (assoc AppSharingRequestElement
+    :success              (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
+    (optional-key :error) (describe ErrorResponse "Information about any errors that may have occurred")))
+
+(defschema UserAppSharingRequestElement
+  {:user (describe NonBlankString "The user ID")
+   :apps (describe [AppSharingRequestElement] "The list of app sharing requests for the user")})
+
+(defschema UserAppSharingResponseElement
+  (assoc UserAppSharingRequestElement
+    :apps (describe [AppSharingResponseElement] "The list of app sharing responses for the user")))
+
+(defschema AppSharingRequest
+  {:sharing (describe [UserAppSharingRequestElement] "The list of app sharing requests")})
+
+(defschema AppSharingResponse
+  {:sharing (describe [UserAppSharingResponseElement] "The list of app sharing responses")})

--- a/services/apps/src/apps/service/apps.clj
+++ b/services/apps/src/apps/service/apps.clj
@@ -348,3 +348,7 @@
 (defn list-app-permissions
   [user app-ids]
   {:apps (.listAppPermissions (get-apps-client user) app-ids)})
+
+(defn share-apps
+  [user sharing-requests]
+  {:sharing (.shareApps (get-apps-client user) sharing-requests)})

--- a/services/apps/src/apps/service/apps/agave.clj
+++ b/services/apps/src/apps/service/apps/agave.clj
@@ -6,6 +6,7 @@
             [apps.service.apps.agave.pipelines :as pipelines]
             [apps.service.apps.agave.jobs :as agave-jobs]
             [apps.service.apps.job-listings :as job-listings]
+            [apps.service.apps.permissions :as app-permissions]
             [apps.service.apps.util :as apps-util]
             [apps.service.util :as util]
             [apps.util.service :as service]))
@@ -14,9 +15,11 @@
   []
   (service/bad-request "Cannot edit documentation for HPC apps with this service"))
 
+(def app-permission-rejection "Cannot list or modify the permissions of HPC apps with this service")
+
 (defn- reject-app-permission-request
   []
-  (service/bad-request "Cannot list or modify the permissions of HPC apps with this service"))
+  (service/bad-request app-permission-rejection))
 
 (deftype AgaveApps [agave user-has-access-token? user]
   apps.protocols.Apps
@@ -140,4 +143,15 @@
   (listAppPermissions [_ app-ids]
     (when (and (user-has-access-token?)
                (some (complement util/uuid?) app-ids))
-      (reject-app-permission-request))))
+      (reject-app-permission-request)))
+
+  (shareApps [self sharing-requests]
+    (app-permissions/process-app-sharing-requests self sharing-requests))
+
+  (shareAppsWithUser [self sharee user-app-sharing-requests]
+    (app-permissions/process-user-app-sharing-requests self sharee user-app-sharing-requests))
+
+  (shareAppWithUser [_ _ app-id level]
+    (when (and (user-has-access-token?)
+               (not (util/uuid? app-id)))
+      (app-permissions/app-sharing-failure app-id level app-permission-rejection))))

--- a/services/apps/src/apps/service/apps/agave/listings.clj
+++ b/services/apps/src/apps/service/apps/agave/listings.clj
@@ -2,7 +2,7 @@
   (:use [apps.service.util :only [sort-apps apply-offset apply-limit uuid?]]
         [slingshot.slingshot :only [try+]])
   (:require [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
+            [clojure-commons.error-codes :as ce :refer [clj-http-error?]]
             [apps.persistence.app-metadata :as ap]))
 
 (defn list-apps
@@ -22,7 +22,7 @@
    (catch [:error_code ce/ERR_UNAVAILABLE] _
      (log/error (:throwable &throw-context) "Agave app search timed out")
      nil)
-   (catch :status _
+   (catch clj-http-error? _
      (log/error (:throwable &throw-context) "HTTP error returned by Agave")
      nil)))
 
@@ -37,7 +37,7 @@
    (catch [:type :clojure-commons.exception/unavailable] _
      (log/warn (:throwable &throw-context) "Agave app table retrieval timed out")
      [])
-   (catch :status _
+   (catch clj-http-error? _
      (log/error (:throwable &throw-context) "HTTP error returned by Agave")
      [])))
 

--- a/services/apps/src/apps/service/apps/combined.clj
+++ b/services/apps/src/apps/service/apps/combined.clj
@@ -8,7 +8,8 @@
             [apps.service.apps.job-listings :as job-listings]
             [apps.service.apps.combined.job-view :as job-view]
             [apps.service.apps.combined.jobs :as combined-jobs]
-            [apps.service.apps.combined.util :as util]))
+            [apps.service.apps.combined.util :as util]
+            [apps.service.apps.permissions :as app-permissions]))
 
 (deftype CombinedApps [clients user]
   apps.protocols.Apps
@@ -210,4 +211,13 @@
          (first)))
 
   (listAppPermissions [_ app-ids]
-    (mapcat #(.listAppPermissions % app-ids) clients)))
+    (mapcat #(.listAppPermissions % app-ids) clients))
+
+  (shareApps [self sharing-requests]
+    (app-permissions/process-app-sharing-requests self sharing-requests))
+
+  (shareAppsWithUser [self sharee user-app-sharing-requests]
+    (app-permissions/process-user-app-sharing-requests self sharee user-app-sharing-requests))
+
+  (shareAppWithUser [_ sharee app-id level]
+    (first (remove nil? (map #(.shareAppWithUser % sharee app-id level) clients)))))

--- a/services/apps/src/apps/service/apps/de.clj
+++ b/services/apps/src/apps/service/apps/de.clj
@@ -16,6 +16,7 @@
             [apps.service.apps.de.pipeline-edit :as pipeline-edit]
             [apps.service.apps.de.validation :as app-validation]
             [apps.service.apps.job-listings :as job-listings]
+            [apps.service.apps.permissions :as app-permissions]
             [apps.service.apps.util :as apps-util]
             [apps.service.util :as util]))
 
@@ -225,4 +226,16 @@
 
   (listAppPermissions [_ app-ids]
     (when-let [uuids (util/extract-uuids app-ids)]
-      (perms/list-app-permissions user uuids))))
+      (perms/list-app-permissions user uuids)))
+
+  (shareApps [self sharing-requests]
+    (app-permissions/process-app-sharing-requests self sharing-requests))
+
+  (shareAppsWithUser [self sharee user-app-sharing-requests]
+    (app-permissions/process-user-app-sharing-requests self sharee user-app-sharing-requests))
+
+  (shareAppWithUser [_ sharee app-id level]
+    (when (util/uuid? app-id)
+      (if-let [failure-reason (perms/share-app-with-user user sharee (uuidify app-id) level)]
+        (app-permissions/app-sharing-failure app-id level failure-reason)
+        (app-permissions/app-sharing-success app-id level)))))

--- a/services/apps/src/apps/service/apps/de/permissions.clj
+++ b/services/apps/src/apps/service/apps/de/permissions.clj
@@ -1,4 +1,5 @@
 (ns apps.service.apps.de.permissions
+  (:use [slingshot.slingshot :only [try+]])
   (:require [apps.clients.iplant-groups :as iplant-groups]
             [clojure.string :as string]
             [clojure-commons.exception-util :as cxu]))
@@ -23,6 +24,12 @@
     (when-let [forbidden-apps (seq (filter (partial lacks-permission-level perms required-level) app-ids))]
       (cxu/forbidden (str "insufficient privileges for apps: " (string/join ", " forbidden-apps))))))
 
+(defn- get-permission-error
+  [user required-level app-id]
+  (let [perms (iplant-groups/load-app-permissions user [app-id])]
+    (when (lacks-permission-level perms required-level app-id)
+      (str "insufficient privileges for app: " (str app-id)))))
+
 (defn- format-app-permissions
   [user perms app-id]
   (->> (group-by (comp string/lower-case :id :subject) (perms app-id))
@@ -34,3 +41,9 @@
   [{user :shortUsername} app-ids]
   (check-app-permissions user "read" app-ids)
   (map (partial format-app-permissions user (iplant-groups/list-app-permissions app-ids)) app-ids))
+
+(defn share-app-with-user
+  [{user :shortUsername} sharee app-id level]
+  (if-let [permission-error (get-permission-error user "own" app-id)]
+    permission-error
+    (iplant-groups/share-app app-id sharee level)))

--- a/services/apps/src/apps/service/apps/de/permissions.clj
+++ b/services/apps/src/apps/service/apps/de/permissions.clj
@@ -1,5 +1,6 @@
 (ns apps.service.apps.de.permissions
-  (:use [slingshot.slingshot :only [try+]])
+  (:use [clojure-commons.error-codes :only [clj-http-error?]]
+        [slingshot.slingshot :only [try+]])
   (:require [apps.clients.iplant-groups :as iplant-groups]
             [apps.util.service :as service]
             [clojure.string :as string]
@@ -31,7 +32,7 @@
    (let [perms (iplant-groups/load-app-permissions user [app-id])]
      (when (lacks-permission-level perms required-level app-id)
        (str "insufficient privileges for app: " (str app-id))))
-   (catch :status {:keys [body]}
+   (catch clj-http-error? {:keys [body]}
      (let [reason (:grouper_result_message (service/parse-json body))]
        (str "unable to load permissions for " app-id ": " reason)))))
 

--- a/services/apps/src/apps/service/apps/permissions.clj
+++ b/services/apps/src/apps/service/apps/permissions.clj
@@ -1,0 +1,29 @@
+(ns apps.service.apps.permissions
+  (:require [clojure.tools.logging :as log]
+            [clojure-commons.error-codes :as ce]))
+
+(defn process-app-sharing-requests
+  [apps-client app-sharing-requests]
+  (for [{sharee :user user-app-sharing-requests :apps} app-sharing-requests]
+    {:user sharee
+     :apps (.shareAppsWithUser apps-client sharee user-app-sharing-requests)}))
+
+(defn process-user-app-sharing-requests
+  [apps-client sharee user-app-sharing-requests]
+  (for [{app-id :app_id level :permission :as request} user-app-sharing-requests]
+    (do (log/spy :warn request)
+        (.shareAppWithUser apps-client sharee app-id level))))
+
+(defn app-sharing-success
+  [app-id level]
+  {:app_id     app-id
+   :permission level
+   :success    true})
+
+(defn app-sharing-failure
+  [app-id level reason]
+  {:app_id     app-id
+   :permission level
+   :success    false
+   :error      {:error_code ce/ERR_BAD_REQUEST
+                :reason     reason}})

--- a/services/iplant-groups/src/iplant_groups/clients/grouper.clj
+++ b/services/iplant-groups/src/iplant_groups/clients/grouper.clj
@@ -520,20 +520,60 @@
 
 ;; Permission assignment
 ;; search/lookup
+(defn- role-lookup
+  [role-name]
+  (when-not (nil? role-name)
+    {:groupName role-name}))
+
+(defn- role-lookups
+  [role-names]
+  (when-not (every? nil? role-names)
+    (mapv role-lookup (remove nil? role-names))))
+
+(defn- subject-lookup
+  [subject-id]
+  (when-not (nil? subject-id)
+    {:subjectId subject-id}))
+
+(defn- subject-lookups
+  [subject-ids]
+  (when-not (every? nil? subject-ids)
+    (mapv subject-lookup (remove nil? subject-ids))))
+
+(defn- name-lookup
+  [name]
+  (when-not (nil? name)
+    {:name name}))
+
+(defn- name-lookups
+  [names]
+  (when-not (every? nil? names)
+    (mapv name-lookup (remove nil? names))))
+
+(defn- uuid-lookup
+  [uuid]
+  (when-not (nil? uuid)
+    {:uuid uuid}))
+
+(defn- uuid-lookups
+  [uuids]
+  (when-not (every? nil? uuids)
+    (mapv uuid-lookup (remove nil? uuids))))
+
 (defn- format-attribute-def-lookup
   [{:keys [attribute_def_id attribute_def]}]
-  (cond attribute_def_id [{:uuid attribute_def_id}]
-        attribute_def    [{:name attribute_def}]))
+  (cond attribute_def_id (uuid-lookups [attribute_def_id])
+        attribute_def    (name-lookups [attribute_def])))
 
 (defn- format-attribute-def-name-lookup
   [{:keys [attribute_def_name_ids attribute_def_names]}]
-  (concat (mapv (partial hash-map :uuid) attribute_def_name_ids)
-          (mapv (partial hash-map :name) attribute_def_names)))
+  (concat (uuid-lookups attribute_def_name_ids)
+          (name-lookups attribute_def_names)))
 
 (defn- format-role-lookup
   [{:keys [role_id role]}]
-  (cond role_id [{:uuid role_id}]
-        role    [{:groupName role}]))
+  (cond role_id (uuid-lookups [role_id])
+        role    (role-lookups [role])))
 
 (defn- format-action-names-lookup
   [{:keys [action_names]}]
@@ -548,7 +588,7 @@
                       :wsAttributeDefNameLookups (format-attribute-def-name-lookup params)
                       :roleLookups (format-role-lookup params)
                       :actions (format-action-names-lookup params)
-                      :wsSubjectLookups (if subject_id [{:subjectId subject_id}])
+                      :wsSubjectLookups (subject-lookups [subject_id])
                       :immediateOnly (parse-boolean immediate_only)})})
 
 (defn permission-assignment-search*
@@ -586,7 +626,7 @@
 (defn- role-permissions
   [role-names]
   {:permissionType "role"
-   :roleLookups (mapv (partial hash-map :groupName) role-names)})
+   :roleLookups (role-lookups role-names)})
 
 (defn- role-permission
   [role-name]
@@ -594,8 +634,8 @@
 
 (defn- subject-role-lookup
   [[role-name subject-id]]
-  {:wsGroupLookup {:groupName role-name}
-   :wsSubjectLookup {:subjectId subject-id}})
+  {:wsGroupLookup (role-lookup role-name)
+   :wsSubjectLookup (subject-lookup subject-id)})
 
 (defn- membership-permissions
   [roles-and-subjects]
@@ -666,14 +706,16 @@
       username attribute-def-name role-name subject-id action-names)))
 
 (defn- format-all-permission-search-request
-  [username attribute-def-name]
+  [username attribute-def-name role subject-id]
   {:WsRestGetPermissionAssignmentsRequest
    (remove-vals nil? {:actAsSubjectLookup (act-as-subject-lookup username)
-                      :wsAttributeDefNameLookups [{:name attribute-def-name}]})})
+                      :wsAttributeDefNameLookups (name-lookups [attribute-def-name])
+                      :roleLookups (role-lookups [role])
+                      :subjectLookups (subject-lookups [subject-id])})})
 
 (defn- get-permission-assign-ids
-  [username attribute-def-name]
-  (->> (format-all-permission-search-request username attribute-def-name)
+  [username attribute-def-name & {:keys [role subject-id]}]
+  (->> (format-all-permission-search-request username attribute-def-name role subject-id)
        (permission-assignment-search*)
        (distinct-by :attributeAssignId)
        (group-by :permissionType)
@@ -685,7 +727,7 @@
    {:permissionAssignOperation "remove_permission"
     :actAsSubjectLookup (act-as-subject-lookup username)
     :permissionType permission-type
-    :wsAttributeAssignLookups (mapv (partial hash-map :uuid) ids)}})
+    :wsAttributeAssignLookups (uuid-lookups ids)}})
 
 (defn- remove-permission-assign-ids
   [username permission-type ids]

--- a/services/terrain/src/terrain/clients/apps/raw.clj
+++ b/services/terrain/src/terrain/clients/apps/raw.clj
@@ -90,6 +90,15 @@
                 :as               :stream
                 :follow-redirects false}))
 
+(defn share
+  [body]
+  (client/post (apps-url "apps" "sharing")
+               {:query-params     (secured-params)
+                :body             body
+                :content-type     :json
+                :as               :stream
+                :follow-redirects false}))
+
 (defn get-app
   [app-id]
   (client/get (apps-url "apps" app-id)

--- a/services/terrain/src/terrain/routes/metadata.clj
+++ b/services/terrain/src/terrain/routes/metadata.clj
@@ -105,6 +105,9 @@
     (POST "/apps/permission-lister" [:as {:keys [body]}]
           (service/success-response (apps/list-permissions body)))
 
+    (POST "/apps/sharing" [:as {:keys [body]}]
+          (service/success-response (apps/share body)))
+
     (GET "/apps/:app-id" [app-id]
          (service/success-response (apps/get-app app-id)))
 


### PR DESCRIPTION
This one was interesting because grouper (:fish:) doesn't treat duplicate permission assignments as no-ops. I worked around this by removing any matching permission assignments (that is, any permission assignments that match on everything but the action name) before assigning the new permissions. Note: this only works for us because we never expect to have direct permission assignments to more than one action name.
