### PR TITLE
CORE-4791 & CORE-6747

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
@@ -41,6 +41,8 @@ public interface AppCategoriesView extends IsWidget,
         String headingText();
 
         void setTreeIcons(TreeStyle style);
+
+        String copyAppSuccessMessage(String appName);
     }
 
     /**

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/AppsGridView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/AppsGridView.java
@@ -58,6 +58,10 @@ public interface AppsGridView extends IsWidget,
         String ratingColumnLabel();
 
         String searchAppResultsHeader(String searchText, int total);
+
+        String agaveAuthRequiredTitle();
+
+        String agaveAuthRequiredMsg();
     }
 
     /**

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
@@ -29,6 +29,7 @@ import org.iplantc.de.client.util.JsonUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -318,6 +319,8 @@ public class AppCategoriesPresenterImpl implements AppCategoriesView.Presenter,
             public void onSuccess(final AppTemplate app) {
                 // Update the user's private apps group count.
                 if (!app.getId().isEmpty()) {
+                    announcer.schedule(new SuccessAnnouncementConfig(appearance.copyAppSuccessMessage(appToBeCopied.getName())));
+
                     view.getTree().getSelectionModel().deselectAll();
                     AppCategory userCategory = findAppCategoryByName(USER_APPS_GROUP);
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/grid/AppsGridPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/grid/AppsGridPresenterImpl.java
@@ -27,6 +27,7 @@ import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.comments.view.dialogs.CommentsDialog;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.shared.exceptions.HttpRedirectException;
 
 import com.google.common.base.Preconditions;
 import com.google.gwt.event.shared.GwtEvent;
@@ -40,6 +41,7 @@ import com.sencha.gxt.data.shared.event.StoreAddEvent;
 import com.sencha.gxt.data.shared.event.StoreClearEvent;
 import com.sencha.gxt.data.shared.event.StoreRemoveEvent;
 import com.sencha.gxt.data.shared.event.StoreUpdateEvent;
+import com.sencha.gxt.widget.core.client.box.MessageBox;
 
 import java.util.List;
 
@@ -138,7 +140,13 @@ public class AppsGridPresenterImpl implements AppsGridView.Presenter,
         appService.getApps(appCategory, new AsyncCallback<List<App>>() {
             @Override
             public void onFailure(Throwable caught) {
-                ErrorHandler.post(caught);
+                if (caught instanceof HttpRedirectException) {
+                    MessageBox messageBox = new MessageBox(appearance.agaveAuthRequiredTitle(), appearance.agaveAuthRequiredMsg());
+                    messageBox.setIcon(MessageBox.ICONS.info());
+                    messageBox.show();
+                } else {
+                    ErrorHandler.post(caught);
+                }
                 view.unmask();
             }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/resources/client/messages/IplantDisplayStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/resources/client/messages/IplantDisplayStrings.java
@@ -2967,4 +2967,7 @@ public interface IplantDisplayStrings extends com.google.gwt.i18n.client.Message
 
     String removeFromFavorites(String resource_name);
 
+    @DefaultMessage("Agave Redirect")
+    @Key("agaveAuthRequiredTitle")
+    String agaveAuthRequiredTitle();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
@@ -117,4 +117,6 @@ public interface AppsMessages extends Messages {
     String appUrl();
 
     String copyAppUrl();
+
+    String copyAppSuccessMessage(String appName);
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
@@ -53,3 +53,4 @@ featureNotSupported = Feature not supported for external apps!
 url = URL:
 appUrl = App URL
 copyAppUrl = Copy App URL
+copyAppSuccessMessage = ''{0}'' was successfully copied, and the copy is now open for editing.

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/categories/AppCategoriesViewDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/categories/AppCategoriesViewDefaultAppearance.java
@@ -72,4 +72,9 @@ public class AppCategoriesViewDefaultAppearance implements AppCategoriesView.App
         style.setNodeOpenIcon(resources.categoryOpen());
         style.setLeafIcon(resources.subCategory());
     }
+
+    @Override
+    public String copyAppSuccessMessage(String appName) {
+        return appsMessages.copyAppSuccessMessage(appName);
+    }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/grid/AppsGridViewDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/grid/AppsGridViewDefaultAppearance.java
@@ -68,4 +68,14 @@ public class AppsGridViewDefaultAppearance implements AppsGridView.AppsGridAppea
     public String searchAppResultsHeader(String searchText, int total) {
         return appsMessages.searchAppResultsHeader(searchText, total);
     }
+
+    @Override
+    public String agaveAuthRequiredTitle() {
+        return iplantDisplayStrings.agaveAuthRequiredTitle();
+    }
+
+    @Override
+    public String agaveAuthRequiredMsg() {
+        return iplantDisplayStrings.agaveAuthRequiredMsg();
+    }
 }

--- a/ui/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantDisplayStrings.properties
+++ b/ui/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantDisplayStrings.properties
@@ -6,6 +6,7 @@ addnlData = Select additional data
 adminInfo = &nbsp;Click on the app name to edit. To re-categorize an app, drag and drop it into appropriate category in the categories tree.
 affirmativeResponse=Yes
 agaveAuthRequiredMsg = Your browser will be temporarily redirected to Agave for authorization.
+agaveAuthRequiredTitle = Agave Redirect
 alert=Alert
 analyses = Analyses
 analysesNotDeleted = Analyses that are not in completed or failed status were not deleted.


### PR DESCRIPTION
CORE-4791 is adding an announcement to show to the user when they've successfully copied an App.  Prior to this, there was no indication the app was copied.  The user was immediately presented with the Edit App window which made it unclear if the app was already copied or if they had to save the edit window first.

CORE-6747 is adding a message to indicate to the user when they've clicked on the HPC app category that they'll be redirected to the Agave auth page instead of a `302` error message.