### PR TITLE
CORE-6215: migrate /secured/filesystem/anon-files

### DIFF
--- a/services/data-info/src/data_info/routes.clj
+++ b/services/data-info/src/data_info/routes.clj
@@ -14,6 +14,7 @@
             [data-info.routes.users :as users-routes]
             [data-info.routes.navigation :as navigation-routes]
             [data-info.routes.rename :as rename-routes]
+            [data-info.routes.sharing :as sharing-routes]
             [data-info.routes.status :as status-routes]
             [data-info.routes.stats :as stat-routes]
             [data-info.routes.trash :as trash-routes]
@@ -53,5 +54,6 @@
     users-routes/permissions-gatherer
     navigation-routes/navigation
     stat-routes/stat-gatherer
+    sharing-routes/sharing-routes
     trash-routes/trash
     (route/not-found (svc/unrecognized-path-response))))

--- a/services/data-info/src/data_info/routes/domain/sharing.clj
+++ b/services/data-info/src/data_info/routes/domain/sharing.clj
@@ -1,0 +1,25 @@
+(ns data-info.routes.domain.sharing
+  (:use [common-swagger-api.schema :only [describe
+                                          NonBlankString]])
+  (:require [schema.core :as s]))
+
+(s/defschema AnonFileUrls
+  {(describe s/Keyword "the iRODS data item's path")
+   (describe NonBlankString "the URL for the file to request in anon-files.")})
+
+(s/defschema AnonShareInfo
+  {:user
+   (describe NonBlankString "The user performing the request.")
+
+   :paths
+   (describe AnonFileUrls "The anon-files URLs for the paths provided with the request.")})
+
+;; Used only for display as documentation in Swagger UI
+(s/defschema AnonFilePathsMap
+  {:/path/from/request/to/a/file
+   (describe NonBlankString "the URL for the file to request in anon-files.")})
+
+;; Used only for display as documentation in Swagger UI
+(s/defschema AnonShareResponse
+  (assoc AnonShareInfo
+         :paths (describe AnonFilePathsMap "The anon-files URLs for the paths provided with the request.")))

--- a/services/data-info/src/data_info/routes/sharing.clj
+++ b/services/data-info/src/data_info/routes/sharing.clj
@@ -1,0 +1,19 @@
+(ns data-info.routes.sharing
+  (:use [common-swagger-api.schema]
+        [data-info.routes.domain.common]
+        [data-info.routes.domain.sharing])
+  (:require [data-info.services.sharing :as sharing]
+            [data-info.util.service :as svc]
+            [data-info.util.schema :as s]))
+
+(defroutes* sharing-routes
+  (POST* "/anonymizer" [:as {uri :uri}]
+    :tags ["bulk"]
+    :query [params StandardUserQueryParams]
+    :body [body (describe Paths "The paths to make readable by the anonymous user.")]
+    :return (s/doc-only AnonShareInfo AnonShareResponse)
+    :summary "Make Data Items Anonymously Readable"
+    :description (str
+"Given a list of files in the body, makes the files readable by the anonymous user."
+(get-error-code-block "ERR_NOT_A_FILE, ERR_DOES_NOT_EXIST, ERR_NOT_OWNER, ERR_TOO_MANY_PATHS, ERR_NOT_A_USER"))
+    (svc/trap uri sharing/do-anon-files params body)))

--- a/services/data-info/src/data_info/services/sharing.clj
+++ b/services/data-info/src/data_info/services/sharing.clj
@@ -1,0 +1,121 @@
+(ns data-info.services.sharing
+  (:use [clj-jargon.init :only [with-jargon]]
+        [clj-jargon.item-info :only [trash-base-dir is-dir?]]
+        [clj-jargon.permissions]
+        [slingshot.slingshot :only [try+ throw+]])
+  (:require [clojure.tools.logging :as log]
+            [clojure.string :as string]
+            [clojure-commons.file-utils :as ft]
+            [cemerick.url :as url]
+            [dire.core :refer [with-pre-hook! with-post-hook!]]
+            [data-info.util.logging :as dul]
+            [data-info.util.paths :as paths]
+            [data-info.util.config :as cfg]
+            [data-info.util.validators :as validators]))
+
+(defn- shared?
+  ([cm share-with fpath]
+     (:read (permissions cm share-with fpath)))
+  ([cm share-with fpath desired-perm]
+     (let [curr-perm (permission-for cm share-with fpath)]
+       (= curr-perm desired-perm))))
+
+(defn- skip-share
+  [user path reason]
+  (log/warn "Skipping share of" path "with" user "because:" reason)
+  {:user    user
+   :path    path
+   :reason  reason
+   :skipped true})
+
+(defn- share-path-home
+  "Returns the home directory that a shared file is under."
+  [share-path]
+  (string/join "/" (take 4 (string/split share-path #"\/"))))
+
+(defn- share-path
+  "Shares a path with a user. This consists of the following steps:
+
+       1. The parent directories up to the sharer's home directory need to be marked as readable
+          by the sharee. Othwerwise, any files that are shared will be orphaned in the UI.
+
+       2. If the shared item is a directory then the inherit bit needs to be set so that files
+          that are uploaded into the directory will also be shared.
+
+       3. The permissions are set on the item being shared. This is done recursively in case the
+          item being shared is a directory."
+  [cm user share-with perm fpath]
+  (let [hdir      (share-path-home fpath)
+        trash-dir (trash-base-dir (:zone cm) user)
+        base-dirs #{hdir trash-dir}]
+    (log/warn fpath "is being shared with" share-with "by" user)
+    (process-parent-dirs (partial set-readable cm share-with true) #(not (base-dirs %)) fpath)
+
+    (when (is-dir? cm fpath)
+      (log/warn fpath "is a directory, setting the inherit bit.")
+      (set-inherits cm fpath))
+
+    (when-not (is-readable? cm share-with hdir)
+      (log/warn share-with "is being given read permissions on" hdir "by" user)
+      (set-permission cm share-with hdir :read false))
+
+    (log/warn share-with "is being given recursive permissions (" perm ") on" fpath)
+    (set-permission cm share-with fpath (keyword perm) true)
+
+    {:user share-with :path fpath}))
+
+(defn- share-paths
+  [cm user share-withs fpaths perm]
+  (for [share-with share-withs
+        fpath      fpaths]
+    (cond (= user share-with)                (skip-share share-with fpath :share-with-self)
+          (paths/in-trash? user fpath)       (skip-share share-with fpath :share-from-trash)
+          (shared? cm share-with fpath perm) (skip-share share-with fpath :already-shared)
+          :else                              (share-path cm user share-with perm fpath))))
+
+(defn- share
+  [cm user share-withs fpaths perm]
+  (validators/user-exists cm user)
+  (validators/all-users-exist cm share-withs)
+  (validators/all-paths-exist cm fpaths)
+  (validators/user-owns-paths cm user fpaths)
+
+  (let [keyfn      #(if (:skipped %) :skipped :succeeded)
+        share-recs (group-by keyfn (share-paths cm user share-withs fpaths perm))
+        sharees    (map :user (:succeeded share-recs))
+        home-dir   (paths/user-home-dir user)]
+    {:user        sharees
+     :path        fpaths
+     :skipped     (map #(dissoc % :skipped) (:skipped share-recs))
+     :permission  perm}))
+
+(defn- anon-file-url
+  [p]
+  (let [aurl (url/url (cfg/anon-files-base))]
+    (str (-> aurl (assoc :path (ft/path-join (:path aurl) (string/replace p #"^\/" "")))))))
+
+(defn- anon-files-urls
+  [paths]
+  (into {} (map #(vector %1 (anon-file-url %1)) paths)))
+
+(defn- anon-files
+  [user paths]
+  (with-jargon (cfg/jargon-cfg) [cm]
+    (validators/user-exists cm user)
+    (validators/all-paths-exist cm paths)
+    (validators/paths-are-files cm paths)
+    (validators/user-owns-paths cm user paths)
+    (log/warn "Giving read access to" (cfg/anon-user) "on:" (string/join " " paths))
+    (share cm user [(cfg/anon-user)] paths :read)
+    {:user user :paths (anon-files-urls paths)}))
+
+(defn do-anon-files
+  [{:keys [user]} {:keys [paths]}]
+  (anon-files user (mapv ft/rm-last-slash paths)))
+
+(with-pre-hook! #'do-anon-files
+  (fn [params body]
+    (dul/log-call "do-anon-files" params body)
+    (validators/validate-num-paths (:paths body))))
+
+(with-post-hook! #'do-anon-files (dul/log-func "do-anon-files"))

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -228,6 +228,11 @@
     (let [path-uuid (uuid-for-path (:user params) (:path body))]
       (raw/set-file-type (:user params) path-uuid (:type body))))
 
+(defn share-with-anonymous
+    "Uses the data-info anonymizer endpoint to share paths with the anonymous user."
+    [params body]
+    (raw/share-with-anonymous (:user params) (:paths body)))
+
 (defn gen-output-dir
   "Either obtains or creates a default output directory using a specified base name."
   [base]

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -221,6 +221,14 @@
   (request :post ["data" path-uuid "metadata" "save"]
            (mk-req-map user (json/encode {:dest dest :recursive recursive}))))
 
+;; SHARING
+
+(defn share-with-anonymous
+  "Share a list of paths with the anonymous user."
+  [user paths]
+  (request :post ["anonymizer"]
+           (mk-req-map user (json/encode {:paths paths}))))
+
 ;; MISC
 
 (defn collect-permissions

--- a/services/terrain/src/terrain/routes/filesystem.clj
+++ b/services/terrain/src/terrain/routes/filesystem.clj
@@ -90,7 +90,7 @@
       (controller req data/read-tabular-chunk :params :body))
 
     (POST "/filesystem/anon-files" [:as req]
-      (controller req sharing/do-anon-files :params :body))))
+      (controller req data/share-with-anonymous :params :body))))
 
 (defn secured-filesystem-metadata-routes
   "The routes for file metadata endpoints."

--- a/services/terrain/src/terrain/services/filesystem/sharing.clj
+++ b/services/terrain/src/terrain/services/filesystem/sharing.clj
@@ -172,30 +172,3 @@
   [p]
   (let [aurl (url/url (cfg/anon-files-base))]
     (str (-> aurl (assoc :path (ft/path-join (:path aurl) (string/replace p #"^\/" "")))))))
-
-(defn anon-files-urls
-  [paths]
-  (into {} (map #(vector %1 (anon-file-url %1)) paths)))
-
-(defn anon-files
-  [user paths]
-  (with-jargon (icat/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (validators/all-paths-exist cm paths)
-    (validators/paths-are-files cm paths)
-    (validators/user-owns-paths cm user paths)
-    (log/warn "Giving read access to" (cfg/fs-anon-user) "on:" (string/join " " paths))
-    (share user [(cfg/fs-anon-user)] paths :read)
-    {:user user :paths (anon-files-urls paths)}))
-
-(defn fix-broken-paths
-  [paths]
-  (mapv #(string/replace % #"\/$" "") paths))
-
-(defn do-anon-files
-  [params body]
-  (paths/log-call "do-anon-files" params body)
-  (validate-map params {:user string?})
-  (validate-map body {:paths sequential?})
-  (validators/validate-num-paths (:paths body))
-  (anon-files (:user params) (fix-broken-paths (:paths body))))


### PR DESCRIPTION
The first commit removes an AVU-based hack that we used to use for revoking permissions on unsharing, but don't any more. Since the code was also written to circumvent a jargon bug at the time, it also used the units field as the attribute field, so it added very unuseful AVUs, and only to user home directories, which usually the AVUs can't even be seen on.

This also migrates the start of some sharing stuff, but that will probably be refactored as I migrate the actual sharing endpoints, since I'd like to make those more file-centric. Currently the function is written to take only one permission, a list of users, and a list of files, and it assigns each user that permission on each file. With a future PR, I'll most likely change this to expect a single file (per invocation) and a list of user-permission pairs.