### PR TITLE
CORE-7474 Open BED, BOWTIE, and GTF files in Tabular View

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/MimeTypeViewerResolverFactory.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/MimeTypeViewerResolverFactory.java
@@ -3,8 +3,11 @@
  */
 package org.iplantc.de.fileViewers.client.presenter;
 
+import static org.iplantc.de.client.models.viewer.InfoType.BED;
+import static org.iplantc.de.client.models.viewer.InfoType.BOWTIE;
 import static org.iplantc.de.client.models.viewer.InfoType.CSV;
 import static org.iplantc.de.client.models.viewer.InfoType.GFF;
+import static org.iplantc.de.client.models.viewer.InfoType.GTF;
 import static org.iplantc.de.client.models.viewer.InfoType.HT_ANALYSIS_PATH_LIST;
 import static org.iplantc.de.client.models.viewer.InfoType.TSV;
 import static org.iplantc.de.client.models.viewer.InfoType.VCF;
@@ -148,7 +151,10 @@ public class MimeTypeViewerResolverFactory {
                 if(CSV.toString().equals(infoType)
                     || TSV.toString().equals(infoType)
                     || VCF.toString().equals(infoType)
-                    || GFF.toString().equals(infoType)){
+                    || GFF.toString().equals(infoType)
+                    || GTF.toString().equals(infoType)
+                    || BED.toString().equals(infoType)
+                    || BOWTIE.toString().equals(infoType)){
                     StructuredTextViewer structuredTextViewer = new StructuredTextViewer(file,
                                                                                          infoType,
                                                                                          editing,

--- a/ui/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/AbstractStructuredTextViewer.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/AbstractStructuredTextViewer.java
@@ -1,7 +1,10 @@
 package org.iplantc.de.fileViewers.client.views;
 
+import static org.iplantc.de.client.models.viewer.InfoType.BED;
+import static org.iplantc.de.client.models.viewer.InfoType.BOWTIE;
 import static org.iplantc.de.client.models.viewer.InfoType.CSV;
 import static org.iplantc.de.client.models.viewer.InfoType.GFF;
+import static org.iplantc.de.client.models.viewer.InfoType.GTF;
 import static org.iplantc.de.client.models.viewer.InfoType.HT_ANALYSIS_PATH_LIST;
 import static org.iplantc.de.client.models.viewer.InfoType.TSV;
 import static org.iplantc.de.client.models.viewer.InfoType.VCF;
@@ -137,7 +140,10 @@ public abstract class AbstractStructuredTextViewer extends AbstractFileViewer {
             return COMMA_DELIMITER;
         } else if (TSV.equals(fromTypeString)
                        || VCF.equals(fromTypeString)
-                       || GFF.equals(fromTypeString)) {
+                       || GFF.equals(fromTypeString)
+                       || BED.equals(fromTypeString)
+                       || GTF.equals(fromTypeString)
+                       || BOWTIE.equals(fromTypeString)) {
             return TAB_DELIMITER;
         } else {
             return SPACE_DELIMITER;


### PR DESCRIPTION
As the title says, this is just allowing the BED, BOWTIE, and GTF file formats to open in Tabular View since they're tab-delimited file types.