### PR TITLE
CORE-3358

### DIFF
--- a/libs/kameleon/src/kameleon/util.clj
+++ b/libs/kameleon/src/kameleon/util.clj
@@ -6,3 +6,10 @@
   [desc query]
   (log/debug desc (sql-only (select query)))
   query)
+
+(defn normalize-string
+  "Normalizes a string for use in comparisons. Comparisons in which this function is used on both sides will be
+  case-insensitive with leading and trailing whitespace removed and consecutive whitespace collapsed to a single
+  space."
+  [s]
+  (sqlfn lower (sqlfn regexp_replace (sqlfn trim s) "\\s+" " ")))

--- a/services/apps/src/apps/persistence/app_metadata.clj
+++ b/services/apps/src/apps/persistence/app_metadata.clj
@@ -1,6 +1,7 @@
 (ns apps.persistence.app-metadata
   "Persistence layer for app metadata."
   (:use [kameleon.entities]
+        [kameleon.util :only [normalize-string]]
         [kameleon.uuids :only [uuidify]]
         [korma.core :exclude [update]]
         [korma.db :only [transaction]]
@@ -725,10 +726,10 @@
   (select [:apps :a]
           (fields :a.id :a.name :a.description)
           (join [:app_category_app :aca] {:a.id :aca.app_id})
-          (where {(raw "trim(both from a.name)") (string/trim app-name)
-                  :a.deleted                     false
-                  :aca.app_category_id           [in category-id-set]
-                  :a.id                          [not= app-id]})))
+          (where {(normalize-string :a.name) (normalize-string app-name)
+                  :a.deleted                 false
+                  :aca.app_category_id       [in category-id-set]
+                  :a.id                      [not= app-id]})))
 
 (defn- app-category-id-subselect
   [app-id beta-app-category-id]

--- a/services/apps/src/apps/persistence/app_metadata.clj
+++ b/services/apps/src/apps/persistence/app_metadata.clj
@@ -692,6 +692,14 @@
        (map (juxt :id :name))
        (into {})))
 
+(defn get-app-name
+  [app-id]
+  (->> (select :apps
+               (fields :name)
+               (where {:id (uuidify app-id)}))
+       first
+       :name))
+
 (defn- user-favorite-subselect
   [root-category-field faves-idx]
   (subselect [:app_category_group :acg]

--- a/services/apps/src/apps/persistence/app_metadata.clj
+++ b/services/apps/src/apps/persistence/app_metadata.clj
@@ -8,6 +8,7 @@
         [apps.util.assertions]
         [apps.util.conversions :only [remove-nil-vals]])
   (:require [clojure.set :as set]
+            [clojure.string :as string]
             [kameleon.app-listing :as app-listing]
             [korma.core :as sql]
             [apps.persistence.app-metadata.delete :as delete]
@@ -710,3 +711,13 @@
                            {:u.username username})
                        {:aca.app_id (uuidify app-id)
                         :l.id       [not= (user-favorite-subselect :w.root_category_id faves-idx)]})))))
+
+(defn list-duplicate-apps
+  "List apps with the same name that exist in the same category as the new app."
+  [app-name category-ids]
+  (select [:apps :a]
+          (fields :a.id :a.name :a.description)
+          (join [:app_category_app :aca] {:a.id :aca.app_id})
+          (where {:aca.app_category_id           [in category-ids]
+                  (raw "trim(both from a.name)") (string/trim app-name)
+                  :a.deleted                     false})))

--- a/services/apps/src/apps/service/apps/de/admin.clj
+++ b/services/apps/src/apps/service/apps/de/admin.clj
@@ -92,10 +92,10 @@
   "This service updates high-level details and labels in an App, and can mark or unmark the app as
    deleted or disabled in the database."
   [{app-name :name app-id :id :as app}]
-  (validate-app-existence app-id)
-  (when-not (nil? app-name)
-    (av/validate-app-name app-name app-id (workspace-beta-app-category-id)))
   (transaction
+   (validate-app-existence app-id)
+   (when-not (nil? app-name)
+     (av/validate-app-name app-name app-id (workspace-beta-app-category-id)))
    (if (empty? (select-keys app [:name :description :wiki_url :references :groups]))
      (update-app-deleted-disabled app)
      (update-app-details app))))

--- a/services/apps/src/apps/service/apps/de/admin.clj
+++ b/services/apps/src/apps/service/apps/de/admin.clj
@@ -1,6 +1,5 @@
 (ns apps.service.apps.de.admin
-  (:use [kameleon.uuids :only [uuidify]]
-        [korma.db :only [transaction]]
+  (:use [korma.db :only [transaction]]
         [apps.persistence.app-metadata.relabel :only [update-app-labels]]
         [apps.util.assertions :only [assert-not-nil]]
         [apps.util.config :only [workspace-public-id]]
@@ -106,7 +105,7 @@
   (validate-subcategory-name parent_id name)
   (validate-category-empty parent_id)
   (transaction
-   (let [category-id (:id (app-groups/create-app-group (uuidify (workspace-public-id)) category))]
+   (let [category-id (:id (app-groups/create-app-group (workspace-public-id) category))]
      (app-groups/add-subgroup parent_id category-id)
      category-id)))
 

--- a/services/apps/src/apps/service/apps/de/categorization.clj
+++ b/services/apps/src/apps/service/apps/de/categorization.clj
@@ -4,7 +4,9 @@
         [kameleon.app-groups]
         [kameleon.entities]
         [apps.validation]
-        [slingshot.slingshot :only [throw+]]))
+        [slingshot.slingshot :only [throw+]])
+  (:require [apps.persistence.app-metadata :as ap]
+            [apps.service.apps.de.validation :as av]))
 
 (defn- categorize-app
   "Associates an app with an app category."
@@ -48,11 +50,18 @@
              :path  path}))
   (dorun (map (partial validate-category-id path) category-ids)))
 
+(defn- validate-app-name
+  "Validates the app name to ensure that there are no apps with the same name in any of the
+  destination categories."
+  [app-id category-ids path]
+  (av/validate-app-name-with-path (ap/get-app-name app-id) category-ids path))
+
 (defn- validate-category
   "Validates each categorized app in the request."
   [{app-id :app_id category-ids :category_ids :as category} path]
   (validate-app-info app-id path)
-  (validate-category-ids category-ids path))
+  (validate-category-ids category-ids path)
+  (validate-app-name app-id category-ids path))
 
 (defn- validate-request-body
   "Validates the request body."

--- a/services/apps/src/apps/service/apps/de/categorization.clj
+++ b/services/apps/src/apps/service/apps/de/categorization.clj
@@ -73,5 +73,6 @@
 (defn categorize-apps
   "A service that categorizes one or more apps in the database."
   [{:keys [categories] :as body}]
-  (validate-request-body body)
-  (transaction (dorun (map categorize-app categories))))
+  (transaction
+   (validate-request-body body)
+   (dorun (map categorize-app categories))))

--- a/services/apps/src/apps/service/apps/de/categorization.clj
+++ b/services/apps/src/apps/service/apps/de/categorization.clj
@@ -6,7 +6,8 @@
         [apps.validation]
         [slingshot.slingshot :only [throw+]])
   (:require [apps.persistence.app-metadata :as ap]
-            [apps.service.apps.de.validation :as av]))
+            [apps.service.apps.de.validation :as av]
+            [apps.util.config :as cfg]))
 
 (defn- categorize-app
   "Associates an app with an app category."
@@ -54,7 +55,7 @@
   "Validates the app name to ensure that there are no apps with the same name in any of the
   destination categories."
   [app-id category-ids path]
-  (av/validate-app-name-with-path (ap/get-app-name app-id) category-ids path))
+  (av/validate-app-name (ap/get-app-name app-id) app-id (cfg/workspace-beta-app-category-id) category-ids path))
 
 (defn- validate-category
   "Validates each categorized app in the request."

--- a/services/apps/src/apps/service/apps/de/edit.clj
+++ b/services/apps/src/apps/service/apps/de/edit.clj
@@ -347,8 +347,9 @@
 (defn update-app
   "This service will update a single-step App, including the information at its top level and the
    tool used by its single task, as long as the App has not been submitted for public use."
-  [user {app-id :id :keys [references groups] :as app}]
+  [user {app-id :id app-name :name :keys [references groups] :as app}]
   (verify-app-editable user (persistence/get-app app-id))
+  (validate-app-name app-name app-id (workspace-beta-app-category-id))
   (transaction
     (persistence/update-app app)
     (let [tool-id (->> app :tools first :id)

--- a/services/apps/src/apps/service/apps/de/edit.clj
+++ b/services/apps/src/apps/service/apps/de/edit.clj
@@ -463,8 +463,9 @@
    for public use."
   [user {app-name :name app-id :id :as body}]
   (let [app (persistence/get-app app-id)]
-    (validate-app-name app-name app-id (workspace-beta-app-category-id))
     (when-not (user-owns-app? user app)
       (verify-app-permission user app "write")))
-  (transaction (persistence/update-app-labels body))
+  (transaction
+   (validate-app-name app-name app-id (workspace-beta-app-category-id))
+   (persistence/update-app-labels body))
   (get-app-ui user app-id))

--- a/services/apps/src/apps/service/apps/de/edit.clj
+++ b/services/apps/src/apps/service/apps/de/edit.clj
@@ -8,7 +8,7 @@
         [kameleon.entities]
         [kameleon.uuids :only [uuidify]]
         [apps.metadata.params :only [format-reference-genome-value]]
-        [apps.service.apps.de.validation :only [verify-app-editable verify-app-permission]]
+        [apps.service.apps.de.validation :only [verify-app-editable verify-app-permission validate-app-name]]
         [apps.util.config :only [workspace-dev-app-category-index]]
         [apps.util.conversions :only [remove-nil-vals convert-rule-argument]]
         [apps.validation :only [validate-parameter]]
@@ -384,7 +384,8 @@
 
 (defn add-app
   "This service will add a single-step App, including the information at its top level."
-  [user {:keys [references groups] :as app}]
+  [{:keys [username] :as user} {app-name :name :keys [references groups] :as app}]
+  (validate-app-name app-name [(get-user-subcategory username (workspace-dev-app-category-index))])
   (transaction
     (let [app-id  (:id (persistence/add-app app))
           tool-id (->> app :tools first :id)

--- a/services/apps/src/apps/service/apps/de/edit.clj
+++ b/services/apps/src/apps/service/apps/de/edit.clj
@@ -386,9 +386,10 @@
 (defn add-app
   "This service will add a single-step App, including the information at its top level."
   [{:keys [username] :as user} {app-name :name :keys [references groups] :as app}]
-  (validate-app-name app-name [(get-user-subcategory username (workspace-dev-app-category-index))])
   (transaction
-    (let [app-id  (:id (persistence/add-app app))
+    (let [cat-id  (get-user-subcategory username (workspace-dev-app-category-index))
+          _       (validate-app-name app-name nil (workspace-beta-app-category-id) [cat-id])
+          app-id  (:id (persistence/add-app app))
           tool-id (->> app :tools first :id)
           task-id (-> (assoc app :id app-id :tool_id tool-id)
                       (add-single-step-task)

--- a/services/apps/src/apps/service/apps/de/edit.clj
+++ b/services/apps/src/apps/service/apps/de/edit.clj
@@ -9,7 +9,7 @@
         [kameleon.uuids :only [uuidify]]
         [apps.metadata.params :only [format-reference-genome-value]]
         [apps.service.apps.de.validation :only [verify-app-editable verify-app-permission validate-app-name]]
-        [apps.util.config :only [workspace-dev-app-category-index]]
+        [apps.util.config :only [workspace-dev-app-category-index workspace-beta-app-category-id]]
         [apps.util.conversions :only [remove-nil-vals convert-rule-argument]]
         [apps.validation :only [validate-parameter]]
         [apps.workspace :only [get-workspace]]
@@ -459,7 +459,8 @@
 (defn relabel-app
   "This service allows labels to be updated in any app, whether or not the app has been submitted
    for public use."
-  [user {app-id :id :as body}]
+  [user {app-name :name app-id :id :as body}]
+  (validate-app-name app-name app-id (workspace-beta-app-category-id))
   (let [app (persistence/get-app app-id)]
     (when-not (user-owns-app? user app)
       (verify-app-permission user app "write")))

--- a/services/apps/src/apps/service/apps/de/edit.clj
+++ b/services/apps/src/apps/service/apps/de/edit.clj
@@ -349,8 +349,8 @@
    tool used by its single task, as long as the App has not been submitted for public use."
   [user {app-id :id app-name :name :keys [references groups] :as app}]
   (verify-app-editable user (persistence/get-app app-id))
-  (validate-app-name app-name app-id (workspace-beta-app-category-id))
   (transaction
+    (validate-app-name app-name app-id (workspace-beta-app-category-id))
     (persistence/update-app app)
     (let [tool-id (->> app :tools first :id)
           app-task (->> (get-app-details app-id) :tasks first)
@@ -462,8 +462,8 @@
   "This service allows labels to be updated in any app, whether or not the app has been submitted
    for public use."
   [user {app-name :name app-id :id :as body}]
-  (validate-app-name app-name app-id (workspace-beta-app-category-id))
   (let [app (persistence/get-app app-id)]
+    (validate-app-name app-name app-id (workspace-beta-app-category-id))
     (when-not (user-owns-app? user app)
       (verify-app-permission user app "write")))
   (transaction (persistence/update-app-labels body))

--- a/services/apps/src/apps/service/apps/de/metadata.clj
+++ b/services/apps/src/apps/service/apps/de/metadata.clj
@@ -6,7 +6,6 @@
                                     decategorize-app
                                     get-app-subcategory-id
                                     remove-app-from-category]]
-        [kameleon.uuids :only [uuidify]]
         [apps.service.apps.de.validation :only [app-publishable? verify-app-permission]]
         [apps.util.config :only [workspace-beta-app-category-id
                                        workspace-favorites-app-category-index]]
@@ -146,7 +145,7 @@
     (amp/set-app-references app-id references)
     (amp/set-app-suggested-categories app-id categories)
     (decategorize-app app-id)
-    (add-app-to-category app-id (uuidify (workspace-beta-app-category-id)))
+    (add-app-to-category app-id (workspace-beta-app-category-id))
     (iplant-groups/make-app-public app-id))
   nil)
 

--- a/services/apps/src/apps/service/apps/de/validation.clj
+++ b/services/apps/src/apps/service/apps/de/validation.clj
@@ -1,11 +1,11 @@
 (ns apps.service.apps.de.validation
-  (:use [clojure-commons.exception-util :only [forbidden]]
+  (:use [clojure-commons.exception-util :only [forbidden exists]]
         [slingshot.slingshot :only [try+ throw+]]
         [korma.core :exclude [update]]
         [kameleon.core]
         [kameleon.entities]
         [kameleon.queries :only [parameter-types-for-tool-type]]
-        [apps.persistence.app-metadata :only [get-app]])
+        [apps.persistence.app-metadata :only [get-app list-duplicate-apps]])
   (:require [apps.service.apps.de.permissions :as perms]
             [clojure.string :as string]))
 
@@ -137,3 +137,11 @@
   [user app]
   (verify-app-permission user app "write")
   (verify-app-not-public app))
+
+(defn validate-app-name
+  "Verifies that an app with the same name doesn't already exist in any of the same app categories. The beta
+   category is treated as an exception because it's intended to be a staging area for new apps."
+  [app-name category-ids]
+  (when (seq (list-duplicate-apps app-name category-ids))
+    (exists "An app with the same name already exists in one of the same categories."
+            :app_name app-name :category_ids category-ids)))

--- a/services/apps/src/apps/service/apps/de/validation.clj
+++ b/services/apps/src/apps/service/apps/de/validation.clj
@@ -147,16 +147,15 @@
 (defn validate-app-name
   "Verifies that an app with the same name doesn't already exist in any of the same app categories. The beta
    category is treated as an exception because it's intended to be a staging area for new apps."
-  ([app-name category-ids]
-     (when (seq (list-duplicate-apps app-name category-ids))
-       (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids)))
-  ([app-name app-id beta-category-id]
-     (when (seq (list-duplicate-apps app-name app-id beta-category-id))
-       (exists duplicate-app-existing-categories-msg :app_name app-name :app_id app-id))))
-
-(defn validate-app-name-with-path
-  "Verifies that an app with the same name doesn't already exist in any of the same app categories. The beta
-   category is treated as an exception because it's intended to be a staging area for new apps."
-  [app-name category-ids path]
-  (when (seq (list-duplicate-apps app-name category-ids))
-    (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids :path path)))
+  ([app-name app-id beta-app-category-id]
+     (validate-app-name app-name app-id beta-app-category-id nil))
+  ([app-name app-id beta-app-category-id category-ids]
+     (when (seq (list-duplicate-apps app-name app-id beta-app-category-id category-ids))
+       (if (seq category-ids)
+         (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids)
+         (exists duplicate-app-existing-categories-msg :app_name app-name :app_id app-id))))
+  ([app-name app-id beta-app-category-id category-ids path]
+     (when (seq (list-duplicate-apps app-name app-id beta-app-category-id category-ids))
+       (if (seq category-ids)
+         (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids :path path)
+         (exists duplicate-app-existing-categories-msg :app_name app-name :app_id app-id :path path)))))

--- a/services/apps/src/apps/service/apps/de/validation.clj
+++ b/services/apps/src/apps/service/apps/de/validation.clj
@@ -141,7 +141,11 @@
 (defn validate-app-name
   "Verifies that an app with the same name doesn't already exist in any of the same app categories. The beta
    category is treated as an exception because it's intended to be a staging area for new apps."
-  [app-name category-ids]
-  (when (seq (list-duplicate-apps app-name category-ids))
-    (exists "An app with the same name already exists in one of the same categories."
-            :app_name app-name :category_ids category-ids)))
+  ([app-name category-ids]
+     (when (seq (list-duplicate-apps app-name category-ids))
+       (exists "An app with the same name already exists in one of the selected categories."
+               :app_name app-name :category_ids category-ids)))
+  ([app-name app-id beta-category-id]
+     (when (seq (list-duplicate-apps app-name app-id beta-category-id))
+       (exists "An app with the same name already exists in one of the same categories."
+               :app_name app-name :app_id app-id))))

--- a/services/apps/src/apps/service/apps/de/validation.clj
+++ b/services/apps/src/apps/service/apps/de/validation.clj
@@ -138,14 +138,25 @@
   (verify-app-permission user app "write")
   (verify-app-not-public app))
 
+(def ^:private duplicate-app-selected-categories-msg
+  "An app with the same name already exists in one of the selected categories.")
+
+(def ^:private duplicate-app-existing-categories-msg
+  "An app with the same name already exists in one of the same categories.")
+
 (defn validate-app-name
   "Verifies that an app with the same name doesn't already exist in any of the same app categories. The beta
    category is treated as an exception because it's intended to be a staging area for new apps."
   ([app-name category-ids]
      (when (seq (list-duplicate-apps app-name category-ids))
-       (exists "An app with the same name already exists in one of the selected categories."
-               :app_name app-name :category_ids category-ids)))
+       (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids)))
   ([app-name app-id beta-category-id]
      (when (seq (list-duplicate-apps app-name app-id beta-category-id))
-       (exists "An app with the same name already exists in one of the same categories."
-               :app_name app-name :app_id app-id))))
+       (exists duplicate-app-existing-categories-msg :app_name app-name :app_id app-id))))
+
+(defn validate-app-name-with-path
+  "Verifies that an app with the same name doesn't already exist in any of the same app categories. The beta
+   category is treated as an exception because it's intended to be a staging area for new apps."
+  [app-name category-ids path]
+  (when (seq (list-duplicate-apps app-name category-ids))
+    (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids :path path)))

--- a/services/apps/src/apps/util/config.clj
+++ b/services/apps/src/apps/util/config.clj
@@ -115,12 +115,12 @@
   [props config-valid configs]
   "apps.workspace.favorites-app-category-index")
 
-(cc/defprop-str workspace-beta-app-category-id
+(cc/defprop-uuid workspace-beta-app-category-id
   "The UUID of the default Beta app category."
   [props config-valid configs]
   "apps.workspace.beta-app-category-id")
 
-(cc/defprop-str workspace-public-id
+(cc/defprop-uuid workspace-public-id
   "The UUID of the default Beta app category."
   [props config-valid configs]
   "apps.workspace.public-id")


### PR DESCRIPTION
This change adds duplicate app name checking to the apps services. Two apps that are in the same category and are not marked as deleted should not be allowed to have the same name in order to avoid confusion. The `Beta` category is treated as an exception because it's intended to be a staging area for newly published apps. It is left to the app administrator to determine if an app in the `Beta` category needs to be renamed before it can be placed in its destination category.
