### PR TITLE
CORE-6086: make clj-jargon.item-ops/copy-stream ownership-setting behavior configurable

### DIFF
--- a/libs/clj-jargon/src/clj_jargon/item_ops.clj
+++ b/libs/clj-jargon/src/clj_jargon/item_ops.clj
@@ -142,7 +142,7 @@
     (.copy dto source res dest nil nil)))
 
 (defn copy-stream
-  [cm ^Closeable istream user dest-path]
+  [cm ^Closeable istream user dest-path & {:keys [set-owner?] :or {set-owner? true}}]
   (validate-path-lengths dest-path)
   (let [^Closeable ostream (output-stream cm dest-path)]
     (try
@@ -150,7 +150,8 @@
       (finally
         (.close istream)
         (.close ostream)
-        (set-owner cm dest-path user)))
+        (when set-owner?
+          (set-owner cm dest-path user))))
     (info/stat cm dest-path)))
 
 

--- a/services/data-info/src/data_info/services/write.clj
+++ b/services/data-info/src/data_info/services/write.clj
@@ -12,8 +12,8 @@
 
 (defn- save-file-contents
   "Save an istream to a destination. Relies on upstream functions to validate."
-  [cm istream user dest-path]
-  (ops/copy-stream cm istream user dest-path)
+  [cm istream user dest-path set-owner?]
+  (ops/copy-stream cm istream user dest-path :set-owner? set-owner?)
   dest-path)
 
 (defn- create-at-path
@@ -26,7 +26,7 @@
     (validators/path-not-exists cm dest-path)
     (validators/path-exists cm dest-dir)
     (validators/path-writeable cm user dest-dir)
-    (save-file-contents cm istream user dest-path)))
+    (save-file-contents cm istream user dest-path true)))
 
 (defn- overwrite-path
   "Save new contents for the file at dest-path from istream.
@@ -37,7 +37,7 @@
   (validators/path-exists cm dest-path)
   (validators/path-is-file cm dest-path)
   (validators/path-writeable cm user dest-path)
-  (save-file-contents cm istream user dest-path))
+  (save-file-contents cm istream user dest-path false))
 
 (defn- multipart-create-handler
   "When partially applied, creates a storage handler for


### PR DESCRIPTION
Ticket title: You can steal ownership of files in a write-shared folder.

This was the case because both creating and overwriting files use `clj-jargon.item-ops/copy-stream`, which unconditionally called `set-owner` for the user making the request (which is to say, it allowed stealing ownership of any writeable file). This changes it to take an extra argument which can optionally turn off this behavior, and then uses this argument in `data-info.services.write` to explicitly specify when ownership should be granted (a new file) and shouldn't (modifying an existing one).