### PR TITLE
Switch the base of jex-events' docker image to use jeanblanchard/alpine-glibc

### DIFF
--- a/services/jex-events/Dockerfile
+++ b/services/jex-events/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM jeanblanchard/alpine-glibc
 
 ADD bin/jex-events /bin/
 


### PR DESCRIPTION
This reduces the size of the image substantially, and means it's sharing more layers with our other services as well (alpine-glibc is the base image for the java base image we're using). Go's builds do rely on glibc (like java does), but we don't need the rest of ubuntu to run our stuff.

From what I can determine, this is removing four layers, all used only by this (187.7 MB, 194.5 kB, 1.895 kB, 0B) and replacing them with three (5.244MB + shared with all our other services, 0B + shared with all our other services, 6.738 MB + possibly shared but I'm not sure).

I've run this with `--version` to ensure it starts; this should be sufficient since the potential errors are mostly in it finding the libc stuff it needs.

`docker history` outputs:

```
✔ ~/Source/DE [shrink-jexevents L|✔] 
12:33 $ docker history jex-events-alpine-glibc
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
c42bfe7a1f74        3 minutes ago       /bin/sh -c #(nop) CMD ["--help"]                0 B                 
c2c7e8b8ffdb        3 minutes ago       /bin/sh -c #(nop) ENTRYPOINT &{["jex-events"]   0 B                 
9446b6b0f2c5        3 minutes ago       /bin/sh -c #(nop) EXPOSE 60000/tcp              0 B                 
e24b79f9ec2a        3 minutes ago       /bin/sh -c #(nop) LABEL org.iplantc.de.jex-ev   0 B                 
30e258b043bd        3 minutes ago       /bin/sh -c #(nop) ARG version=unknown           0 B                 
efe76ab423d1        3 minutes ago       /bin/sh -c #(nop) ARG buildenv_git_commit=unk   0 B                 
80edc1a4bf16        3 minutes ago       /bin/sh -c #(nop) ARG git_commit=unknown        0 B                 
ad38a10f4970        3 minutes ago       /bin/sh -c #(nop) ADD file:4535fe808e05e87814   9.249 MB            
ebc3c51a6773        3 months ago        /bin/sh -c apk add --update curl &&   curl -o   6.738 MB            
ec43ec17504a        3 months ago        /bin/sh -c #(nop) MAINTAINER Jean Blanchard <   0 B                 
558af09712a4        4 months ago        /bin/sh -c #(nop) ADD file:43a95cc218d164ff58   5.244 MB            
✔ ~/Source/DE [shrink-jexevents|✔] 
12:38 $ docker history discoenv/jex-events:dev
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
f849885d6503        19 hours ago        /bin/sh -c #(nop) CMD ["--help"]                0 B                 
<missing>           19 hours ago        /bin/sh -c #(nop) ENTRYPOINT &{["jex-events"]   0 B                 
<missing>           19 hours ago        /bin/sh -c #(nop) EXPOSE 60000/tcp              0 B                 
<missing>           19 hours ago        /bin/sh -c #(nop) LABEL org.iplantc.de.jex-ev   0 B                 
<missing>           19 hours ago        /bin/sh -c #(nop) ARG version=unknown           0 B                 
<missing>           19 hours ago        /bin/sh -c #(nop) ARG buildenv_git_commit=unk   0 B                 
<missing>           19 hours ago        /bin/sh -c #(nop) ARG git_commit=unknown        0 B                 
<missing>           19 hours ago        /bin/sh -c #(nop) ADD file:6b74bb1d5b17311ab0   9.25 MB             
<missing>           2 weeks ago         /bin/sh -c #(nop) CMD ["/bin/bash"]             0 B                 
<missing>           2 weeks ago         /bin/sh -c sed -i 's/^#\s*\(deb.*universe\)$/   1.895 kB            
<missing>           2 weeks ago         /bin/sh -c echo '#!/bin/sh' > /usr/sbin/polic   194.5 kB            
<missing>           2 weeks ago         /bin/sh -c #(nop) ADD file:7ce20ce3daa6af21db   187.7 MB            

```