### PR TITLE
CORE-7386: remove support for the `public` query parmeter from GET /a…

### DIFF
--- a/services/apps/src/apps/routes/admin.clj
+++ b/services/apps/src/apps/routes/admin.clj
@@ -108,7 +108,7 @@
 
 (defroutes* admin-categories
   (GET* "/" []
-        :query [params CategoryListingParams]
+        :query [params SecuredQueryParams]
         :return AppCategoryListing
         :summary "List App Categories"
         :description "This service is used by DE admins to obtain a list of public app categories along

--- a/services/apps/src/apps/service/apps/de/listings.clj
+++ b/services/apps/src/apps/service/apps/de/listings.clj
@@ -154,7 +154,7 @@
   "Retrieves the list of app groups that are accessible to administrators. This includes all public
    app groups along with the trash group."
   [user params]
-  (let [params (assoc params :admin true)]
+  (let [params (assoc params :admin true :public true)]
     (conj (vec (get-app-groups user params))
           (format-trash-category nil nil params))))
 


### PR DESCRIPTION
…dmin/apps/categories

For this issue, I decided to have terrain continue to ignore the `public` query parameter. We can make the endpoint definitions more formal when we migrate terrain to compojure-api. See the Jira issue for more details.
