### PR TITLE
Core 3114 & Core 5560

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/submit/SubmitAppForPublicUseViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/submit/SubmitAppForPublicUseViewImpl.java
@@ -13,6 +13,8 @@ import org.iplantc.de.diskResource.client.gin.factory.DiskResourceSelectorFieldF
 import org.iplantc.de.diskResource.client.views.widgets.FolderSelectorField;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.json.client.JSONArray;
@@ -265,6 +267,21 @@ public class SubmitAppForPublicUseViewImpl implements SubmitAppForPublicUseView 
         tree.setCheckable(true);
         tree.setCheckStyle(CheckCascade.CHILDREN);
         tree.setCheckNodes(CheckNodes.LEAF);
+        tree.getSelectionModel().addSelectionHandler(new SelectionHandler<AppCategory>() {
+            @Override
+            public void onSelection(SelectionEvent<AppCategory> event) {
+                AppCategory selectedItem = event.getSelectedItem();
+                // Have to deselect after un/checking the item, or else a second
+                // SelectionEvent gets fired and reverts the check
+                if (tree.isChecked(selectedItem)) {
+                    tree.setChecked(selectedItem, Tree.CheckState.UNCHECKED);
+                    tree.getSelectionModel().deselect(selectedItem);
+                } else {
+                    tree.setChecked(selectedItem, Tree.CheckState.CHECKED);
+                    tree.getSelectionModel().deselect(selectedItem);
+                }
+            }
+        });
     }
 
     private void initTreeStoreSorter() {

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/toolRequest/ToolRequestStatus.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/toolRequest/ToolRequestStatus.java
@@ -13,7 +13,7 @@ import com.google.common.base.Strings;
 public enum ToolRequestStatus {
     Submitted("Submitted", I18N.HELP.toolRequestStatusSubmittedHelp()), Pending("Pending", I18N.HELP.toolRequestStatusPendingHelp()), Evaluation("Evaluation", I18N.HELP
             .toolRequestStatusEvaluationHelp()), Installation("Installation", I18N.HELP.toolRequestStatusInstallationHelp()), Validation("Validation", I18N.HELP.toolRequestStatusValidationHelp()), Completion(
-            "Completion", I18N.HELP.toolRequestStatusCompleteHelp()), Failed("Failed", I18N.HELP.toolRequestStatusFailedHelp());
+            "Completion", I18N.HELP.toolRequestStatusCompleteHelp()), Failed("Failed", I18N.HELP.toolRequestStatusFailedHelp()), Other("Other", I18N.HELP.toolRequestStatusOtherHelp());
 
     private String helpText;
     private String displayText;

--- a/ui/de-lib/src/main/java/org/iplantc/de/notifications/client/views/cells/RequestStatusCell.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/notifications/client/views/cells/RequestStatusCell.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.notifications.client.views.cells;
 
+import org.iplantc.de.client.models.tool.Tool;
 import org.iplantc.de.client.models.toolRequest.ToolRequestStatus;
 
 import com.google.gwt.cell.client.AbstractCell;
@@ -25,7 +26,10 @@ public class RequestStatusCell extends AbstractCell<String> {
                 || value.equalsIgnoreCase(ToolRequestStatus.Validation.toString())) ) {
             qtip = Format.substitute("qtip=\"{0}\"", ToolRequestStatus.valueOf(value).getHelpText()); //$NON-NLS-1$
             sb.appendHtmlConstant(Format.substitute("<div {0}>{1}</div>", qtip, value));
-        } else {
+        } else if (value != null) {
+            qtip = Format.substitute("qtip=\"{0}\"", ToolRequestStatus.valueOf(ToolRequestStatus.Other.toString()).getHelpText()); //$NON-NLS-1$
+            sb.appendHtmlConstant(Format.substitute("<div {0}>{1}</div>", qtip, value));
+        } else{
             sb.appendHtmlConstant(Format.substitute("<div>{0}</div>", value));
         }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/resources/client/messages/IplantContextualHelpStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/resources/client/messages/IplantContextualHelpStrings.java
@@ -87,4 +87,7 @@ public interface IplantContextualHelpStrings extends com.google.gwt.i18n.client.
   @Key("toolRequestStatusValidationHelp")
   String toolRequestStatusValidationHelp();
 
+  @DefaultMessage("A custom status can sometimes be applicable. Please see the Status Comments for more information.")
+  @Key("toolRequestStatusOtherHelp")
+  String toolRequestStatusOtherHelp();
 }

--- a/ui/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantContextualHelpStrings.properties
+++ b/ui/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantContextualHelpStrings.properties
@@ -7,3 +7,4 @@ toolRequestStatusInstallationHelp = The iPlant team is currently installing your
 toolRequestStatusValidationHelp = The iPlant team is currently validating your requested tool. You will receive notifications in the Discovery Environment as the process proceeds. Please see the Status Comments for more information.
 toolRequestStatusCompleteHelp = Your requested tool is now available in the Discovery Environment. Please see the Status Comments for more information.
 toolRequestStatusFailedHelp = The installation of your requested tool was unsuccessful. Please see the Status Comments for more information.
+toolRequestStatusOtherHelp = A custom status can sometimes be applicable. Please see the Status Comments for more information.


### PR DESCRIPTION
Two tickets, one pull request.

Copied from the tickets:
CORE-3114 - At present, you can choose an App category in the Public Submission form for apps only by clicking in the check-box. To unselect a category, you to un-check the category again. It would be better if we can add support select / unselect categories just by clicking on the category itself.

CORE-5560 - The Help/Info popup lists the 7 standard Tool Request statues, and says the request will be in one of those.  With 1.8.7, arbitrary/custom status support was added.  The Help/Info popup should be updated to indicate this.