### PR TITLE
Refactor data-info routes.

### DIFF
--- a/services/data-info/src/data_info/routes.clj
+++ b/services/data-info/src/data_info/routes.clj
@@ -13,6 +13,7 @@
             [data-info.routes.filetypes :as filetypes-routes]
             [data-info.routes.users :as users-routes]
             [data-info.routes.navigation :as navigation-routes]
+            [data-info.routes.rename :as rename-routes]
             [data-info.routes.status :as status-routes]
             [data-info.routes.stats :as stat-routes]
             [data-info.routes.trash :as trash-routes]
@@ -45,6 +46,7 @@
      log-validation-errors]
     status-routes/status
     data-routes/data-operations
+    rename-routes/rename-routes
     avus-routes/avus-routes
     exists-routes/existence-marker
     filetypes-routes/filetypes-operations

--- a/services/data-info/src/data_info/routes.clj
+++ b/services/data-info/src/data_info/routes.clj
@@ -7,6 +7,7 @@
         [ring.util.response :only [redirect]])
   (:require [compojure.route :as route]
             [clojure-commons.exception :as cx]
+            [data-info.routes.avus :as avus-routes]
             [data-info.routes.data :as data-routes]
             [data-info.routes.exists :as exists-routes]
             [data-info.routes.filetypes :as filetypes-routes]
@@ -44,6 +45,7 @@
      log-validation-errors]
     status-routes/status
     data-routes/data-operations
+    avus-routes/avus-routes
     exists-routes/existence-marker
     filetypes-routes/filetypes-operations
     users-routes/permissions-gatherer

--- a/services/data-info/src/data_info/routes/avus.clj
+++ b/services/data-info/src/data_info/routes/avus.clj
@@ -1,0 +1,66 @@
+(ns data-info.routes.avus
+  (:use [common-swagger-api.schema]
+        [data-info.routes.domain.common]
+        [data-info.routes.domain.avus])
+  (:require [data-info.services.metadata :as meta]
+            [data-info.util.service :as svc]))
+
+(defroutes* avus-routes
+  (context* "/admin/data/:data-id" []
+    :path-params [data-id :- DataIdPathParam]
+    :tags ["data-by-id"]
+
+    (GET* "/avus" [:as {uri :uri}]
+      :query [{:keys [user]} StandardUserQueryParams]
+      :return AVUGetResult
+      :summary "List AVUs (administrative)"
+      :description (str "List iRODS AVUs associated with a data item. Include administrative/system AVUs."
+(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE"))
+      (svc/trap uri meta/admin-metadata-get data-id))
+
+    (POST* "/avus" [:as {uri :uri}]
+      :query [{:keys [user]} StandardUserQueryParams]
+      :body [{:keys [irods-avus]} (describe AVUListing "An list of AVUs to add")]
+      :return AVUChangeResult
+      :summary "Add AVUs (administrative)"
+      :description (str "Associate AVUs with a data item. Allow adding any AVU."
+(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED"))
+      (svc/trap uri meta/admin-metadata-add data-id irods-avus))
+
+    (DELETE* "/avus" [:as {uri :uri}]
+      :query [{:keys [user attr value]} AVUDeleteParams]
+      :return AVUChangeResult
+      :summary "Delete AVU (administrative)"
+      :description (str "Delete a single AVU from a data item. Allows deleting any AVU."
+(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED"))
+      (svc/trap uri meta/admin-metadata-delete data-id [{:attr attr :value value}])))
+
+  (context* "/data/:data-id" []
+    :path-params [data-id :- DataIdPathParam]
+    :tags ["data-by-id"]
+
+    (GET* "/avus" [:as {uri :uri}]
+      :query [{:keys [user]} StandardUserQueryParams]
+      :return AVUGetResult
+      :summary "List AVUs"
+      :description (str "List iRODS AVUs associated with a data item."
+(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE"))
+      (svc/trap uri meta/metadata-get user data-id :system false))
+
+    (POST* "/avus" [:as {uri :uri}]
+      :query [{:keys [user]} StandardUserQueryParams]
+      :body [{:keys [irods-avus]} (describe AVUListing "An list of AVUs to add")]
+      :return AVUChangeResult
+      :summary "Add AVUs"
+      :description (str "Associate AVUs with a data item. Administrative AVUs may not be added with this endpoint."
+(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED"))
+      (svc/trap uri meta/metadata-add user data-id irods-avus))
+
+    (PUT* "/avus" [:as {uri :uri}]
+      :query [{:keys [user]} StandardUserQueryParams]
+      :body [{:keys [irods-avus]} (describe AVUListing "A list of AVUs to set for this file. May not include administrative AVUs, and will not delete them.")]
+      :return AVUSetResult
+      :summary "Set AVUs"
+      :description (str "Set the iRODS AVUS for a data item to a provided set. This set may not include administrative AVUs, and similarly will not remove administrative AVUs."
+(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED"))
+      (svc/trap uri meta/metadata-set user data-id irods-avus))))

--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -28,38 +28,6 @@
 (get-error-code-block "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_TOO_MANY_PATHS, ERR_NOT_A_USER"))
     (svc/trap uri rename/do-move params body))
 
-  (context* "/admin/data" []
-    :tags ["data"]
-
-    (context* "/:data-id" []
-      :path-params [data-id :- DataIdPathParam]
-      :tags ["data-by-id"]
-
-      (GET* "/avus" [:as {uri :uri}]
-        :query [{:keys [user]} StandardUserQueryParams]
-        :return AVUGetResult
-        :summary "List AVUs (administrative)"
-        :description (str "List iRODS AVUs associated with a data item. Include administrative/system AVUs."
-(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE"))
-        (svc/trap uri meta/admin-metadata-get data-id))
-
-      (POST* "/avus" [:as {uri :uri}]
-        :query [{:keys [user]} StandardUserQueryParams]
-        :body [{:keys [irods-avus]} (describe AVUListing "An list of AVUs to add")]
-        :return AVUChangeResult
-        :summary "Add AVUs (administrative)"
-        :description (str "Associate AVUs with a data item. Allow adding any AVU."
-(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED"))
-        (svc/trap uri meta/admin-metadata-add data-id irods-avus))
-
-      (DELETE* "/avus" [:as {uri :uri}]
-        :query [{:keys [user attr value]} AVUDeleteParams]
-        :return AVUChangeResult
-        :summary "Delete AVU (administrative)"
-        :description (str "Delete a single AVU from a data item. Allows deleting any AVU."
-(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED"))
-        (svc/trap uri meta/admin-metadata-delete data-id [{:attr attr :value value}]))))
-
   (context* "/data" []
     :tags ["data"]
 
@@ -139,32 +107,6 @@ with characters in a runtime-configurable parameter. Currently, this parameter l
 "Overwrites a file as a user, given the user can write to it and the file already exists."
 (get-error-code-block "ERR_NOT_A_USER, ERR_DOES_NOT_EXIST, ERR_NOT_A_FILE, ERR_NOT_WRITEABLE"))
         (svc/trap uri write/do-upload params file))
-
-      (GET* "/avus" [:as {uri :uri}]
-        :query [{:keys [user]} StandardUserQueryParams]
-        :return AVUGetResult
-        :summary "List AVUs"
-        :description (str "List iRODS AVUs associated with a data item."
-(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE"))
-        (svc/trap uri meta/metadata-get user data-id :system false))
-
-      (POST* "/avus" [:as {uri :uri}]
-        :query [{:keys [user]} StandardUserQueryParams]
-        :body [{:keys [irods-avus]} (describe AVUListing "An list of AVUs to add")]
-        :return AVUChangeResult
-        :summary "Add AVUs"
-        :description (str "Associate AVUs with a data item. Administrative AVUs may not be added with this endpoint."
-(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED"))
-        (svc/trap uri meta/metadata-add user data-id irods-avus))
-
-      (PUT* "/avus" [:as {uri :uri}]
-        :query [{:keys [user]} StandardUserQueryParams]
-        :body [{:keys [irods-avus]} (describe AVUListing "A list of AVUs to set for this file. May not include administrative AVUs, and will not delete them.")]
-        :return AVUSetResult
-        :summary "Set AVUs"
-        :description (str "Set the iRODS AVUS for a data item to a provided set. This set may not include administrative AVUs, and similarly will not remove administrative AVUs."
-(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED"))
-        (svc/trap uri meta/metadata-set user data-id irods-avus))
 
       (PUT* "/name" [:as {uri :uri}]
         :query [params StandardUserQueryParams]

--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -4,7 +4,6 @@
         [data-info.routes.domain.data]
         [data-info.routes.domain.stats])
   (:require [data-info.services.create :as create]
-            [data-info.services.rename :as rename]
             [data-info.services.metadata :as meta]
             [data-info.services.entry :as entry]
             [data-info.services.write :as write]
@@ -16,17 +15,6 @@
             [data-info.util.schema :as s]))
 
 (defroutes* data-operations
-
-  (POST* "/mover" [:as {uri :uri}]
-    :tags ["bulk"]
-    :query [params StandardUserQueryParams]
-    :body [body (describe MultiRenameRequest "The paths to rename and their destination.")]
-    :return MultiRenameResult
-    :summary "Move Data Items"
-    :description (str
-"Given a list of sources and a destination in the body, moves all the sources into the given destination directory."
-(get-error-code-block "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_TOO_MANY_PATHS, ERR_NOT_A_USER"))
-    (svc/trap uri rename/do-move params body))
 
   (context* "/data" []
     :tags ["data"]
@@ -107,39 +95,6 @@ with characters in a runtime-configurable parameter. Currently, this parameter l
 "Overwrites a file as a user, given the user can write to it and the file already exists."
 (get-error-code-block "ERR_NOT_A_USER, ERR_DOES_NOT_EXIST, ERR_NOT_A_FILE, ERR_NOT_WRITEABLE"))
         (svc/trap uri write/do-upload params file))
-
-      (PUT* "/name" [:as {uri :uri}]
-        :query [params StandardUserQueryParams]
-        :body [body (describe Filename "The new name of the data item.")]
-        :return RenameResult
-        :summary "Rename Data Item"
-        :description (str
-  "Moves the data item with the provided UUID to a new name within the same folder."
-  (get-error-code-block
-    "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_INCOMPLETE_RENAME, ERR_NOT_A_USER, ERR_TOO_MANY_PATHS"))
-        (svc/trap uri rename/do-rename-uuid params body data-id))
-
-      (PUT* "/dir" [:as {uri :uri}]
-        :query [params StandardUserQueryParams]
-        :body [body (describe Dirname "The new directory name of the data item.")]
-        :return RenameResult
-        :summary "Move Data Item"
-        :description (str
-  "Moves the data item with the provided UUID to a new folder, retaining its name."
-  (get-error-code-block
-    "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_INCOMPLETE_RENAME, ERR_NOT_A_USER, ERR_TOO_MANY_PATHS"))
-        (svc/trap uri rename/do-move-uuid params body data-id))
-
-      (PUT* "/children/dir" [:as {uri :uri}]
-        :query [params StandardUserQueryParams]
-        :body [body (describe Dirname "The new directory name of the data items.")]
-        :return MultiRenameResult
-        :summary "Move Data Item Contents"
-        :description (str
-  "Moves the contents of the folder with the provided UUID to a new folder, retaining their filenames."
-  (get-error-code-block
-    "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_INCOMPLETE_RENAME, ERR_NOT_A_USER, ERR_TOO_MANY_PATHS"))
-        (svc/trap uri rename/do-move-uuid-contents params body data-id))
 
       (GET* "/chunks" [:as {uri :uri}]
         :query [params ChunkParams]

--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -116,6 +116,7 @@ with characters in a runtime-configurable parameter. Currently, this parameter l
     "ERR_DOES_NOT_EXIST, ERR_NOT_A_FILE, ERR_NOT_READABLE, ERR_NOT_A_USER, ERR_INVALID_PAGE, ERR_PAGE_NOT_POS, ERR_CHUNK_TOO_SMALL"))
         (svc/trap uri page-tabular/do-read-csv-chunk params data-id))
 
+      ;; XXX: The logic coordinating this with the metadata service should be migrated up into terrain; it should just use POST /data
       (POST* "/metadata/save" [:as {uri :uri}]
         :query [params StandardUserQueryParams]
         :body [body (describe MetadataSaveRequest "The metadata save request.")]

--- a/services/data-info/src/data_info/routes/domain/avus.clj
+++ b/services/data-info/src/data_info/routes/domain/avus.clj
@@ -1,0 +1,34 @@
+(ns data-info.routes.domain.avus
+  (:use [common-swagger-api.schema :only [describe
+                                          NonBlankString
+                                          StandardUserQueryParams]]
+        [data-info.routes.domain.common])
+  (:require [schema.core :as s]))
+
+(s/defschema AVUMap
+  {:attr  (describe String "The attribute name")
+   :value (describe String "The value associated with this attribute")
+   :unit  (describe String "The unit associated with this value")})
+
+(s/defschema AVUDeleteParams
+  (merge StandardUserQueryParams
+    (dissoc AVUMap :unit)))
+
+(s/defschema AVUListing
+  {:irods-avus (describe [AVUMap] "A list of AVUs on this object.")})
+
+(s/defschema AVUGetResult
+  (assoc AVUListing
+   :path
+   (describe NonBlankString "The iRODS path of the file whose AVUs are being listed.")))
+
+(s/defschema AVUChangeResult
+  {:path
+   (describe NonBlankString "The iRODS path of the file whose AVUs changed.")
+   :user
+   (describe NonBlankString "The effective user who performed the request.")})
+
+(s/defschema AVUSetResult
+  (assoc AVUChangeResult
+         :type
+         (describe (s/enum :dir :file) "Whether this data object is a directory or file.")))

--- a/services/data-info/src/data_info/routes/domain/data.clj
+++ b/services/data-info/src/data_info/routes/domain/data.clj
@@ -23,39 +23,6 @@
       their files and subfolders) under the source folder will be included in the exported file,
       along with all of their metadata")})
 
-(s/defschema RenameResult
-  {:user
-   (describe NonBlankString "The user performing the request.")
-
-   :source
-   (describe NonBlankString "An iRODS path to the initial location of the data item being renamed.")
-
-   :dest
-   (describe NonBlankString "An iRODS path to the destination of the data item being renamed.")})
-
-(s/defschema MultiRenameRequest
-  {:sources
-   (describe [NonBlankString] "iRODS paths to the initial locations of the data items to rename.")
-
-   :dest
-   (describe NonBlankString "An iRODS path to the destination directory for the items being renamed.")})
-
-(s/defschema MultiRenameResult
-  {:user
-   (describe NonBlankString "The user performing the request.")
-
-   :sources
-   (describe [NonBlankString] "iRODS paths to the initial locations of the data items being renamed.")
-
-   :dest
-   (describe NonBlankString "An iRODS path to the destination directory of the data items being renamed.")})
-
-(s/defschema Filename
-  {:filename (describe NonBlankString "The name of the data item.")})
-
-(s/defschema Dirname
-  {:dirname (describe NonBlankString "The directory name of the data item.")})
-
 (def ValidSortFields
   #{:datecreated
     :datemodified

--- a/services/data-info/src/data_info/routes/domain/data.clj
+++ b/services/data-info/src/data_info/routes/domain/data.clj
@@ -13,34 +13,6 @@
   (assoc StandardUserQueryParams
          :dest (describe NonBlankString "The destination directory for the uploaded file.")))
 
-(s/defschema AVUMap
-  {:attr  (describe String "The attribute name")
-   :value (describe String "The value associated with this attribute")
-   :unit  (describe String "The unit associated with this value")})
-
-(s/defschema AVUDeleteParams
-  (merge StandardUserQueryParams
-    (dissoc AVUMap :unit)))
-
-(s/defschema AVUListing
-  {:irods-avus (describe [AVUMap] "A list of AVUs on this object.")})
-
-(s/defschema AVUGetResult
-  (assoc AVUListing
-   :path
-   (describe NonBlankString "The iRODS path of the file whose AVUs are being listed.")))
-
-(s/defschema AVUChangeResult
-  {:path
-   (describe NonBlankString "The iRODS path of the file whose AVUs changed.")
-   :user
-   (describe NonBlankString "The effective user who performed the request.")})
-
-(s/defschema AVUSetResult
-  (assoc AVUChangeResult
-         :type
-         (describe (s/enum :dir :file) "Whether this data object is a directory or file.")))
-
 (s/defschema MetadataSaveRequest
   {:dest
    (describe NonBlankString "An IRODS path to a destination file where the metadata will be saved")

--- a/services/data-info/src/data_info/routes/domain/rename.clj
+++ b/services/data-info/src/data_info/routes/domain/rename.clj
@@ -1,0 +1,37 @@
+(ns data-info.routes.domain.rename
+  (:use [common-swagger-api.schema :only [describe
+                                          NonBlankString]])
+  (:require [schema.core :as s]))
+
+(s/defschema MultiRenameRequest
+  {:sources
+   (describe [NonBlankString] "iRODS paths to the initial locations of the data items to rename.")
+
+   :dest
+   (describe NonBlankString "An iRODS path to the destination directory for the items being renamed.")})
+
+(s/defschema MultiRenameResult
+  {:user
+   (describe NonBlankString "The user performing the request.")
+
+   :sources
+   (describe [NonBlankString] "iRODS paths to the initial locations of the data items being renamed.")
+
+   :dest
+   (describe NonBlankString "An iRODS path to the destination directory of the data items being renamed.")})
+
+(s/defschema RenameResult
+  {:user
+   (describe NonBlankString "The user performing the request.")
+
+   :source
+   (describe NonBlankString "An iRODS path to the initial location of the data item being renamed.")
+
+   :dest
+   (describe NonBlankString "An iRODS path to the destination of the data item being renamed.")})
+
+(s/defschema Filename
+  {:filename (describe NonBlankString "The name of the data item.")})
+
+(s/defschema Dirname
+  {:dirname (describe NonBlankString "The directory name of the data item.")})

--- a/services/data-info/src/data_info/routes/rename.clj
+++ b/services/data-info/src/data_info/routes/rename.clj
@@ -1,0 +1,55 @@
+(ns data-info.routes.rename
+  (:use [common-swagger-api.schema]
+        [data-info.routes.domain.common]
+        [data-info.routes.domain.rename])
+  (:require [data-info.services.rename :as rename]
+            [data-info.util.service :as svc]))
+
+(defroutes* rename-routes
+  (POST* "/mover" [:as {uri :uri}]
+    :tags ["bulk"]
+    :query [params StandardUserQueryParams]
+    :body [body (describe MultiRenameRequest "The paths to rename and their destination.")]
+    :return MultiRenameResult
+    :summary "Move Data Items"
+    :description (str
+"Given a list of sources and a destination in the body, moves all the sources into the given destination directory."
+(get-error-code-block "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_TOO_MANY_PATHS, ERR_NOT_A_USER"))
+    (svc/trap uri rename/do-move params body))
+
+  (context* "/data/:data-id" []
+    :path-params [data-id :- DataIdPathParam]
+    :tags ["data-by-id"]
+
+    (PUT* "/name" [:as {uri :uri}]
+      :query [params StandardUserQueryParams]
+      :body [body (describe Filename "The new name of the data item.")]
+      :return RenameResult
+      :summary "Rename Data Item"
+      :description (str
+"Moves the data item with the provided UUID to a new name within the same folder."
+(get-error-code-block
+  "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_INCOMPLETE_RENAME, ERR_NOT_A_USER, ERR_TOO_MANY_PATHS"))
+      (svc/trap uri rename/do-rename-uuid params body data-id))
+
+    (PUT* "/dir" [:as {uri :uri}]
+      :query [params StandardUserQueryParams]
+      :body [body (describe Dirname "The new directory name of the data item.")]
+      :return RenameResult
+      :summary "Move Data Item"
+      :description (str
+"Moves the data item with the provided UUID to a new folder, retaining its name."
+(get-error-code-block
+  "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_INCOMPLETE_RENAME, ERR_NOT_A_USER, ERR_TOO_MANY_PATHS"))
+      (svc/trap uri rename/do-move-uuid params body data-id))
+
+    (PUT* "/children/dir" [:as {uri :uri}]
+      :query [params StandardUserQueryParams]
+      :body [body (describe Dirname "The new directory name of the data items.")]
+      :return MultiRenameResult
+      :summary "Move Data Item Contents"
+      :description (str
+"Moves the contents of the folder with the provided UUID to a new folder, retaining their filenames."
+(get-error-code-block
+  "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_INCOMPLETE_RENAME, ERR_NOT_A_USER, ERR_TOO_MANY_PATHS"))
+      (svc/trap uri rename/do-move-uuid-contents params body data-id))))


### PR DESCRIPTION
A lot of my early migration work I put lots of things into the `data-info.routes.data` namespace and the `data-info.routes.domain.data` namespace, but those files were getting really big. So this splits out the AVU operations and the move/rename operations into their own namespaces, which are much more reasonably sized.

It also adds a quick note about the metadata save endpoint (which remains in the data namespace), since it should be migrated partly back up into terrain in order to decouple the data-info and metadata services.