### PR TITLE
Removed more elk references

### DIFF
--- a/ansible/inventories/example.cfg
+++ b/ansible/inventories/example.cfg
@@ -7,7 +7,6 @@
 condor
 condor-submission
 db-proxy
-elk
 grouper
 services
 ui
@@ -21,7 +20,6 @@ ui
 condor
 condor-submission
 docker-registry
-elk
 grouper
 services
 ui
@@ -130,13 +128,6 @@ services.example.com
 ###############################################################################
 [ui]
 ui.example.com
-
-###############################################################################
-# elk:
-#    The host group for the Discovery Environment ELK stack.
-###############################################################################
-[elk]
-elk.example.com
 
 ###############################################################################
 # condor:

--- a/ansible/roles/util-cfg-service/templates/docker-cleanup/docker-gc-exclude-containers.j2
+++ b/ansible/roles/util-cfg-service/templates/docker-cleanup/docker-gc-exclude-containers.j2
@@ -1,5 +1,4 @@
 {{data_container.container_name}}
-{{elk.data.container_name}}
 wc-data
 ncbi-sra-configs
 ncbi-sra-test-configs
@@ -12,9 +11,6 @@ config-data-info
 config-de-ui
 config-de-ui-nginx
 config-dewey
-config-elk-elasticsearch
-config-elk-kibana
-config-elk-logstash
 config-info-typer
 config-infosquito
 config-iplant-email


### PR DESCRIPTION
These should be the last of the elk references. It should also correct the `docker-gc.properties` build error.