### PR TITLE
CORE-7511 Add more user info to PermID Request details.

### DIFF
--- a/services/terrain/src/terrain/routes/permanent_id_requests.clj
+++ b/services/terrain/src/terrain/routes/permanent_id_requests.clj
@@ -14,17 +14,17 @@
     (GET "/permanent-id-requests" [:as {params :params}]
       (service/success-response (list-permanent-id-requests params)))
 
-    (POST "/permanent-id-requests" [:as {:keys [params body]}]
-      (service/success-response (create-permanent-id-request params body)))
+    (POST "/permanent-id-requests" [:as {:keys [body]}]
+      (service/success-response (create-permanent-id-request body)))
 
-    (GET "/permanent-id-requests/status-codes" [:as {params :params}]
-      (service/success-response (list-permanent-id-request-status-codes params)))
+    (GET "/permanent-id-requests/status-codes" []
+      (service/success-response (list-permanent-id-request-status-codes)))
 
-    (GET "/permanent-id-requests/types" [:as {params :params}]
-      (service/success-response (list-permanent-id-request-types params)))
+    (GET "/permanent-id-requests/types" []
+      (service/success-response (list-permanent-id-request-types)))
 
-    (GET "/permanent-id-requests/:request-id" [request-id :as {params :params}]
-      (service/success-response (get-permanent-id-request request-id params)))))
+    (GET "/permanent-id-requests/:request-id" [request-id]
+      (service/success-response (get-permanent-id-request request-id)))))
 
 (defn admin-permanent-id-request-routes
   "The admin routes for Permanent ID Request endpoints."
@@ -36,11 +36,11 @@
     (GET "/permanent-id-requests" [:as {params :params}]
       (service/success-response (admin-list-permanent-id-requests params)))
 
-    (GET "/permanent-id-requests/:request-id" [request-id :as {params :params}]
-      (service/success-response (admin-get-permanent-id-request request-id params)))
+    (GET "/permanent-id-requests/:request-id" [request-id]
+      (service/success-response (admin-get-permanent-id-request request-id)))
 
-    (POST "/permanent-id-requests/:request-id/ezid" [request-id :as {:keys [params body]}]
-      (service/success-response (create-permanent-id request-id params body)))
+    (POST "/permanent-id-requests/:request-id/ezid" [request-id :as {:keys [body]}]
+      (service/success-response (create-permanent-id request-id body)))
 
-    (POST "/permanent-id-requests/:request-id/status" [request-id :as {:keys [params body]}]
-      (service/success-response (update-permanent-id-request request-id params body)))))
+    (POST "/permanent-id-requests/:request-id/status" [request-id :as {:keys [body]}]
+      (service/success-response (update-permanent-id-request request-id body)))))


### PR DESCRIPTION
Updated the responses of Permanent ID Request endpoints that return a request's details to include more user info in the 'requested_by' field, such as email and first/last name.
Since the requesting user's email is now available when notifications are sent to that user, notification emails can now be enabled.
Added the new ID to the "Completion" notification update in the "comments" field, which is now included as the body of the "Completion" notification email.