### PR TITLE
Add email notifications for Permanent ID requesters

### DIFF
--- a/services/iplant-email/conf/permanent_id_request_submitted.st
+++ b/services/iplant-email/conf/permanent_id_request_submitted.st
@@ -1,0 +1,3 @@
+Your $request_type$ Permanent ID Request was successfully submitted.
+Your data set has been moved to $path$ for administrative review.
+You will receive notifications in the Discovery Environment as the request process proceeds.

--- a/services/terrain/src/terrain/services/permanent_id_requests.clj
+++ b/services/terrain/src/terrain/services/permanent_id_requests.clj
@@ -118,7 +118,8 @@
         curators    (config/permanent-id-curators-group)]
     (data-info-client/move-single (config/irods-user) id (config/permanent-id-staging-dir))
     (data-info/share (config/irods-user) [user] [staged-path] "write")
-    (data-info/share (config/irods-user) [curators] [staged-path] "own")))
+    (data-info/share (config/irods-user) [curators] [staged-path] "own")
+    staged-path))
 
 (defn- send-notification
   [user subject request-id]
@@ -201,10 +202,11 @@
         user                           (:shortUsername current-user)
         {:keys [path] :as folder}      (get-validated-data-item user folder-id)
         target-type                    (validate-request-target-type folder)
-        {request-id :id :as response}  (submit-permanent-id-request type folder-id target-type path)]
-    (stage-data-item user folder)
+        {request-id :id :as response}  (submit-permanent-id-request type folder-id target-type path)
+        staged-path                    (stage-data-item user folder)]
     (send-notification user (str type " Request Submitted for " (ft/basename path)) request-id)
-    (email/send-permanent-id-request-new type path current-user)
+    (email/send-permanent-id-request-new type staged-path current-user)
+    (email/send-permanent-id-request-submitted type staged-path current-user)
     (format-perm-id-req-response user response)))
 
 (defn list-permanent-id-request-status-codes

--- a/services/terrain/src/terrain/util/email.clj
+++ b/services/terrain/src/terrain/util/email.clj
@@ -65,6 +65,21 @@
       "permanent_id_request_complete"
       template-values)))
 
+(defn send-permanent-id-request-submitted
+  "Sends an email message to the user requesting a new Permanent ID Request."
+  [request-type path {:keys [commonName email]}]
+  (let [template-values {:username     commonName
+                         :environment  (config/environment-name)
+                         :request_type request-type
+                         :path         path}
+        subject         (str request-type " Permanent ID Request Submitted")]
+    (send-email
+      :to        email
+      :from-addr (config/permanent-id-request-src-addr)
+      :subject   subject
+      :template  "permanent_id_request_submitted"
+      :values    template-values)))
+
 (defn- format-question
   "Formats a question and answer for a user feedback submission."
   [[q a]]


### PR DESCRIPTION
The requesting user will now receive an email notification on successful submission.
The data curator email notification has been improved to include the staged path rather than the original path.