### PR TITLE
CORE-5291: After delete, return path in trash

### DIFF
--- a/services/data-info/src/data_info/routes/domain/trash.clj
+++ b/services/data-info/src/data_info/routes/domain/trash.clj
@@ -27,3 +27,21 @@
 (s/defschema RestorationPaths
   {:restored
    (describe RestorationPathsMap "A map of paths from the request to their restoration info")})
+
+(s/defschema TrashPathsMap
+  {(describe s/Keyword "The iRODS data item's original path.")
+   (describe String "The data item's path in the trash")})
+
+(s/defschema TrashPaths
+  (assoc Paths
+         :trash-paths (describe TrashPathsMap "A map of paths from the request to their location in the trash, if any.")))
+
+;; Used only for documentation in Swagger UI
+(s/defschema TrashPathsDocMap
+  {:/path/from/request/to/a/file/or/folder
+   (describe String "The data item's path in the trash")})
+
+;; Used only for documentation in Swagger UI
+(s/defschema TrashPathsDoc
+  (assoc TrashPaths
+         :trash-paths (describe TrashPathsDocMap "A map of paths from the request to their location in the trash, if any.")))

--- a/services/data-info/src/data_info/routes/trash.clj
+++ b/services/data-info/src/data_info/routes/trash.clj
@@ -20,7 +20,7 @@
       :tags ["bulk"]
       :query [params StandardUserQueryParams]
       :body [body (describe Paths "The paths to move to the trash")]
-      :return Paths
+      :return (s/doc-only TrashPaths TrashPathsDoc)
       :summary "Delete Data Items"
       :description (str
   "Delete the data items with the listed paths."
@@ -46,7 +46,7 @@
 
       (DELETE* "/" [:as {uri :uri}]
         :query [params StandardUserQueryParams]
-        :return Paths
+        :return TrashPaths
         :summary "Delete Data Item"
         :description (str
   "Deletes the data item with the provided UUID."
@@ -56,7 +56,7 @@
 
       (DELETE* "/children" [:as {uri :uri}]
         :query [params StandardUserQueryParams]
-        :return Paths
+        :return TrashPaths
         :summary "Delete Data Item Contents"
         :description (str
   "Deletes the contents of the folder with the provided UUID."

--- a/services/data-info/src/data_info/services/trash.clj
+++ b/services/data-info/src/data_info/services/trash.clj
@@ -72,8 +72,7 @@
         ;;; otherwise, do a hard delete.
         (if-not (.startsWith p (paths/user-trash-path user))
           (do (let [trash-path (move-to-trash cm p user)]
-              (reset! trash-paths
-                      (assoc @trash-paths p trash-path))))
+              (swap! trash-paths assoc p trash-path)))
           (delete cm p true))) ;;; Force a delete to bypass proxy user's trash.
 
        {:paths paths
@@ -206,9 +205,8 @@
                 (move cm path fully-restored :user user :admin-users (cfg/irods-admins))
                 (log/warn "Done moving " path " to " fully-restored)
 
-                (reset! retval
-                        (assoc @retval path {:restored-path fully-restored
-                                             :partial-restore restored-to-homedir}))))
+                (swap! retval assoc path {:restored-path fully-restored
+                                          :partial-restore restored-to-homedir})))
             {:restored @retval}))
         {:restored {}}))))
 


### PR DESCRIPTION
This modifies only the data-info endpoints, but since terrain serves as a pure
passthrough for these endpoints, it will also be reflected in the terrain
endpoints.

One thing I'd like someone familiar with the UI to confirm or deny for me is if this will cause problems for the UI. This result (for all affected endpoints) is parsed with `decode(HasPaths.class, json)`, but I don't know if this will ignore unrecognized keys (in this case, the `"trash-paths"` key) or error. Obviously, I'm hoping the former!