### PR TITLE
CORE-7473 Add metadata template AVUs from completed Permanent ID Request info.

### DIFF
--- a/ansible/roles/util-cfg-service/templates/terrain.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/terrain.properties.j2
@@ -133,9 +133,18 @@ terrain.saved-searches.host = http://{{ saved_searches.host }}:{{ saved_searches
 # Tree URLs Settings
 terrain.tree-urls.host = http://{{ tree_urls.host }}:{{ tree_urls.port }}
 
-terrain.permanent-id.curators-group     = {{ irods.data_curators_group }}
-terrain.permanent-id.staging-dir        = /iplant/home/shared/data_commons/staging
-terrain.permanent-id.publish-dir        = /iplant/home/shared/data_commons/curated
+# Permanent ID Request Settings
+terrain.permanent-id.curators-group = {{ irods.data_curators_group }}
+terrain.permanent-id.staging-dir    = /iplant/home/shared/data_commons/staging
+terrain.permanent-id.publish-dir    = /iplant/home/shared/data_commons/curated
+
+# Permanent ID Request Metadata Attribute Settings
+terrain.permanent-id.attr.identifier          = Identifier
+terrain.permanent-id.attr.alt-identifier      = AlternateIdentifier
+terrain.permanent-id.attr.alt-identifier-type = alternateIdentifierType
+terrain.permanent-id.attr.publication-year    = publicationYear
+
+# Permanent ID Request EZID API Settings
 terrain.permanent-id.ezid.base-url      = https://ezid.cdlib.org
 terrain.permanent-id.ezid.username      = {{ permanent_id.ezid.username }}
 terrain.permanent-id.ezid.password      = {{ permanent_id.ezid.password }}

--- a/ansible/roles/util-cfg-service/templates/terrain.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/terrain.properties.j2
@@ -134,9 +134,10 @@ terrain.saved-searches.host = http://{{ saved_searches.host }}:{{ saved_searches
 terrain.tree-urls.host = http://{{ tree_urls.host }}:{{ tree_urls.port }}
 
 # Permanent ID Request Settings
-terrain.permanent-id.curators-group = {{ irods.data_curators_group }}
-terrain.permanent-id.staging-dir    = /iplant/home/shared/data_commons/staging
-terrain.permanent-id.publish-dir    = /iplant/home/shared/data_commons/curated
+terrain.permanent-id.curators-group  = {{ irods.data_curators_group }}
+terrain.permanent-id.staging-dir     = /iplant/home/shared/data_commons/staging
+terrain.permanent-id.publish-dir     = /iplant/home/shared/data_commons/curated
+terrain.permanent-id.target-base-url = http://mirrors.iplantcollaborative.org/browse
 
 # Permanent ID Request Metadata Attribute Settings
 terrain.permanent-id.attr.identifier          = Identifier

--- a/services/terrain/src/terrain/util/config.clj
+++ b/services/terrain/src/terrain/util/config.clj
@@ -458,6 +458,26 @@
   [props config-valid configs]
   "terrain.permanent-id.publish-dir")
 
+(cc/defprop-str permanent-id-identifier-attr
+  "The metadata attribute where a new permanent ID is stored."
+  [props config-valid configs]
+  "terrain.permanent-id.attr.identifier")
+
+(cc/defprop-str permanent-id-alt-identifier-attr
+  "The metadata attribute where a new permanent ID is stored."
+  [props config-valid configs]
+  "terrain.permanent-id.attr.alt-identifier")
+
+(cc/defprop-str permanent-id-alt-identifier-type-attr
+  "The metadata attribute where a new permanent ID is stored."
+  [props config-valid configs]
+  "terrain.permanent-id.attr.alt-identifier-type")
+
+(cc/defprop-str permanent-id-date-attr
+  "The metadata attribute where a permanent ID request's publication year is set."
+  [props config-valid configs]
+  "terrain.permanent-id.attr.publication-year")
+
 (cc/defprop-str ezid-base-url
   "The EZID API base URL."
   [props config-valid configs]

--- a/services/terrain/src/terrain/util/config.clj
+++ b/services/terrain/src/terrain/util/config.clj
@@ -458,6 +458,11 @@
   [props config-valid configs]
   "terrain.permanent-id.publish-dir")
 
+(cc/defprop-str permanent-id-target-base-url
+  "The base URL where curated folders with a permanent ID are published."
+  [props config-valid configs]
+  "terrain.permanent-id.target-base-url")
+
 (cc/defprop-str permanent-id-identifier-attr
   "The metadata attribute where a new permanent ID is stored."
   [props config-valid configs]


### PR DESCRIPTION
Refactored the /permanent-id-requests/:request-id/ezid endpoint to save
the new identifiers as metadata template AVUs instead of iRODS AVUs.
Also saves the current year as the publicationYear attribute, which is
also submitted with the EZID API request metadata.