### PR TITLE
CORE-7467 Store Permanent ID with completed Requests.

### DIFF
--- a/databases/metadata/src/main/conversions/c240_2016012701.clj
+++ b/databases/metadata/src/main/conversions/c240_2016012701.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c240-2016012701
+  (:use [korma.core]
+        [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version."
+  "2.4.0:20160127.01")
+
+(defn- add-permanent-id-column
+  []
+  (println "\t* Adding the permanent_id column to the permanent_id_requests table...")
+  (exec-sql-statement "ALTER TABLE permanent_id_requests ADD COLUMN permanent_id TEXT"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-permanent-id-column))

--- a/databases/metadata/src/main/data/99_version.sql
+++ b/databases/metadata/src/main/data/99_version.sql
@@ -9,3 +9,4 @@ INSERT INTO version (version) VALUES ('2.1.0:20150807.01');
 INSERT INTO version (version) VALUES ('2.1.0:20150810.01');
 INSERT INTO version (version) VALUES ('2.1.0:20150811.01');
 INSERT INTO version (version) VALUES ('2.4.0:20151210.01');
+INSERT INTO version (version) VALUES ('2.4.0:20160127.01');

--- a/databases/metadata/src/main/tables/permanent_id_requests.sql
+++ b/databases/metadata/src/main/tables/permanent_id_requests.sql
@@ -9,5 +9,6 @@ CREATE TABLE permanent_id_requests (
     type UUID,
     target_id UUID NOT NULL,
     target_type target_enum NOT NULL,
-    original_path TEXT
+    original_path TEXT,
+    permanent_id TEXT
 );

--- a/libs/kameleon/project.clj
+++ b/libs/kameleon/project.clj
@@ -14,4 +14,4 @@
                  [slingshot "0.12.2"]]
   :plugins [[lein-marginalia "0.7.1"]
             [test2junit "1.1.3"]]
-  :manifest {"db-version" "2.4.0:20160106.01"})
+  :manifest {"db-version" "2.4.0:20160127.01"})

--- a/services/iplant-email/conf/permanent_id_request_complete.st
+++ b/services/iplant-email/conf/permanent_id_request_complete.st
@@ -1,3 +1,5 @@
 The $request_type$ Permanent ID has been created for the
 $path$
 data set, which has been published in the $environment$ environment.
+See below for the identifiers created by the EZID API request:
+$identifiers$

--- a/services/metadata/src/metadata/routes/domain/permanent_id_requests.clj
+++ b/services/metadata/src/metadata/routes/domain/permanent_id_requests.clj
@@ -17,7 +17,8 @@
   {:type (describe PermanentIDRequestTypeEnum "The type of persistent ID requested")
    :target_id (describe UUID "The UUID of the data item for which the persistent ID is being requested")
    :target_type DataTypeParam
-   (s/optional-key :original_path) (describe String "The path associated with the given `target_id`")})
+   (s/optional-key :original_path) (describe String "The path associated with the given `target_id`")
+   (s/optional-key :permanent_id) (describe String "The identifier of a completed Permanent ID Request")})
 
 (s/defschema PermanentIDRequestBase
   (merge PermanentIDRequest
@@ -26,7 +27,8 @@
 
 (s/defschema PermanentIDRequestStatusUpdate
   {(s/optional-key :status) (describe String "The status code of the Permanent ID Request update")
-   (s/optional-key :comments) (describe String "The curator comments of the Permanent ID Request status update")})
+   (s/optional-key :comments) (describe String "The curator comments of the Permanent ID Request status update")
+   (s/optional-key :permanent_id) (describe String "The identifier of a completed Permanent ID Request")})
 
 (s/defschema PermanentIDRequestStatus
   (merge PermanentIDRequestStatusUpdate

--- a/services/metadata/src/metadata/routes/permanent_id_requests.clj
+++ b/services/metadata/src/metadata/routes/permanent_id_requests.clj
@@ -77,6 +77,9 @@
       :description
 "Allows administrators to update the status of a Permanent ID Request from any user.
 
+`Note`: If the `permanent_id` is provided in the request, then the Permanent ID Request must not already
+have a `permanent_id` set, otherwise an error is returned and the Status is not updated.
+
 `Note`: The status code is case-sensitive, and if it isn't defined in the database already then it will
  be added to the list of known status codes."
       (ok (update-permanent-id-request request-id user body)))))

--- a/services/terrain/src/terrain/util/email.clj
+++ b/services/terrain/src/terrain/util/email.clj
@@ -56,10 +56,11 @@
 
 (defn send-permanent-id-request-complete
   "Sends an email message informing data curators of a Permanent ID Request completion."
-  [request-type path]
+  [request-type path identifiers]
   (let [template-values {:environment  (config/environment-name)
                          :request_type request-type
-                         :path         path}]
+                         :path         path
+                         :identifiers  identifiers}]
     (send-permanent-id-request
       "Permanent ID Request Complete"
       "permanent_id_request_complete"


### PR DESCRIPTION
On successful completion, terrain now sends the new ID with the completion status, and the EZID API response is emailed to data curators with the completion notification.
Permanent ID Request details now include the original_path and a permanent_id for completed requests.