### PR TITLE
Minor clj-icat-direct optimizations

### DIFF
--- a/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
+++ b/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
@@ -546,7 +546,7 @@
    "WITH user_groups AS ( SELECT g.group_user_id FROM r_user_main u
                             JOIN r_user_group g ON g.user_id = u.user_id
                            WHERE u.user_name = ?
-                             AND u.zone_name = ? ),
+                             AND u.zone_name = ? )
 
     SELECT DISTINCT
            c.parent_coll_name                     as dir_name,
@@ -593,7 +593,7 @@
                             FROM r_user_main u
                             JOIN r_user_group g ON g.user_id = u.user_id
                            WHERE u.user_name = ?
-                             AND u.zone_name = ? ),
+                             AND u.zone_name = ? )
 
     SELECT count(DISTINCT c.coll_id) FROM r_coll_main c
       JOIN r_objt_access a ON c.coll_id = a.object_id

--- a/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
+++ b/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
@@ -523,7 +523,7 @@
                            WHERE u.user_name = ?
                              AND u.zone_name = ? ),
 
-         parent      AS ( SELECT DISTINCT coll_id, coll_name from r_coll_main
+         parent      AS ( SELECT coll_id, coll_name from r_coll_main
                            WHERE coll_name = ?
                               OR coll_name LIKE ? || '/%' ),
 

--- a/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
+++ b/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
@@ -581,7 +581,7 @@
 
          data_objs   AS ( SELECT data_id
                             FROM r_data_main
-                           WHERE coll_id IN ( SELECT coll_id FROM parent ))
+                           WHERE coll_id = ANY(ARRAY( SELECT coll_id FROM parent )) )
 
       SELECT count(DISTINCT d.data_id) FROM r_objt_access a
         JOIN data_objs d ON a.object_id = d.data_id

--- a/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
+++ b/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
@@ -712,7 +712,7 @@
                        AND o.object_id IN (SELECT object_id
                                              FROM r_objt_access
                                              WHERE user_id in (SELECT group_user_id FROM groups))),
-         file_types AS (SELECT *
+         file_types AS (SELECT om.object_id, mm.meta_attr_value
                           FROM r_objt_metamap AS om
                             JOIN r_meta_main AS mm ON mm.meta_id = om.meta_id
                           WHERE om.object_id = ANY(ARRAY(SELECT object_id FROM uuids))


### PR DESCRIPTION
All fairly minor stuff, @psarando work the other day hit the big issues. But, reducing these column counts and extra CTEs should make these queries run slightly faster due to reduced memory usage and less query planning (respectively), so I figured I'd put it up.