### PR TITLE
CORE-7522: require at least one path in the Paths schema.

### DIFF
--- a/services/data-info/src/data_info/routes/domain/common.clj
+++ b/services/data-info/src/data_info/routes/domain/common.clj
@@ -11,18 +11,16 @@
 (def DataIdPathParam (describe UUID "The data item's UUID"))
 
 (s/defschema Paths
-  {:paths (describe [NonBlankString] "A list of iRODS paths")})
+  {:paths (describe [(s/one NonBlankString "path") NonBlankString] "A list of iRODS paths")})
 
 (s/defschema OptionalPaths
-  (-> Paths
-    (->optional-param :paths)))
+  {(s/optional-key :paths) (describe [NonBlankString] "A list of iRODS paths")})
 
 (s/defschema DataIds
   {:ids (describe [UUID] "A list of iRODS data-object UUIDs")})
 
 (s/defschema OptionalPathsOrDataIds
-  (-> (merge DataIds Paths)
-      (->optional-param :paths)
+  (-> (merge DataIds OptionalPaths)
       (->optional-param :ids)))
 
 (def ValidInfoTypesEnum (apply s/enum (hm/supported-formats)))


### PR DESCRIPTION
This makes it so that `/secured/filesystem/anon-files` will properly validate -- QA has a test which passes a misspelled key, and terrain was pulling out the nonexistent "paths" key and passing it to data-info, which was then happily doing nothing and returning rather than erroring.