### PR TITLE
CORE-4345 & CORE-4832

### DIFF
--- a/services/NotificationAgent/src/notification_agent/delete.clj
+++ b/services/NotificationAgent/src/notification_agent/delete.clj
@@ -2,7 +2,8 @@
   (:use [notification-agent.common]
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.tools.logging :as log]
-            [notification-agent.db :as db]))
+            [notification-agent.db :as db]
+            [notification-agent.query :as query]))
 
 (defn delete-messages
   "Handles a message deletion request.  The request body should consist of
@@ -23,9 +24,10 @@
   "Handles a request to delete all messages for a specific user that match"
   [params]
   (log/debug "handling a notification delete-all request")
-  (let [user (validate-user (:user params))]
+  (let [user (validate-user (:user params))
+        query {:filter  (query/get-filter params)}]
     (log/debug "deleting notifications for" user)
-    (db/delete-matching-notifications user params)
+    (db/delete-matching-notifications user query)
     {:count (str (db/count-matching-messages user {:seen false}))}))
 
 (defn delete-system-messages

--- a/services/NotificationAgent/src/notification_agent/query.clj
+++ b/services/NotificationAgent/src/notification_agent/query.clj
@@ -83,7 +83,7 @@
         filt (mangle-filter (:filter query-params))]
     (if (= filt "new") false seen)))
 
-(defn- get-filter
+(defn get-filter
   "Gets the filter from the query parameters."
   [query-params]
   (let [filt (mangle-filter (:filter query-params))]

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/MessageServiceFacade.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/MessageServiceFacade.java
@@ -3,6 +3,7 @@ package org.iplantc.de.client.services;
 import org.iplantc.de.client.models.HasId;
 import org.iplantc.de.client.models.notifications.Counts;
 import org.iplantc.de.client.models.notifications.Notification;
+import org.iplantc.de.client.models.notifications.NotificationCategory;
 import org.iplantc.de.client.services.callbacks.NotificationCallback;
 
 import com.google.gwt.json.client.JSONObject;
@@ -53,7 +54,7 @@ public interface MessageServiceFacade {
      */
     void getMessageCounts(AsyncCallback<Counts> callback);
 
-    void deleteAll(String filter, AsyncCallback<String> callback);
+    void deleteAll(NotificationCategory category, AsyncCallback<String> callback);
 
     void markAllNotificationsSeen(AsyncCallback<Void> callback);
     

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/MessageServiceFacade.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/MessageServiceFacade.java
@@ -53,7 +53,7 @@ public interface MessageServiceFacade {
      */
     void getMessageCounts(AsyncCallback<Counts> callback);
 
-    void deleteAll(AsyncCallback<String> callback);
+    void deleteAll(String filter, AsyncCallback<String> callback);
 
     void markAllNotificationsSeen(AsyncCallback<Void> callback);
     

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/MessageServiceFacadeImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/MessageServiceFacadeImpl.java
@@ -142,11 +142,11 @@ public class MessageServiceFacadeImpl implements MessageServiceFacade {
     }
 
     @Override
-    public void deleteAll(String filter, AsyncCallback<String> callback) {
+    public void deleteAll(NotificationCategory category, AsyncCallback<String> callback) {
         String address = deProperties.getMuleServiceBaseUrl() + "notifications/delete-all"; //$NON-NLS-1$
 
-        if (!filter.toLowerCase().equals(NotificationCategory.ALL.toString().toLowerCase())){
-            address += "?filter=" + URL.encodeQueryString(filter.toLowerCase());
+        if (!category.equals(NotificationCategory.ALL)) {
+            address += "?filter=" + URL.encodeQueryString(category.name().toLowerCase());
         }
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(DELETE, address);

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/MessageServiceFacadeImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/MessageServiceFacadeImpl.java
@@ -145,7 +145,7 @@ public class MessageServiceFacadeImpl implements MessageServiceFacade {
     public void deleteAll(NotificationCategory category, AsyncCallback<String> callback) {
         String address = deProperties.getMuleServiceBaseUrl() + "notifications/delete-all"; //$NON-NLS-1$
 
-        if (!category.equals(NotificationCategory.ALL)) {
+        if (NotificationCategory.ALL != category) {
             address += "?filter=" + URL.encodeQueryString(category.name().toLowerCase());
         }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/MessageServiceFacadeImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/MessageServiceFacadeImpl.java
@@ -8,6 +8,7 @@ import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.notifications.Counts;
 import org.iplantc.de.client.models.notifications.Notification;
 import org.iplantc.de.client.models.notifications.NotificationAutoBeanFactory;
+import org.iplantc.de.client.models.notifications.NotificationCategory;
 import org.iplantc.de.client.services.MessageServiceFacade;
 import org.iplantc.de.client.services.PermIdRequestUserServiceFacade;
 import org.iplantc.de.client.services.callbacks.NotificationCallback;
@@ -141,8 +142,12 @@ public class MessageServiceFacadeImpl implements MessageServiceFacade {
     }
 
     @Override
-    public void deleteAll(AsyncCallback<String> callback) {
+    public void deleteAll(String filter, AsyncCallback<String> callback) {
         String address = deProperties.getMuleServiceBaseUrl() + "notifications/delete-all"; //$NON-NLS-1$
+
+        if (!filter.toLowerCase().equals(NotificationCategory.ALL.toString().toLowerCase())){
+            address += "?filter=" + URL.encodeQueryString(filter.toLowerCase());
+        }
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(DELETE, address);
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -248,4 +248,6 @@ public interface DesktopView extends IsWidget {
     void setUnseenNotificationCount(int count);
 
     void setUnseenSystemMessageCount(int count);
+
+    void hideNotificationMenu();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -214,12 +214,14 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
 
     @Override
     public void doSeeAllNotifications() {
-         show(ConfigFactory.notifyWindowConfig(NotificationCategory.ALL));
+        show(ConfigFactory.notifyWindowConfig(NotificationCategory.ALL));
+        view.hideNotificationMenu();
     }
 
     @Override
     public void doSeeNewNotifications() {
         show(ConfigFactory.notifyWindowConfig(NotificationCategory.NEW));
+        view.hideNotificationMenu();
     }
 
     public void doViewGenomes(final File file) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
@@ -105,6 +105,10 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
         }
     }
 
+    public void hideNotificationMenu() {
+        ((DesktopIconButton)notificationsBtn).hideMenu();
+    }
+
     @Override
     public void onRegister(RegisterEvent<Widget> event) {
         final Widget eventItem = event.getItem();

--- a/ui/de-lib/src/main/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImpl.java
@@ -115,12 +115,12 @@ public class NotificationPresenterImpl implements NotificationView.Presenter, No
 
     private final IplantErrorStrings errorStrings;
 
-    private final EventBus eventBus;
-    private final MessageServiceFacade messageServiceFacade;
-    private final NotificationToolbarView toolbar;
+    EventBus eventBus;
+    MessageServiceFacade messageServiceFacade;
+    NotificationToolbarView toolbar;
     private final NotificationView view;
     private PagingLoadResult<NotificationMessage> callbackResult;
-    private NotificationCategory currentCategory;
+    NotificationCategory currentCategory;
     private final JsonUtil jsonUtil;
 
     public NotificationPresenterImpl(final NotificationView view) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImpl.java
@@ -202,7 +202,7 @@ public class NotificationPresenterImpl implements NotificationView.Presenter, No
     @Override
     public void onDeleteAllClicked() {
         view.mask();
-        messageServiceFacade.deleteAll(currentCategory.toString(), new AsyncCallback<String>() {
+        messageServiceFacade.deleteAll(currentCategory, new AsyncCallback<String>() {
 
             @Override
             public void onFailure(Throwable caught) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImpl.java
@@ -202,7 +202,7 @@ public class NotificationPresenterImpl implements NotificationView.Presenter, No
     @Override
     public void onDeleteAllClicked() {
         view.mask();
-        messageServiceFacade.deleteAll(new AsyncCallback<String>() {
+        messageServiceFacade.deleteAll(currentCategory.toString(), new AsyncCallback<String>() {
 
             @Override
             public void onFailure(Throwable caught) {

--- a/ui/de-lib/src/test/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImplTest.java
@@ -5,10 +5,12 @@ import org.iplantc.de.desktop.client.presenter.util.MessagePoller;
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.commons.client.requests.KeepaliveTimer;
+import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
 import org.iplantc.de.systemMessages.client.view.NewMessageView;
 
 import com.google.gwt.dom.client.Element;
 import com.google.gwtmockito.GxtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
 
 import com.sencha.gxt.widget.core.client.WindowManager;
 
@@ -22,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
 @RunWith(GxtMockitoTestRunner.class)
+@WithClassesToStub(ConfigFactory.class)
 public class DesktopPresenterImplTest {
 
     @Mock DesktopWindowManager desktopWindowManagerMock;
@@ -82,6 +85,16 @@ public class DesktopPresenterImplTest {
         uut.onSystemMessagesClick();
         verify(desktopWindowManagerMock).show(WindowType.SYSTEM_MESSAGES);
         verifyNoMoreInteractions(desktopWindowManagerMock);
+    }
+
+    @Test public void testDoSeeAllNotifications() {
+        uut.doSeeAllNotifications();
+        verify(viewMock).hideNotificationMenu();
+    }
+
+    @Test public void testDoSeeNewNotifications() {
+        uut.doSeeNewNotifications();
+        verify(viewMock).hideNotificationMenu();
     }
 
 }

--- a/ui/de-lib/src/test/java/org/iplantc/de/desktop/client/views/DesktopNotifications_DesktopViewTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/desktop/client/views/DesktopNotifications_DesktopViewTest.java
@@ -57,7 +57,6 @@ public class DesktopNotifications_DesktopViewTest {
 
     @Test public void notificationsNotMarkedSeenWhenNotificationBtnSelectedWithGreaterThan10Unseen() {
 
-        uut.setPresenter(mockPresenter);
         uut.unseenNotificationCount = 11;
 
         uut.onNotificationMenuClicked(mock(ShowContextMenuEvent.class));

--- a/ui/de-lib/src/test/java/org/iplantc/de/desktop/client/views/DesktopNotifications_DesktopViewTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/desktop/client/views/DesktopNotifications_DesktopViewTest.java
@@ -1,35 +1,53 @@
 package org.iplantc.de.desktop.client.views;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import org.iplantc.de.desktop.client.DesktopView;
+import org.iplantc.de.desktop.client.views.widgets.DesktopIconButton;
 import org.iplantc.de.resources.client.messages.IplantNewUserTourStrings;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GxtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
 
 import com.sencha.gxt.widget.core.client.WindowManager;
 import com.sencha.gxt.widget.core.client.event.RegisterEvent;
 import com.sencha.gxt.widget.core.client.event.ShowContextMenuEvent;
 import com.sencha.gxt.widget.core.client.event.UnregisterEvent;
 
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
 @RunWith(GxtMockitoTestRunner.class)
+@WithClassesToStub(DesktopIconButton.class)
 public class DesktopNotifications_DesktopViewTest {
 
     @Mock RegisterEvent<Widget> registerEventMock;
     @Mock IplantNewUserTourStrings tourStringsMock;
     @Mock UnregisterEvent<Widget> unregisterEventMock;
     @Mock WindowManager windowManagerMock;
+    @Mock DesktopView.Presenter mockPresenter;
+    @Mock DesktopIconButton notificationsBtnMock;
+
+    private DesktopViewImpl uut;
+
+    @Before
+    public void setUp() {
+        uut = new DesktopViewImpl(tourStringsMock, windowManagerMock);
+        uut.notificationsBtn = notificationsBtnMock;
+        verifyViewInit(uut);
+        uut.setPresenter(mockPresenter);
+    }
 
     @Test public void notificationsMarkedSeenWhenNotificationBtnSelectedWithLessThan10Unseen() {
-        DesktopViewImpl uut = new DesktopViewImpl(tourStringsMock, windowManagerMock);
-        verifyViewInit(uut);
-        final DesktopView.Presenter mockPresenter = mock(DesktopView.Presenter.class);
-        uut.setPresenter(mockPresenter);
+
         uut.unseenNotificationCount = 9;
 
         uut.onNotificationMenuClicked(mock(ShowContextMenuEvent.class));
@@ -38,15 +56,19 @@ public class DesktopNotifications_DesktopViewTest {
     }
 
     @Test public void notificationsNotMarkedSeenWhenNotificationBtnSelectedWithGreaterThan10Unseen() {
-        DesktopViewImpl uut = new DesktopViewImpl(tourStringsMock, windowManagerMock);
-        verifyViewInit(uut);
-        final DesktopView.Presenter mockPresenter = mock(DesktopView.Presenter.class);
+
         uut.setPresenter(mockPresenter);
         uut.unseenNotificationCount = 11;
 
         uut.onNotificationMenuClicked(mock(ShowContextMenuEvent.class));
         verify(mockPresenter, never()).doMarkAllSeen(anyBoolean());
         verifyNoMoreInteractions(mockPresenter);
+    }
+
+    @Test public void notificationMenuHidesOnSeeAllNotifications() {
+        uut.hideNotificationMenu();
+        verify(notificationsBtnMock).hideMenu();
+        verifyNoMoreInteractions(notificationsBtnMock, mockPresenter);
     }
 
     private void verifyViewInit(DesktopViewImpl uut) {

--- a/ui/de-lib/src/test/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImplTest.java
@@ -105,7 +105,7 @@ public class NotificationPresenterImplTest {
         uut.onDeleteAllClicked();
 
         verify(viewMock).mask();
-        verify(messageServiceFacadeMock).deleteAll(eq(currentCategoryMock.toString()), asyncCallbackStringCaptor.capture());
+        verify(messageServiceFacadeMock).deleteAll(eq(currentCategoryMock), asyncCallbackStringCaptor.capture());
         AsyncCallback<String> asyncCallback = asyncCallbackStringCaptor.getValue();
 
         asyncCallback.onSuccess("result");

--- a/ui/de-lib/src/test/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/notifications/client/presenter/NotificationPresenterImplTest.java
@@ -1,0 +1,135 @@
+package org.iplantc.de.notifications.client.presenter;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.client.events.EventBus;
+import org.iplantc.de.client.models.notifications.NotificationCategory;
+import org.iplantc.de.client.models.notifications.NotificationMessage;
+import org.iplantc.de.client.services.MessageServiceFacade;
+import org.iplantc.de.notifications.client.events.DeleteNotificationsUpdateEvent;
+import org.iplantc.de.notifications.client.views.NotificationToolbarView;
+import org.iplantc.de.notifications.client.views.NotificationView;
+
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwtmockito.GxtMockitoTestRunner;
+
+import com.sencha.gxt.data.shared.ListStore;
+import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+@RunWith(GxtMockitoTestRunner.class)
+public class NotificationPresenterImplTest {
+
+    @Mock NotificationView viewMock;
+    @Mock MessageServiceFacade messageServiceFacadeMock;
+    @Mock NotificationToolbarView toolbarViewMock;
+    @Mock EventBus eventBusMock;
+    @Mock NotificationCategory currentCategoryMock;
+    @Mock ListStore<NotificationMessage> listStoreMock;
+    @Mock List<NotificationMessage> listMock;
+    @Mock NotificationMessage notificationMessageMock;
+    @Mock Iterator<NotificationMessage> iteratorMock;
+
+    @Captor ArgumentCaptor<AsyncCallback<String>> asyncCallbackStringCaptor;
+
+    private NotificationPresenterImpl uut;
+
+    @Before
+    public void setUp() {
+        when(currentCategoryMock.toString()).thenReturn("sample");
+        when(viewMock.getCurrentLoadConfig()).thenReturn(mock(FilterPagingLoadConfig.class));
+        when(notificationMessageMock.getId()).thenReturn("id");
+
+        uut = new NotificationPresenterImpl(viewMock);
+
+        uut.currentCategory = currentCategoryMock;
+        uut.messageServiceFacade = messageServiceFacadeMock;
+        uut.toolbar = toolbarViewMock;
+        uut.eventBus = eventBusMock;
+    }
+
+    @Test
+    public void testOnNotificationGridRefresh_emptyListStore() {
+        when(listStoreMock.size()).thenReturn(0);
+        when(viewMock.getListStore()).thenReturn(listStoreMock);
+
+        uut.onGridRefresh();
+        verify(toolbarViewMock).setDeleteAllButtonEnabled(eq(false));
+    }
+
+    @Test
+    public void testOnNotificationGridRefresh_nonEmptyListStore() {
+        when(listStoreMock.size()).thenReturn(5);
+        when(viewMock.getListStore()).thenReturn(listStoreMock);
+
+        uut.onGridRefresh();
+        verify(toolbarViewMock).setDeleteAllButtonEnabled(eq(true));
+    }
+
+    @Test
+    public void testOnNotificationSelection_emptyListStore() {
+        when(listMock.size()).thenReturn(0);
+
+        uut.onNotificationSelection(listMock);
+        verify(toolbarViewMock).setDeleteButtonEnabled(eq(false));
+    }
+
+    @Test
+    public void testOnNotificationSelection_nonEmptyListStore() {
+        when(listMock.size()).thenReturn(5);
+
+        uut.onNotificationSelection(listMock);
+        verify(toolbarViewMock).setDeleteButtonEnabled(eq(true));
+    }
+
+
+    @Test
+    public void testOnNotificationToolbarDeleteAllClicked() {
+        uut.onDeleteAllClicked();
+
+        verify(viewMock).mask();
+        verify(messageServiceFacadeMock).deleteAll(eq(currentCategoryMock.toString()), asyncCallbackStringCaptor.capture());
+        AsyncCallback<String> asyncCallback = asyncCallbackStringCaptor.getValue();
+
+        asyncCallback.onSuccess("result");
+        verify(viewMock).unmask();
+        verify(viewMock).loadNotifications(eq(viewMock.getCurrentLoadConfig()));
+        verify(eventBusMock).fireEvent(isA(DeleteNotificationsUpdateEvent.class));
+
+    }
+
+    @Test
+    public void testOnNotificationToolbarDeleteClicked() {
+        when(listMock.isEmpty()).thenReturn(false);
+        when(listMock.size()).thenReturn(1);
+        when(iteratorMock.hasNext()).thenReturn(true, false);
+        when(iteratorMock.next()).thenReturn(notificationMessageMock);
+        when(listMock.iterator()).thenReturn(iteratorMock);
+        when(viewMock.getSelectedItems()).thenReturn(listMock);
+
+        uut.onDeleteClicked();
+
+        verify(messageServiceFacadeMock).deleteMessages(isA(JSONObject.class), asyncCallbackStringCaptor.capture());
+
+        asyncCallbackStringCaptor.getValue().onSuccess("result");
+        verify(eventBusMock).fireEvent(isA(DeleteNotificationsUpdateEvent.class));
+
+    }
+}


### PR DESCRIPTION
CORE-4345 In the Notifications window, now if you hit the "Delete All" button, it will only delete all the notifications within the category you are currently viewing (Data, Analysis, etc). If the "ALL" category is selected, then all notifications regardless of the category will get deleted.

CORE-4832 If you click either the "See All Notifications" or "See New Notifications" button in the Notification drop down menu, the Notification window will open and now the drop down will close itself instead of staying open.