### PR TITLE
Minor jex-go updates

### DIFF
--- a/services/jobservices/.gitignore
+++ b/services/jobservices/.gitignore
@@ -1,6 +1,2 @@
-Godeps/_workspace/
-Godeps/Readme
-bin/
-pkg/
-.hg/
-.git/
+/bin/
+/pkg/

--- a/services/jobservices/README.md
+++ b/services/jobservices/README.md
@@ -32,6 +32,8 @@ To run integration tests, use the **test.sh** script. It uses **docker-compose**
 
     ./test.sh
 
+If you notice connections failing, check if the **dedb** container started up properly. If **docker logs dedb** shows errors about SHMMAX, you may need to set it up with **--ipc host** (on some older systems, SHMMAX isn't properly inherited from the host system without this). Other sorts of failures may simply require a bit of a forced wait between starting the dedb, rabbit, and dind containers and running the test container.
+
 ## Workflow
 
 A user submits a job through the UI. The job submission is assembled into JSON in the **apps** service, which posts the JSON to the **jex-adapter** service. The **jex-adapter** service sends the JSON as a message out on the **jobs.launches** topic of the **jobs** exchange.

--- a/services/jobservices/test.yml
+++ b/services/jobservices/test.yml
@@ -1,22 +1,31 @@
-dind:
-    image: docker:dind
-    container_name: dind
-    privileged: true
-    net: jobservices
-rabbit:
-    image: rabbitmq:management
-    container_name: rabbit
-    net: jobservices
-dedb:
-    image: discoenv/unittest-dedb:dev
-    container_name: dedb
-    net: jobservices
-test:
-    image: discoenv/buildenv
-    net: jobservices
-    environment:
-      RUN_INTEGRATION_TESTS: 1
-    volumes:
-      - .:/jex
-    working_dir: /jex
-    command: gb test -test.v
+version: '2'
+services:
+    dind:
+        image: docker:dind
+        container_name: dind
+        privileged: true
+        networks:
+         - jobservices
+    rabbit:
+        image: rabbitmq:management
+        container_name: rabbit
+        networks:
+         - jobservices
+    dedb:
+        image: discoenv/unittest-dedb:jex-go
+        container_name: dedb
+        networks:
+         - jobservices
+    test:
+        image: discoenv/buildenv
+        networks:
+         - jobservices
+        environment:
+          RUN_INTEGRATION_TESTS: 1
+        volumes:
+          - .:/jex
+        working_dir: /jex
+        command: gb test -test.v
+networks:
+    jobservices:
+        driver: bridge

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/README.md
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/README.md
@@ -1,0 +1,1 @@
+This code provides helper functions for dealing with archive files.

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive.go
@@ -1,0 +1,902 @@
+package archive
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/promise"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+type (
+	Archive         io.ReadCloser
+	ArchiveReader   io.Reader
+	Compression     int
+	TarChownOptions struct {
+		UID, GID int
+	}
+	TarOptions struct {
+		IncludeFiles     []string
+		ExcludePatterns  []string
+		Compression      Compression
+		NoLchown         bool
+		ChownOpts        *TarChownOptions
+		Name             string
+		IncludeSourceDir bool
+		// When unpacking, specifies whether overwriting a directory with a
+		// non-directory is allowed and vice versa.
+		NoOverwriteDirNonDir bool
+	}
+
+	// Archiver allows the reuse of most utility functions of this package
+	// with a pluggable Untar function.
+	Archiver struct {
+		Untar func(io.Reader, string, *TarOptions) error
+	}
+
+	// breakoutError is used to differentiate errors related to breaking out
+	// When testing archive breakout in the unit tests, this error is expected
+	// in order for the test to pass.
+	breakoutError error
+)
+
+var (
+	ErrNotImplemented = errors.New("Function not implemented")
+	defaultArchiver   = &Archiver{Untar}
+)
+
+const (
+	Uncompressed Compression = iota
+	Bzip2
+	Gzip
+	Xz
+)
+
+func IsArchive(header []byte) bool {
+	compression := DetectCompression(header)
+	if compression != Uncompressed {
+		return true
+	}
+	r := tar.NewReader(bytes.NewBuffer(header))
+	_, err := r.Next()
+	return err == nil
+}
+
+func DetectCompression(source []byte) Compression {
+	for compression, m := range map[Compression][]byte{
+		Bzip2: {0x42, 0x5A, 0x68},
+		Gzip:  {0x1F, 0x8B, 0x08},
+		Xz:    {0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00},
+	} {
+		if len(source) < len(m) {
+			logrus.Debugf("Len too short")
+			continue
+		}
+		if bytes.Compare(m, source[:len(m)]) == 0 {
+			return compression
+		}
+	}
+	return Uncompressed
+}
+
+func xzDecompress(archive io.Reader) (io.ReadCloser, error) {
+	args := []string{"xz", "-d", "-c", "-q"}
+
+	return CmdStream(exec.Command(args[0], args[1:]...), archive)
+}
+
+func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
+	p := pools.BufioReader32KPool
+	buf := p.Get(archive)
+	bs, err := buf.Peek(10)
+	if err != nil {
+		return nil, err
+	}
+
+	compression := DetectCompression(bs)
+	switch compression {
+	case Uncompressed:
+		readBufWrapper := p.NewReadCloserWrapper(buf, buf)
+		return readBufWrapper, nil
+	case Gzip:
+		gzReader, err := gzip.NewReader(buf)
+		if err != nil {
+			return nil, err
+		}
+		readBufWrapper := p.NewReadCloserWrapper(buf, gzReader)
+		return readBufWrapper, nil
+	case Bzip2:
+		bz2Reader := bzip2.NewReader(buf)
+		readBufWrapper := p.NewReadCloserWrapper(buf, bz2Reader)
+		return readBufWrapper, nil
+	case Xz:
+		xzReader, err := xzDecompress(buf)
+		if err != nil {
+			return nil, err
+		}
+		readBufWrapper := p.NewReadCloserWrapper(buf, xzReader)
+		return readBufWrapper, nil
+	default:
+		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+	}
+}
+
+func CompressStream(dest io.WriteCloser, compression Compression) (io.WriteCloser, error) {
+	p := pools.BufioWriter32KPool
+	buf := p.Get(dest)
+	switch compression {
+	case Uncompressed:
+		writeBufWrapper := p.NewWriteCloserWrapper(buf, buf)
+		return writeBufWrapper, nil
+	case Gzip:
+		gzWriter := gzip.NewWriter(dest)
+		writeBufWrapper := p.NewWriteCloserWrapper(buf, gzWriter)
+		return writeBufWrapper, nil
+	case Bzip2, Xz:
+		// archive/bzip2 does not support writing, and there is no xz support at all
+		// However, this is not a problem as docker only currently generates gzipped tars
+		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+	default:
+		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+	}
+}
+
+func (compression *Compression) Extension() string {
+	switch *compression {
+	case Uncompressed:
+		return "tar"
+	case Bzip2:
+		return "tar.bz2"
+	case Gzip:
+		return "tar.gz"
+	case Xz:
+		return "tar.xz"
+	}
+	return ""
+}
+
+type tarAppender struct {
+	TarWriter *tar.Writer
+	Buffer    *bufio.Writer
+
+	// for hardlink mapping
+	SeenFiles map[uint64]string
+}
+
+// canonicalTarName provides a platform-independent and consistent posix-style
+//path for files and directories to be archived regardless of the platform.
+func canonicalTarName(name string, isDir bool) (string, error) {
+	name, err := CanonicalTarNameForPath(name)
+	if err != nil {
+		return "", err
+	}
+
+	// suffix with '/' for directories
+	if isDir && !strings.HasSuffix(name, "/") {
+		name += "/"
+	}
+	return name, nil
+}
+
+func (ta *tarAppender) addTarFile(path, name string) error {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+
+	link := ""
+	if fi.Mode()&os.ModeSymlink != 0 {
+		if link, err = os.Readlink(path); err != nil {
+			return err
+		}
+	}
+
+	hdr, err := tar.FileInfoHeader(fi, link)
+	if err != nil {
+		return err
+	}
+	hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))
+
+	name, err = canonicalTarName(name, fi.IsDir())
+	if err != nil {
+		return fmt.Errorf("tar: cannot canonicalize path: %v", err)
+	}
+	hdr.Name = name
+
+	nlink, inode, err := setHeaderForSpecialDevice(hdr, ta, name, fi.Sys())
+	if err != nil {
+		return err
+	}
+
+	// if it's a regular file and has more than 1 link,
+	// it's hardlinked, so set the type flag accordingly
+	if fi.Mode().IsRegular() && nlink > 1 {
+		// a link should have a name that it links too
+		// and that linked name should be first in the tar archive
+		if oldpath, ok := ta.SeenFiles[inode]; ok {
+			hdr.Typeflag = tar.TypeLink
+			hdr.Linkname = oldpath
+			hdr.Size = 0 // This Must be here for the writer math to add up!
+		} else {
+			ta.SeenFiles[inode] = name
+		}
+	}
+
+	capability, _ := system.Lgetxattr(path, "security.capability")
+	if capability != nil {
+		hdr.Xattrs = make(map[string]string)
+		hdr.Xattrs["security.capability"] = string(capability)
+	}
+
+	if err := ta.TarWriter.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	if hdr.Typeflag == tar.TypeReg {
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		ta.Buffer.Reset(ta.TarWriter)
+		defer ta.Buffer.Reset(nil)
+		_, err = io.Copy(ta.Buffer, file)
+		file.Close()
+		if err != nil {
+			return err
+		}
+		err = ta.Buffer.Flush()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *TarChownOptions) error {
+	// hdr.Mode is in linux format, which we can use for sycalls,
+	// but for os.Foo() calls we need the mode converted to os.FileMode,
+	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
+	hdrInfo := hdr.FileInfo()
+
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		// Create directory unless it exists as a directory already.
+		// In that case we just want to merge the two
+		if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
+			if err := os.Mkdir(path, hdrInfo.Mode()); err != nil {
+				return err
+			}
+		}
+
+	case tar.TypeReg, tar.TypeRegA:
+		// Source is regular file
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(file, reader); err != nil {
+			file.Close()
+			return err
+		}
+		file.Close()
+
+	case tar.TypeBlock, tar.TypeChar, tar.TypeFifo:
+		// Handle this is an OS-specific way
+		if err := handleTarTypeBlockCharFifo(hdr, path); err != nil {
+			return err
+		}
+
+	case tar.TypeLink:
+		targetPath := filepath.Join(extractDir, hdr.Linkname)
+		// check for hardlink breakout
+		if !strings.HasPrefix(targetPath, extractDir) {
+			return breakoutError(fmt.Errorf("invalid hardlink %q -> %q", targetPath, hdr.Linkname))
+		}
+		if err := os.Link(targetPath, path); err != nil {
+			return err
+		}
+
+	case tar.TypeSymlink:
+		// 	path 				-> hdr.Linkname = targetPath
+		// e.g. /extractDir/path/to/symlink 	-> ../2/file	= /extractDir/path/2/file
+		targetPath := filepath.Join(filepath.Dir(path), hdr.Linkname)
+
+		// the reason we don't need to check symlinks in the path (with FollowSymlinkInScope) is because
+		// that symlink would first have to be created, which would be caught earlier, at this very check:
+		if !strings.HasPrefix(targetPath, extractDir) {
+			return breakoutError(fmt.Errorf("invalid symlink %q -> %q", path, hdr.Linkname))
+		}
+		if err := os.Symlink(hdr.Linkname, path); err != nil {
+			return err
+		}
+
+	case tar.TypeXGlobalHeader:
+		logrus.Debugf("PAX Global Extended Headers found and ignored")
+		return nil
+
+	default:
+		return fmt.Errorf("Unhandled tar header type %d\n", hdr.Typeflag)
+	}
+
+	// Lchown is not supported on Windows.
+	if Lchown && runtime.GOOS != "windows" {
+		if chownOpts == nil {
+			chownOpts = &TarChownOptions{UID: hdr.Uid, GID: hdr.Gid}
+		}
+		if err := os.Lchown(path, chownOpts.UID, chownOpts.GID); err != nil {
+			return err
+		}
+	}
+
+	for key, value := range hdr.Xattrs {
+		if err := system.Lsetxattr(path, key, []byte(value), 0); err != nil {
+			return err
+		}
+	}
+
+	// There is no LChmod, so ignore mode for symlink. Also, this
+	// must happen after chown, as that can modify the file mode
+	if err := handleLChmod(hdr, path, hdrInfo); err != nil {
+		return err
+	}
+
+	ts := []syscall.Timespec{timeToTimespec(hdr.AccessTime), timeToTimespec(hdr.ModTime)}
+	// syscall.UtimesNano doesn't support a NOFOLLOW flag atm
+	if hdr.Typeflag == tar.TypeLink {
+		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			if err := system.UtimesNano(path, ts); err != nil && err != system.ErrNotSupportedPlatform {
+				return err
+			}
+		}
+	} else if hdr.Typeflag != tar.TypeSymlink {
+		if err := system.UtimesNano(path, ts); err != nil && err != system.ErrNotSupportedPlatform {
+			return err
+		}
+	} else {
+		if err := system.LUtimesNano(path, ts); err != nil && err != system.ErrNotSupportedPlatform {
+			return err
+		}
+	}
+	return nil
+}
+
+// Tar creates an archive from the directory at `path`, and returns it as a
+// stream of bytes.
+func Tar(path string, compression Compression) (io.ReadCloser, error) {
+	return TarWithOptions(path, &TarOptions{Compression: compression})
+}
+
+// TarWithOptions creates an archive from the directory at `path`, only including files whose relative
+// paths are included in `options.IncludeFiles` (if non-nil) or not in `options.ExcludePatterns`.
+func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) {
+
+	patterns, patDirs, exceptions, err := fileutils.CleanPatterns(options.ExcludePatterns)
+
+	if err != nil {
+		return nil, err
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	compressWriter, err := CompressStream(pipeWriter, options.Compression)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		ta := &tarAppender{
+			TarWriter: tar.NewWriter(compressWriter),
+			Buffer:    pools.BufioWriter32KPool.Get(nil),
+			SeenFiles: make(map[uint64]string),
+		}
+
+		defer func() {
+			// Make sure to check the error on Close.
+			if err := ta.TarWriter.Close(); err != nil {
+				logrus.Debugf("Can't close tar writer: %s", err)
+			}
+			if err := compressWriter.Close(); err != nil {
+				logrus.Debugf("Can't close compress writer: %s", err)
+			}
+			if err := pipeWriter.Close(); err != nil {
+				logrus.Debugf("Can't close pipe writer: %s", err)
+			}
+		}()
+
+		// this buffer is needed for the duration of this piped stream
+		defer pools.BufioWriter32KPool.Put(ta.Buffer)
+
+		// In general we log errors here but ignore them because
+		// during e.g. a diff operation the container can continue
+		// mutating the filesystem and we can see transient errors
+		// from this
+
+		stat, err := os.Lstat(srcPath)
+		if err != nil {
+			return
+		}
+
+		if !stat.IsDir() {
+			// We can't later join a non-dir with any includes because the
+			// 'walk' will error if "file/." is stat-ed and "file" is not a
+			// directory. So, we must split the source path and use the
+			// basename as the include.
+			if len(options.IncludeFiles) > 0 {
+				logrus.Warn("Tar: Can't archive a file with includes")
+			}
+
+			dir, base := SplitPathDirEntry(srcPath)
+			srcPath = dir
+			options.IncludeFiles = []string{base}
+		}
+
+		if len(options.IncludeFiles) == 0 {
+			options.IncludeFiles = []string{"."}
+		}
+
+		seen := make(map[string]bool)
+
+		var renamedRelFilePath string // For when tar.Options.Name is set
+		for _, include := range options.IncludeFiles {
+			// We can't use filepath.Join(srcPath, include) because this will
+			// clean away a trailing "." or "/" which may be important.
+			walkRoot := strings.Join([]string{srcPath, include}, string(filepath.Separator))
+			filepath.Walk(walkRoot, func(filePath string, f os.FileInfo, err error) error {
+				if err != nil {
+					logrus.Debugf("Tar: Can't stat file %s to tar: %s", srcPath, err)
+					return nil
+				}
+
+				relFilePath, err := filepath.Rel(srcPath, filePath)
+				if err != nil || (!options.IncludeSourceDir && relFilePath == "." && f.IsDir()) {
+					// Error getting relative path OR we are looking
+					// at the source directory path. Skip in both situations.
+					return nil
+				}
+
+				if options.IncludeSourceDir && include == "." && relFilePath != "." {
+					relFilePath = strings.Join([]string{".", relFilePath}, string(filepath.Separator))
+				}
+
+				skip := false
+
+				// If "include" is an exact match for the current file
+				// then even if there's an "excludePatterns" pattern that
+				// matches it, don't skip it. IOW, assume an explicit 'include'
+				// is asking for that file no matter what - which is true
+				// for some files, like .dockerignore and Dockerfile (sometimes)
+				if include != relFilePath {
+					skip, err = fileutils.OptimizedMatches(relFilePath, patterns, patDirs)
+					if err != nil {
+						logrus.Debugf("Error matching %s: %v", relFilePath, err)
+						return err
+					}
+				}
+
+				if skip {
+					if !exceptions && f.IsDir() {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+
+				if seen[relFilePath] {
+					return nil
+				}
+				seen[relFilePath] = true
+
+				// TODO Windows: Verify if this needs to be os.Pathseparator
+				// Rename the base resource
+				if options.Name != "" && filePath == srcPath+"/"+filepath.Base(relFilePath) {
+					renamedRelFilePath = relFilePath
+				}
+				// Set this to make sure the items underneath also get renamed
+				if options.Name != "" {
+					relFilePath = strings.Replace(relFilePath, renamedRelFilePath, options.Name, 1)
+				}
+
+				if err := ta.addTarFile(filePath, relFilePath); err != nil {
+					logrus.Debugf("Can't add file %s to tar: %s", filePath, err)
+				}
+				return nil
+			})
+		}
+	}()
+
+	return pipeReader, nil
+}
+
+func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) error {
+	tr := tar.NewReader(decompressedArchive)
+	trBuf := pools.BufioReader32KPool.Get(nil)
+	defer pools.BufioReader32KPool.Put(trBuf)
+
+	var dirs []*tar.Header
+
+	// Iterate through the files in the archive.
+loop:
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// Normalize name, for safety and for a simple is-root check
+		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
+		// This keeps "..\" as-is, but normalizes "\..\" to "\".
+		hdr.Name = filepath.Clean(hdr.Name)
+
+		for _, exclude := range options.ExcludePatterns {
+			if strings.HasPrefix(hdr.Name, exclude) {
+				continue loop
+			}
+		}
+
+		// After calling filepath.Clean(hdr.Name) above, hdr.Name will now be in
+		// the filepath format for the OS on which the daemon is running. Hence
+		// the check for a slash-suffix MUST be done in an OS-agnostic way.
+		if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
+			// Not the root directory, ensure that the parent directory exists
+			parent := filepath.Dir(hdr.Name)
+			parentPath := filepath.Join(dest, parent)
+			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
+				err = system.MkdirAll(parentPath, 0777)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		path := filepath.Join(dest, hdr.Name)
+		rel, err := filepath.Rel(dest, path)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
+		}
+
+		// If path exits we almost always just want to remove and replace it
+		// The only exception is when it is a directory *and* the file from
+		// the layer is also a directory. Then we want to merge them (i.e.
+		// just apply the metadata from the layer).
+		if fi, err := os.Lstat(path); err == nil {
+			if options.NoOverwriteDirNonDir && fi.IsDir() && hdr.Typeflag != tar.TypeDir {
+				// If NoOverwriteDirNonDir is true then we cannot replace
+				// an existing directory with a non-directory from the archive.
+				return fmt.Errorf("cannot overwrite directory %q with non-directory %q", path, dest)
+			}
+
+			if options.NoOverwriteDirNonDir && !fi.IsDir() && hdr.Typeflag == tar.TypeDir {
+				// If NoOverwriteDirNonDir is true then we cannot replace
+				// an existing non-directory with a directory from the archive.
+				return fmt.Errorf("cannot overwrite non-directory %q with directory %q", path, dest)
+			}
+
+			if fi.IsDir() && hdr.Name == "." {
+				continue
+			}
+
+			if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
+				if err := os.RemoveAll(path); err != nil {
+					return err
+				}
+			}
+		}
+		trBuf.Reset(tr)
+
+		if err := createTarFile(path, dest, hdr, trBuf, !options.NoLchown, options.ChownOpts); err != nil {
+			return err
+		}
+
+		// Directory mtimes must be handled at the end to avoid further
+		// file creation in them to modify the directory mtime
+		if hdr.Typeflag == tar.TypeDir {
+			dirs = append(dirs, hdr)
+		}
+	}
+
+	for _, hdr := range dirs {
+		path := filepath.Join(dest, hdr.Name)
+		ts := []syscall.Timespec{timeToTimespec(hdr.AccessTime), timeToTimespec(hdr.ModTime)}
+		if err := syscall.UtimesNano(path, ts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Untar reads a stream of bytes from `archive`, parses it as a tar archive,
+// and unpacks it into the directory at `dest`.
+// The archive may be compressed with one of the following algorithms:
+//  identity (uncompressed), gzip, bzip2, xz.
+// FIXME: specify behavior when target path exists vs. doesn't exist.
+func Untar(tarArchive io.Reader, dest string, options *TarOptions) error {
+	return untarHandler(tarArchive, dest, options, true)
+}
+
+// Untar reads a stream of bytes from `archive`, parses it as a tar archive,
+// and unpacks it into the directory at `dest`.
+// The archive must be an uncompressed stream.
+func UntarUncompressed(tarArchive io.Reader, dest string, options *TarOptions) error {
+	return untarHandler(tarArchive, dest, options, false)
+}
+
+// Handler for teasing out the automatic decompression
+func untarHandler(tarArchive io.Reader, dest string, options *TarOptions, decompress bool) error {
+	if tarArchive == nil {
+		return fmt.Errorf("Empty archive")
+	}
+	dest = filepath.Clean(dest)
+	if options == nil {
+		options = &TarOptions{}
+	}
+	if options.ExcludePatterns == nil {
+		options.ExcludePatterns = []string{}
+	}
+
+	var r io.Reader = tarArchive
+	if decompress {
+		decompressedArchive, err := DecompressStream(tarArchive)
+		if err != nil {
+			return err
+		}
+		defer decompressedArchive.Close()
+		r = decompressedArchive
+	}
+
+	return Unpack(r, dest, options)
+}
+
+func (archiver *Archiver) TarUntar(src, dst string) error {
+	logrus.Debugf("TarUntar(%s %s)", src, dst)
+	archive, err := TarWithOptions(src, &TarOptions{Compression: Uncompressed})
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+	return archiver.Untar(archive, dst, nil)
+}
+
+// TarUntar is a convenience function which calls Tar and Untar, with the output of one piped into the other.
+// If either Tar or Untar fails, TarUntar aborts and returns the error.
+func TarUntar(src, dst string) error {
+	return defaultArchiver.TarUntar(src, dst)
+}
+
+func (archiver *Archiver) UntarPath(src, dst string) error {
+	archive, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+	if err := archiver.Untar(archive, dst, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UntarPath is a convenience function which looks for an archive
+// at filesystem path `src`, and unpacks it at `dst`.
+func UntarPath(src, dst string) error {
+	return defaultArchiver.UntarPath(src, dst)
+}
+
+func (archiver *Archiver) CopyWithTar(src, dst string) error {
+	srcSt, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !srcSt.IsDir() {
+		return archiver.CopyFileWithTar(src, dst)
+	}
+	// Create dst, copy src's content into it
+	logrus.Debugf("Creating dest directory: %s", dst)
+	if err := system.MkdirAll(dst, 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+	logrus.Debugf("Calling TarUntar(%s, %s)", src, dst)
+	return archiver.TarUntar(src, dst)
+}
+
+// CopyWithTar creates a tar archive of filesystem path `src`, and
+// unpacks it at filesystem path `dst`.
+// The archive is streamed directly with fixed buffering and no
+// intermediary disk IO.
+func CopyWithTar(src, dst string) error {
+	return defaultArchiver.CopyWithTar(src, dst)
+}
+
+func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
+	logrus.Debugf("CopyFileWithTar(%s, %s)", src, dst)
+	srcSt, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if srcSt.IsDir() {
+		return fmt.Errorf("Can't copy a directory")
+	}
+
+	// Clean up the trailing slash. This must be done in an operating
+	// system specific manner.
+	if dst[len(dst)-1] == os.PathSeparator {
+		dst = filepath.Join(dst, filepath.Base(src))
+	}
+	// Create the holding directory if necessary
+	if err := system.MkdirAll(filepath.Dir(dst), 0700); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	r, w := io.Pipe()
+	errC := promise.Go(func() error {
+		defer w.Close()
+
+		srcF, err := os.Open(src)
+		if err != nil {
+			return err
+		}
+		defer srcF.Close()
+
+		hdr, err := tar.FileInfoHeader(srcSt, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.Base(dst)
+		hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))
+
+		tw := tar.NewWriter(w)
+		defer tw.Close()
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if _, err := io.Copy(tw, srcF); err != nil {
+			return err
+		}
+		return nil
+	})
+	defer func() {
+		if er := <-errC; err != nil {
+			err = er
+		}
+	}()
+	return archiver.Untar(r, filepath.Dir(dst), nil)
+}
+
+// CopyFileWithTar emulates the behavior of the 'cp' command-line
+// for a single file. It copies a regular file from path `src` to
+// path `dst`, and preserves all its metadata.
+//
+// Destination handling is in an operating specific manner depending
+// where the daemon is running. If `dst` ends with a trailing slash
+// the final destination path will be `dst/base(src)`  (Linux) or
+// `dst\base(src)` (Windows).
+func CopyFileWithTar(src, dst string) (err error) {
+	return defaultArchiver.CopyFileWithTar(src, dst)
+}
+
+// CmdStream executes a command, and returns its stdout as a stream.
+// If the command fails to run or doesn't complete successfully, an error
+// will be returned, including anything written on stderr.
+func CmdStream(cmd *exec.Cmd, input io.Reader) (io.ReadCloser, error) {
+	if input != nil {
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return nil, err
+		}
+		// Write stdin if any
+		go func() {
+			io.Copy(stdin, input)
+			stdin.Close()
+		}()
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	pipeR, pipeW := io.Pipe()
+	errChan := make(chan []byte)
+	// Collect stderr, we will use it in case of an error
+	go func() {
+		errText, e := ioutil.ReadAll(stderr)
+		if e != nil {
+			errText = []byte("(...couldn't fetch stderr: " + e.Error() + ")")
+		}
+		errChan <- errText
+	}()
+	// Copy stdout to the returned pipe
+	go func() {
+		_, err := io.Copy(pipeW, stdout)
+		if err != nil {
+			pipeW.CloseWithError(err)
+		}
+		errText := <-errChan
+		if err := cmd.Wait(); err != nil {
+			pipeW.CloseWithError(fmt.Errorf("%s: %s", err, errText))
+		} else {
+			pipeW.Close()
+		}
+	}()
+	// Run the command and return the pipe
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return pipeR, nil
+}
+
+// NewTempArchive reads the content of src into a temporary file, and returns the contents
+// of that file as an archive. The archive can only be read once - as soon as reading completes,
+// the file will be deleted.
+func NewTempArchive(src Archive, dir string) (*TempArchive, error) {
+	f, err := ioutil.TempFile(dir, "")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(f, src); err != nil {
+		return nil, err
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		return nil, err
+	}
+	st, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := st.Size()
+	return &TempArchive{File: f, Size: size}, nil
+}
+
+type TempArchive struct {
+	*os.File
+	Size   int64 // Pre-computed from Stat().Size() as a convenience
+	read   int64
+	closed bool
+}
+
+// Close closes the underlying file if it's still open, or does a no-op
+// to allow callers to try to close the TempArchive multiple times safely.
+func (archive *TempArchive) Close() error {
+	if archive.closed {
+		return nil
+	}
+
+	archive.closed = true
+
+	return archive.File.Close()
+}
+
+func (archive *TempArchive) Read(data []byte) (int, error) {
+	n, err := archive.File.Read(data)
+	archive.read += int64(n)
+	if err != nil || archive.read == archive.Size {
+		archive.Close()
+		os.Remove(archive.File.Name())
+	}
+	return n, err
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_test.go
@@ -1,0 +1,1204 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+func TestIsArchiveNilHeader(t *testing.T) {
+	out := IsArchive(nil)
+	if out {
+		t.Fatalf("isArchive should return false as nil is not a valid archive header")
+	}
+}
+
+func TestIsArchiveInvalidHeader(t *testing.T) {
+	header := []byte{0x00, 0x01, 0x02}
+	out := IsArchive(header)
+	if out {
+		t.Fatalf("isArchive should return false as %s is not a valid archive header", header)
+	}
+}
+
+func TestIsArchiveBzip2(t *testing.T) {
+	header := []byte{0x42, 0x5A, 0x68}
+	out := IsArchive(header)
+	if !out {
+		t.Fatalf("isArchive should return true as %s is a bz2 header", header)
+	}
+}
+
+func TestIsArchive7zip(t *testing.T) {
+	header := []byte{0x50, 0x4b, 0x03, 0x04}
+	out := IsArchive(header)
+	if out {
+		t.Fatalf("isArchive should return false as %s is a 7z header and it is not supported", header)
+	}
+}
+
+func TestDecompressStreamGzip(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "touch /tmp/archive && gzip -f /tmp/archive")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Fail to create an archive file for test : %s.", output)
+	}
+	archive, err := os.Open("/tmp/archive.gz")
+	_, err = DecompressStream(archive)
+	if err != nil {
+		t.Fatalf("Failed to decompress a gzip file.")
+	}
+}
+
+func TestDecompressStreamBzip2(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "touch /tmp/archive && bzip2 -f /tmp/archive")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Fail to create an archive file for test : %s.", output)
+	}
+	archive, err := os.Open("/tmp/archive.bz2")
+	_, err = DecompressStream(archive)
+	if err != nil {
+		t.Fatalf("Failed to decompress a bzip2 file.")
+	}
+}
+
+func TestDecompressStreamXz(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "touch /tmp/archive && xz -f /tmp/archive")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Fail to create an archive file for test : %s.", output)
+	}
+	archive, err := os.Open("/tmp/archive.xz")
+	_, err = DecompressStream(archive)
+	if err != nil {
+		t.Fatalf("Failed to decompress a xz file.")
+	}
+}
+
+func TestCompressStreamXzUnsuported(t *testing.T) {
+	dest, err := os.Create("/tmp/dest")
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	_, err = CompressStream(dest, Xz)
+	if err == nil {
+		t.Fatalf("Should fail as xz is unsupported for compression format.")
+	}
+}
+
+func TestCompressStreamBzip2Unsupported(t *testing.T) {
+	dest, err := os.Create("/tmp/dest")
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	_, err = CompressStream(dest, Xz)
+	if err == nil {
+		t.Fatalf("Should fail as xz is unsupported for compression format.")
+	}
+}
+
+func TestCompressStreamInvalid(t *testing.T) {
+	dest, err := os.Create("/tmp/dest")
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	_, err = CompressStream(dest, -1)
+	if err == nil {
+		t.Fatalf("Should fail as xz is unsupported for compression format.")
+	}
+}
+
+func TestExtensionInvalid(t *testing.T) {
+	compression := Compression(-1)
+	output := compression.Extension()
+	if output != "" {
+		t.Fatalf("The extension of an invalid compression should be an empty string.")
+	}
+}
+
+func TestExtensionUncompressed(t *testing.T) {
+	compression := Uncompressed
+	output := compression.Extension()
+	if output != "tar" {
+		t.Fatalf("The extension of a uncompressed archive should be 'tar'.")
+	}
+}
+func TestExtensionBzip2(t *testing.T) {
+	compression := Bzip2
+	output := compression.Extension()
+	if output != "tar.bz2" {
+		t.Fatalf("The extension of a bzip2 archive should be 'tar.bz2'")
+	}
+}
+func TestExtensionGzip(t *testing.T) {
+	compression := Gzip
+	output := compression.Extension()
+	if output != "tar.gz" {
+		t.Fatalf("The extension of a bzip2 archive should be 'tar.gz'")
+	}
+}
+func TestExtensionXz(t *testing.T) {
+	compression := Xz
+	output := compression.Extension()
+	if output != "tar.xz" {
+		t.Fatalf("The extension of a bzip2 archive should be 'tar.xz'")
+	}
+}
+
+func TestCmdStreamLargeStderr(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "dd if=/dev/zero bs=1k count=1000 of=/dev/stderr; echo hello")
+	out, err := CmdStream(cmd, nil)
+	if err != nil {
+		t.Fatalf("Failed to start command: %s", err)
+	}
+	errCh := make(chan error)
+	go func() {
+		_, err := io.Copy(ioutil.Discard, out)
+		errCh <- err
+	}()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Command should not have failed (err=%.100s...)", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Command did not complete in 5 seconds; probable deadlock")
+	}
+}
+
+func TestCmdStreamBad(t *testing.T) {
+	badCmd := exec.Command("/bin/sh", "-c", "echo hello; echo >&2 error couldn\\'t reverse the phase pulser; exit 1")
+	out, err := CmdStream(badCmd, nil)
+	if err != nil {
+		t.Fatalf("Failed to start command: %s", err)
+	}
+	if output, err := ioutil.ReadAll(out); err == nil {
+		t.Fatalf("Command should have failed")
+	} else if err.Error() != "exit status 1: error couldn't reverse the phase pulser\n" {
+		t.Fatalf("Wrong error value (%s)", err)
+	} else if s := string(output); s != "hello\n" {
+		t.Fatalf("Command output should be '%s', not '%s'", "hello\\n", output)
+	}
+}
+
+func TestCmdStreamGood(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "echo hello; exit 0")
+	out, err := CmdStream(cmd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output, err := ioutil.ReadAll(out); err != nil {
+		t.Fatalf("Command should not have failed (err=%s)", err)
+	} else if s := string(output); s != "hello\n" {
+		t.Fatalf("Command output should be '%s', not '%s'", "hello\\n", output)
+	}
+}
+
+func TestUntarPathWithInvalidDest(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempFolder)
+	invalidDestFolder := path.Join(tempFolder, "invalidDest")
+	// Create a src file
+	srcFile := path.Join(tempFolder, "src")
+	_, err = os.Create(srcFile)
+	if err != nil {
+		t.Fatalf("Fail to create the source file")
+	}
+	err = UntarPath(srcFile, invalidDestFolder)
+	if err == nil {
+		t.Fatalf("UntarPath with invalid destination path should throw an error.")
+	}
+}
+
+func TestUntarPathWithInvalidSrc(t *testing.T) {
+	dest, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	defer os.RemoveAll(dest)
+	err = UntarPath("/invalid/path", dest)
+	if err == nil {
+		t.Fatalf("UntarPath with invalid src path should throw an error.")
+	}
+}
+
+func TestUntarPath(t *testing.T) {
+	tmpFolder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpFolder)
+	srcFile := path.Join(tmpFolder, "src")
+	tarFile := path.Join(tmpFolder, "src.tar")
+	os.Create(path.Join(tmpFolder, "src"))
+	cmd := exec.Command("/bin/sh", "-c", "tar cf "+tarFile+" "+srcFile)
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	destFolder := path.Join(tmpFolder, "dest")
+	err = os.MkdirAll(destFolder, 0740)
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	err = UntarPath(tarFile, destFolder)
+	if err != nil {
+		t.Fatalf("UntarPath shouldn't throw an error, %s.", err)
+	}
+	expectedFile := path.Join(destFolder, srcFile)
+	_, err = os.Stat(expectedFile)
+	if err != nil {
+		t.Fatalf("Destination folder should contain the source file but did not.")
+	}
+}
+
+// Do the same test as above but with the destination as file, it should fail
+func TestUntarPathWithDestinationFile(t *testing.T) {
+	tmpFolder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpFolder)
+	srcFile := path.Join(tmpFolder, "src")
+	tarFile := path.Join(tmpFolder, "src.tar")
+	os.Create(path.Join(tmpFolder, "src"))
+	cmd := exec.Command("/bin/sh", "-c", "tar cf "+tarFile+" "+srcFile)
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	destFile := path.Join(tmpFolder, "dest")
+	_, err = os.Create(destFile)
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	err = UntarPath(tarFile, destFile)
+	if err == nil {
+		t.Fatalf("UntarPath should throw an error if the destination if a file")
+	}
+}
+
+// Do the same test as above but with the destination folder already exists
+// and the destination file is a directory
+// It's working, see https://github.com/docker/docker/issues/10040
+func TestUntarPathWithDestinationSrcFileAsFolder(t *testing.T) {
+	tmpFolder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpFolder)
+	srcFile := path.Join(tmpFolder, "src")
+	tarFile := path.Join(tmpFolder, "src.tar")
+	os.Create(srcFile)
+	cmd := exec.Command("/bin/sh", "-c", "tar cf "+tarFile+" "+srcFile)
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	destFolder := path.Join(tmpFolder, "dest")
+	err = os.MkdirAll(destFolder, 0740)
+	if err != nil {
+		t.Fatalf("Fail to create the destination folder")
+	}
+	// Let's create a folder that will has the same path as the extracted file (from tar)
+	destSrcFileAsFolder := path.Join(destFolder, srcFile)
+	err = os.MkdirAll(destSrcFileAsFolder, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = UntarPath(tarFile, destFolder)
+	if err != nil {
+		t.Fatalf("UntarPath should throw not throw an error if the extracted file already exists and is a folder")
+	}
+}
+
+func TestCopyWithTarInvalidSrc(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(nil)
+	}
+	destFolder := path.Join(tempFolder, "dest")
+	invalidSrc := path.Join(tempFolder, "doesnotexists")
+	err = os.MkdirAll(destFolder, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = CopyWithTar(invalidSrc, destFolder)
+	if err == nil {
+		t.Fatalf("archiver.CopyWithTar with invalid src path should throw an error.")
+	}
+}
+
+func TestCopyWithTarInexistentDestWillCreateIt(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(nil)
+	}
+	srcFolder := path.Join(tempFolder, "src")
+	inexistentDestFolder := path.Join(tempFolder, "doesnotexists")
+	err = os.MkdirAll(srcFolder, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = CopyWithTar(srcFolder, inexistentDestFolder)
+	if err != nil {
+		t.Fatalf("CopyWithTar with an inexistent folder shouldn't fail.")
+	}
+	_, err = os.Stat(inexistentDestFolder)
+	if err != nil {
+		t.Fatalf("CopyWithTar with an inexistent folder should create it.")
+	}
+}
+
+// Test CopyWithTar with a file as src
+func TestCopyWithTarSrcFile(t *testing.T) {
+	folder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(folder)
+	dest := path.Join(folder, "dest")
+	srcFolder := path.Join(folder, "src")
+	src := path.Join(folder, path.Join("src", "src"))
+	err = os.MkdirAll(srcFolder, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.MkdirAll(dest, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(src, []byte("content"), 0777)
+	err = CopyWithTar(src, dest)
+	if err != nil {
+		t.Fatalf("archiver.CopyWithTar shouldn't throw an error, %s.", err)
+	}
+	_, err = os.Stat(dest)
+	// FIXME Check the content
+	if err != nil {
+		t.Fatalf("Destination file should be the same as the source.")
+	}
+}
+
+// Test CopyWithTar with a folder as src
+func TestCopyWithTarSrcFolder(t *testing.T) {
+	folder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(folder)
+	dest := path.Join(folder, "dest")
+	src := path.Join(folder, path.Join("src", "folder"))
+	err = os.MkdirAll(src, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.MkdirAll(dest, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(path.Join(src, "file"), []byte("content"), 0777)
+	err = CopyWithTar(src, dest)
+	if err != nil {
+		t.Fatalf("archiver.CopyWithTar shouldn't throw an error, %s.", err)
+	}
+	_, err = os.Stat(dest)
+	// FIXME Check the content (the file inside)
+	if err != nil {
+		t.Fatalf("Destination folder should contain the source file but did not.")
+	}
+}
+
+func TestCopyFileWithTarInvalidSrc(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempFolder)
+	destFolder := path.Join(tempFolder, "dest")
+	err = os.MkdirAll(destFolder, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidFile := path.Join(tempFolder, "doesnotexists")
+	err = CopyFileWithTar(invalidFile, destFolder)
+	if err == nil {
+		t.Fatalf("archiver.CopyWithTar with invalid src path should throw an error.")
+	}
+}
+
+func TestCopyFileWithTarInexistentDestWillCreateIt(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(nil)
+	}
+	defer os.RemoveAll(tempFolder)
+	srcFile := path.Join(tempFolder, "src")
+	inexistentDestFolder := path.Join(tempFolder, "doesnotexists")
+	_, err = os.Create(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = CopyFileWithTar(srcFile, inexistentDestFolder)
+	if err != nil {
+		t.Fatalf("CopyWithTar with an inexistent folder shouldn't fail.")
+	}
+	_, err = os.Stat(inexistentDestFolder)
+	if err != nil {
+		t.Fatalf("CopyWithTar with an inexistent folder should create it.")
+	}
+	// FIXME Test the src file and content
+}
+
+func TestCopyFileWithTarSrcFolder(t *testing.T) {
+	folder, err := ioutil.TempDir("", "docker-archive-copyfilewithtar-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(folder)
+	dest := path.Join(folder, "dest")
+	src := path.Join(folder, "srcfolder")
+	err = os.MkdirAll(src, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.MkdirAll(dest, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = CopyFileWithTar(src, dest)
+	if err == nil {
+		t.Fatalf("CopyFileWithTar should throw an error with a folder.")
+	}
+}
+
+func TestCopyFileWithTarSrcFile(t *testing.T) {
+	folder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(folder)
+	dest := path.Join(folder, "dest")
+	srcFolder := path.Join(folder, "src")
+	src := path.Join(folder, path.Join("src", "src"))
+	err = os.MkdirAll(srcFolder, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.MkdirAll(dest, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(src, []byte("content"), 0777)
+	err = CopyWithTar(src, dest+"/")
+	if err != nil {
+		t.Fatalf("archiver.CopyFileWithTar shouldn't throw an error, %s.", err)
+	}
+	_, err = os.Stat(dest)
+	if err != nil {
+		t.Fatalf("Destination folder should contain the source file but did not.")
+	}
+}
+
+func TestTarFiles(t *testing.T) {
+	// try without hardlinks
+	if err := checkNoChanges(1000, false); err != nil {
+		t.Fatal(err)
+	}
+	// try with hardlinks
+	if err := checkNoChanges(1000, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkNoChanges(fileNum int, hardlinks bool) error {
+	srcDir, err := ioutil.TempDir("", "docker-test-srcDir")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(srcDir)
+
+	destDir, err := ioutil.TempDir("", "docker-test-destDir")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(destDir)
+
+	_, err = prepareUntarSourceDirectory(fileNum, srcDir, hardlinks)
+	if err != nil {
+		return err
+	}
+
+	err = TarUntar(srcDir, destDir)
+	if err != nil {
+		return err
+	}
+
+	changes, err := ChangesDirs(destDir, srcDir)
+	if err != nil {
+		return err
+	}
+	if len(changes) > 0 {
+		return fmt.Errorf("with %d files and %v hardlinks: expected 0 changes, got %d", fileNum, hardlinks, len(changes))
+	}
+	return nil
+}
+
+func tarUntar(t *testing.T, origin string, options *TarOptions) ([]Change, error) {
+	archive, err := TarWithOptions(origin, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archive.Close()
+
+	buf := make([]byte, 10)
+	if _, err := archive.Read(buf); err != nil {
+		return nil, err
+	}
+	wrap := io.MultiReader(bytes.NewReader(buf), archive)
+
+	detectedCompression := DetectCompression(buf)
+	compression := options.Compression
+	if detectedCompression.Extension() != compression.Extension() {
+		return nil, fmt.Errorf("Wrong compression detected. Actual compression: %s, found %s", compression.Extension(), detectedCompression.Extension())
+	}
+
+	tmp, err := ioutil.TempDir("", "docker-test-untar")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tmp)
+	if err := Untar(wrap, tmp, nil); err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(tmp); err != nil {
+		return nil, err
+	}
+
+	return ChangesDirs(origin, tmp)
+}
+
+func TestTarUntar(t *testing.T) {
+	origin, err := ioutil.TempDir("", "docker-test-untar-origin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(origin)
+	if err := ioutil.WriteFile(path.Join(origin, "1"), []byte("hello world"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(path.Join(origin, "2"), []byte("welcome!"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(path.Join(origin, "3"), []byte("will be ignored"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range []Compression{
+		Uncompressed,
+		Gzip,
+	} {
+		changes, err := tarUntar(t, origin, &TarOptions{
+			Compression:     c,
+			ExcludePatterns: []string{"3"},
+		})
+
+		if err != nil {
+			t.Fatalf("Error tar/untar for compression %s: %s", c.Extension(), err)
+		}
+
+		if len(changes) != 1 || changes[0].Path != "/3" {
+			t.Fatalf("Unexpected differences after tarUntar: %v", changes)
+		}
+	}
+}
+
+func TestTarUntarWithXattr(t *testing.T) {
+	origin, err := ioutil.TempDir("", "docker-test-untar-origin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(origin)
+	if err := ioutil.WriteFile(path.Join(origin, "1"), []byte("hello world"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(path.Join(origin, "2"), []byte("welcome!"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(path.Join(origin, "3"), []byte("will be ignored"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := system.Lsetxattr(path.Join(origin, "2"), "security.capability", []byte{0x00}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range []Compression{
+		Uncompressed,
+		Gzip,
+	} {
+		changes, err := tarUntar(t, origin, &TarOptions{
+			Compression:     c,
+			ExcludePatterns: []string{"3"},
+		})
+
+		if err != nil {
+			t.Fatalf("Error tar/untar for compression %s: %s", c.Extension(), err)
+		}
+
+		if len(changes) != 1 || changes[0].Path != "/3" {
+			t.Fatalf("Unexpected differences after tarUntar: %v", changes)
+		}
+		capability, _ := system.Lgetxattr(path.Join(origin, "2"), "security.capability")
+		if capability == nil && capability[0] != 0x00 {
+			t.Fatalf("Untar should have kept the 'security.capability' xattr.")
+		}
+	}
+}
+
+func TestTarWithOptions(t *testing.T) {
+	origin, err := ioutil.TempDir("", "docker-test-untar-origin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ioutil.TempDir(origin, "folder"); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(origin)
+	if err := ioutil.WriteFile(path.Join(origin, "1"), []byte("hello world"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(path.Join(origin, "2"), []byte("welcome!"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		opts       *TarOptions
+		numChanges int
+	}{
+		{&TarOptions{IncludeFiles: []string{"1"}}, 2},
+		{&TarOptions{ExcludePatterns: []string{"2"}}, 1},
+		{&TarOptions{ExcludePatterns: []string{"1", "folder*"}}, 2},
+		{&TarOptions{IncludeFiles: []string{"1", "1"}}, 2},
+		{&TarOptions{Name: "test", IncludeFiles: []string{"1"}}, 4},
+	}
+	for _, testCase := range cases {
+		changes, err := tarUntar(t, origin, testCase.opts)
+		if err != nil {
+			t.Fatalf("Error tar/untar when testing inclusion/exclusion: %s", err)
+		}
+		if len(changes) != testCase.numChanges {
+			t.Errorf("Expected %d changes, got %d for %+v:",
+				testCase.numChanges, len(changes), testCase.opts)
+		}
+	}
+}
+
+// Some tar archives such as http://haproxy.1wt.eu/download/1.5/src/devel/haproxy-1.5-dev21.tar.gz
+// use PAX Global Extended Headers.
+// Failing prevents the archives from being uncompressed during ADD
+func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
+	hdr := tar.Header{Typeflag: tar.TypeXGlobalHeader}
+	tmpDir, err := ioutil.TempDir("", "docker-test-archive-pax-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Some tar have both GNU specific (huge uid) and Ustar specific (long name) things.
+// Not supposed to happen (should use PAX instead of Ustar for long name) but it does and it should still work.
+func TestUntarUstarGnuConflict(t *testing.T) {
+	f, err := os.Open("testdata/broken.tar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	tr := tar.NewReader(f)
+	// Iterate through the files in the archive.
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Name == "root/.cpanm/work/1395823785.24209/Plack-1.0030/blib/man3/Plack::Middleware::LighttpdScriptNameFix.3pm" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("%s not found in the archive", "root/.cpanm/work/1395823785.24209/Plack-1.0030/blib/man3/Plack::Middleware::LighttpdScriptNameFix.3pm")
+	}
+}
+
+func TestTarWithBlockCharFifo(t *testing.T) {
+	origin, err := ioutil.TempDir("", "docker-test-tar-hardlink")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(origin)
+	if err := ioutil.WriteFile(path.Join(origin, "1"), []byte("hello world"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := system.Mknod(path.Join(origin, "2"), syscall.S_IFBLK, int(system.Mkdev(int64(12), int64(5)))); err != nil {
+		t.Fatal(err)
+	}
+	if err := system.Mknod(path.Join(origin, "3"), syscall.S_IFCHR, int(system.Mkdev(int64(12), int64(5)))); err != nil {
+		t.Fatal(err)
+	}
+	if err := system.Mknod(path.Join(origin, "4"), syscall.S_IFIFO, int(system.Mkdev(int64(12), int64(5)))); err != nil {
+		t.Fatal(err)
+	}
+
+	dest, err := ioutil.TempDir("", "docker-test-tar-hardlink-dest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dest)
+
+	// we'll do this in two steps to separate failure
+	fh, err := Tar(origin, Uncompressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure we can read the whole thing with no error, before writing back out
+	buf, err := ioutil.ReadAll(fh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bRdr := bytes.NewReader(buf)
+	err = Untar(bRdr, dest, &TarOptions{Compression: Uncompressed})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := ChangesDirs(origin, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) > 0 {
+		t.Fatalf("Tar with special device (block, char, fifo) should keep them (recreate them when untar) : %v", changes)
+	}
+}
+
+func TestTarWithHardLink(t *testing.T) {
+	origin, err := ioutil.TempDir("", "docker-test-tar-hardlink")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(origin)
+	if err := ioutil.WriteFile(path.Join(origin, "1"), []byte("hello world"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(path.Join(origin, "1"), path.Join(origin, "2")); err != nil {
+		t.Fatal(err)
+	}
+
+	var i1, i2 uint64
+	if i1, err = getNlink(path.Join(origin, "1")); err != nil {
+		t.Fatal(err)
+	}
+	// sanity check that we can hardlink
+	if i1 != 2 {
+		t.Skipf("skipping since hardlinks don't work here; expected 2 links, got %d", i1)
+	}
+
+	dest, err := ioutil.TempDir("", "docker-test-tar-hardlink-dest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dest)
+
+	// we'll do this in two steps to separate failure
+	fh, err := Tar(origin, Uncompressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure we can read the whole thing with no error, before writing back out
+	buf, err := ioutil.ReadAll(fh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bRdr := bytes.NewReader(buf)
+	err = Untar(bRdr, dest, &TarOptions{Compression: Uncompressed})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i1, err = getInode(path.Join(dest, "1")); err != nil {
+		t.Fatal(err)
+	}
+	if i2, err = getInode(path.Join(dest, "2")); err != nil {
+		t.Fatal(err)
+	}
+
+	if i1 != i2 {
+		t.Errorf("expected matching inodes, but got %d and %d", i1, i2)
+	}
+}
+
+func getNlink(path string) (uint64, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	statT, ok := stat.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("expected type *syscall.Stat_t, got %t", stat.Sys())
+	}
+	// We need this conversion on ARM64
+	return uint64(statT.Nlink), nil
+}
+
+func getInode(path string) (uint64, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	statT, ok := stat.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("expected type *syscall.Stat_t, got %t", stat.Sys())
+	}
+	return statT.Ino, nil
+}
+
+func prepareUntarSourceDirectory(numberOfFiles int, targetPath string, makeLinks bool) (int, error) {
+	fileData := []byte("fooo")
+	for n := 0; n < numberOfFiles; n++ {
+		fileName := fmt.Sprintf("file-%d", n)
+		if err := ioutil.WriteFile(path.Join(targetPath, fileName), fileData, 0700); err != nil {
+			return 0, err
+		}
+		if makeLinks {
+			if err := os.Link(path.Join(targetPath, fileName), path.Join(targetPath, fileName+"-link")); err != nil {
+				return 0, err
+			}
+		}
+	}
+	totalSize := numberOfFiles * len(fileData)
+	return totalSize, nil
+}
+
+func BenchmarkTarUntar(b *testing.B) {
+	origin, err := ioutil.TempDir("", "docker-test-untar-origin")
+	if err != nil {
+		b.Fatal(err)
+	}
+	tempDir, err := ioutil.TempDir("", "docker-test-untar-destination")
+	if err != nil {
+		b.Fatal(err)
+	}
+	target := path.Join(tempDir, "dest")
+	n, err := prepareUntarSourceDirectory(100, origin, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(origin)
+	defer os.RemoveAll(tempDir)
+
+	b.ResetTimer()
+	b.SetBytes(int64(n))
+	for n := 0; n < b.N; n++ {
+		err := TarUntar(origin, target)
+		if err != nil {
+			b.Fatal(err)
+		}
+		os.RemoveAll(target)
+	}
+}
+
+func BenchmarkTarUntarWithLinks(b *testing.B) {
+	origin, err := ioutil.TempDir("", "docker-test-untar-origin")
+	if err != nil {
+		b.Fatal(err)
+	}
+	tempDir, err := ioutil.TempDir("", "docker-test-untar-destination")
+	if err != nil {
+		b.Fatal(err)
+	}
+	target := path.Join(tempDir, "dest")
+	n, err := prepareUntarSourceDirectory(100, origin, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(origin)
+	defer os.RemoveAll(tempDir)
+
+	b.ResetTimer()
+	b.SetBytes(int64(n))
+	for n := 0; n < b.N; n++ {
+		err := TarUntar(origin, target)
+		if err != nil {
+			b.Fatal(err)
+		}
+		os.RemoveAll(target)
+	}
+}
+
+func TestUntarInvalidFilenames(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{
+			{
+				Name:     "../victim/dotdot",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{
+			{
+				// Note the leading slash
+				Name:     "/../victim/slash-dotdot",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("untar", "docker-TestUntarInvalidFilenames", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
+func TestUntarHardlinkToSymlink(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{
+			{
+				Name:     "symlink1",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "regfile",
+				Mode:     0644,
+			},
+			{
+				Name:     "symlink2",
+				Typeflag: tar.TypeLink,
+				Linkname: "symlink1",
+				Mode:     0644,
+			},
+			{
+				Name:     "regfile",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("untar", "docker-TestUntarHardlinkToSymlink", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
+func TestUntarInvalidHardlink(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{ // try reading victim/hello (../)
+			{
+				Name:     "dotdot",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (/../)
+			{
+				Name:     "slash-dotdot",
+				Typeflag: tar.TypeLink,
+				// Note the leading slash
+				Linkname: "/../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try writing victim/file
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim/file",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (hardlink, symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "symlink",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // Try reading victim/hello (hardlink, hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "hardlink",
+				Typeflag: tar.TypeLink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // Try removing victim directory (hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("untar", "docker-TestUntarInvalidHardlink", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
+func TestUntarInvalidSymlink(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{ // try reading victim/hello (../)
+			{
+				Name:     "dotdot",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (/../)
+			{
+				Name:     "slash-dotdot",
+				Typeflag: tar.TypeSymlink,
+				// Note the leading slash
+				Linkname: "/../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try writing victim/file
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim/file",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (symlink, symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "symlink",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (symlink, hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "hardlink",
+				Typeflag: tar.TypeLink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try removing victim directory (symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{ // try writing to victim/newdir/newfile with a symlink in the path
+			{
+				// this header needs to be before the next one, or else there is an error
+				Name:     "dir/loophole",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "dir/loophole/newdir/newfile",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("untar", "docker-TestUntarInvalidSymlink", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
+func TestTempArchiveCloseMultipleTimes(t *testing.T) {
+	reader := ioutil.NopCloser(strings.NewReader("hello"))
+	tempArchive, err := NewTempArchive(reader, "")
+	buf := make([]byte, 10)
+	n, err := tempArchive.Read(buf)
+	if n != 5 {
+		t.Fatalf("Expected to read 5 bytes. Read %d instead", n)
+	}
+	for i := 0; i < 3; i++ {
+		if err = tempArchive.Close(); err != nil {
+			t.Fatalf("i=%d. Unexpected error closing temp archive: %v", i, err)
+		}
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_unix.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_unix.go
@@ -1,0 +1,89 @@
+// +build !windows
+
+package archive
+
+import (
+	"archive/tar"
+	"errors"
+	"os"
+	"syscall"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+// CanonicalTarNameForPath returns platform-specific filepath
+// to canonical posix-style path for tar archival. p is relative
+// path.
+func CanonicalTarNameForPath(p string) (string, error) {
+	return p, nil // already unix-style
+}
+
+// chmodTarEntry is used to adjust the file permissions used in tar header based
+// on the platform the archival is done.
+
+func chmodTarEntry(perm os.FileMode) os.FileMode {
+	return perm // noop for unix as golang APIs provide perm bits correctly
+}
+
+func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
+	s, ok := stat.(*syscall.Stat_t)
+
+	if !ok {
+		err = errors.New("cannot convert stat value to syscall.Stat_t")
+		return
+	}
+
+	nlink = uint32(s.Nlink)
+	inode = uint64(s.Ino)
+
+	// Currently go does not fil in the major/minors
+	if s.Mode&syscall.S_IFBLK != 0 ||
+		s.Mode&syscall.S_IFCHR != 0 {
+		hdr.Devmajor = int64(major(uint64(s.Rdev)))
+		hdr.Devminor = int64(minor(uint64(s.Rdev)))
+	}
+
+	return
+}
+
+func major(device uint64) uint64 {
+	return (device >> 8) & 0xfff
+}
+
+func minor(device uint64) uint64 {
+	return (device & 0xff) | ((device >> 12) & 0xfff00)
+}
+
+// handleTarTypeBlockCharFifo is an OS-specific helper function used by
+// createTarFile to handle the following types of header: Block; Char; Fifo
+func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
+	mode := uint32(hdr.Mode & 07777)
+	switch hdr.Typeflag {
+	case tar.TypeBlock:
+		mode |= syscall.S_IFBLK
+	case tar.TypeChar:
+		mode |= syscall.S_IFCHR
+	case tar.TypeFifo:
+		mode |= syscall.S_IFIFO
+	}
+
+	if err := system.Mknod(path, mode, int(system.Mkdev(hdr.Devmajor, hdr.Devminor))); err != nil {
+		return err
+	}
+	return nil
+}
+
+func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+	if hdr.Typeflag == tar.TypeLink {
+		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+				return err
+			}
+		}
+	} else if hdr.Typeflag != tar.TypeSymlink {
+		if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_unix_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_unix_test.go
@@ -1,0 +1,60 @@
+// +build !windows
+
+package archive
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCanonicalTarNameForPath(t *testing.T) {
+	cases := []struct{ in, expected string }{
+		{"foo", "foo"},
+		{"foo/bar", "foo/bar"},
+		{"foo/dir/", "foo/dir/"},
+	}
+	for _, v := range cases {
+		if out, err := CanonicalTarNameForPath(v.in); err != nil {
+			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
+		} else if out != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		}
+	}
+}
+
+func TestCanonicalTarName(t *testing.T) {
+	cases := []struct {
+		in       string
+		isDir    bool
+		expected string
+	}{
+		{"foo", false, "foo"},
+		{"foo", true, "foo/"},
+		{"foo/bar", false, "foo/bar"},
+		{"foo/bar", true, "foo/bar/"},
+	}
+	for _, v := range cases {
+		if out, err := canonicalTarName(v.in, v.isDir); err != nil {
+			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
+		} else if out != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		}
+	}
+}
+
+func TestChmodTarEntry(t *testing.T) {
+	cases := []struct {
+		in, expected os.FileMode
+	}{
+		{0000, 0000},
+		{0777, 0777},
+		{0644, 0644},
+		{0755, 0755},
+		{0444, 0444},
+	}
+	for _, v := range cases {
+		if out := chmodTarEntry(v.in); out != v.expected {
+			t.Fatalf("wrong chmod. expected:%v got:%v", v.expected, out)
+		}
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_windows.go
@@ -1,0 +1,50 @@
+// +build windows
+
+package archive
+
+import (
+	"archive/tar"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// canonicalTarNameForPath returns platform-specific filepath
+// to canonical posix-style path for tar archival. p is relative
+// path.
+func CanonicalTarNameForPath(p string) (string, error) {
+	// windows: convert windows style relative path with backslashes
+	// into forward slashes. Since windows does not allow '/' or '\'
+	// in file names, it is mostly safe to replace however we must
+	// check just in case
+	if strings.Contains(p, "/") {
+		return "", fmt.Errorf("Windows path contains forward slash: %s", p)
+	}
+	return strings.Replace(p, string(os.PathSeparator), "/", -1), nil
+
+}
+
+// chmodTarEntry is used to adjust the file permissions used in tar header based
+// on the platform the archival is done.
+func chmodTarEntry(perm os.FileMode) os.FileMode {
+	perm &= 0755
+	// Add the x bit: make everything +x from windows
+	perm |= 0111
+
+	return perm
+}
+
+func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
+	// do nothing. no notion of Rdev, Inode, Nlink in stat on Windows
+	return
+}
+
+// handleTarTypeBlockCharFifo is an OS-specific helper function used by
+// createTarFile to handle the following types of header: Block; Char; Fifo
+func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
+	return nil
+}
+
+func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+	return nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_windows_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/archive_windows_test.go
@@ -1,0 +1,65 @@
+// +build windows
+
+package archive
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCanonicalTarNameForPath(t *testing.T) {
+	cases := []struct {
+		in, expected string
+		shouldFail   bool
+	}{
+		{"foo", "foo", false},
+		{"foo/bar", "___", true}, // unix-styled windows path must fail
+		{`foo\bar`, "foo/bar", false},
+	}
+	for _, v := range cases {
+		if out, err := CanonicalTarNameForPath(v.in); err != nil && !v.shouldFail {
+			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
+		} else if v.shouldFail && err == nil {
+			t.Fatalf("canonical path call should have failed with error. in=%s out=%s", v.in, out)
+		} else if !v.shouldFail && out != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		}
+	}
+}
+
+func TestCanonicalTarName(t *testing.T) {
+	cases := []struct {
+		in       string
+		isDir    bool
+		expected string
+	}{
+		{"foo", false, "foo"},
+		{"foo", true, "foo/"},
+		{`foo\bar`, false, "foo/bar"},
+		{`foo\bar`, true, "foo/bar/"},
+	}
+	for _, v := range cases {
+		if out, err := canonicalTarName(v.in, v.isDir); err != nil {
+			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
+		} else if out != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		}
+	}
+}
+
+func TestChmodTarEntry(t *testing.T) {
+	cases := []struct {
+		in, expected os.FileMode
+	}{
+		{0000, 0111},
+		{0777, 0755},
+		{0644, 0755},
+		{0755, 0755},
+		{0444, 0555},
+	}
+	for _, v := range cases {
+		if out := chmodTarEntry(v.in); out != v.expected {
+			t.Fatalf("wrong chmod. expected:%v got:%v", v.expected, out)
+		}
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes.go
@@ -1,0 +1,383 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+type ChangeType int
+
+const (
+	ChangeModify = iota
+	ChangeAdd
+	ChangeDelete
+)
+
+type Change struct {
+	Path string
+	Kind ChangeType
+}
+
+func (change *Change) String() string {
+	var kind string
+	switch change.Kind {
+	case ChangeModify:
+		kind = "C"
+	case ChangeAdd:
+		kind = "A"
+	case ChangeDelete:
+		kind = "D"
+	}
+	return fmt.Sprintf("%s %s", kind, change.Path)
+}
+
+// for sort.Sort
+type changesByPath []Change
+
+func (c changesByPath) Less(i, j int) bool { return c[i].Path < c[j].Path }
+func (c changesByPath) Len() int           { return len(c) }
+func (c changesByPath) Swap(i, j int)      { c[j], c[i] = c[i], c[j] }
+
+// Gnu tar and the go tar writer don't have sub-second mtime
+// precision, which is problematic when we apply changes via tar
+// files, we handle this by comparing for exact times, *or* same
+// second count and either a or b having exactly 0 nanoseconds
+func sameFsTime(a, b time.Time) bool {
+	return a == b ||
+		(a.Unix() == b.Unix() &&
+			(a.Nanosecond() == 0 || b.Nanosecond() == 0))
+}
+
+func sameFsTimeSpec(a, b syscall.Timespec) bool {
+	return a.Sec == b.Sec &&
+		(a.Nsec == b.Nsec || a.Nsec == 0 || b.Nsec == 0)
+}
+
+// Changes walks the path rw and determines changes for the files in the path,
+// with respect to the parent layers
+func Changes(layers []string, rw string) ([]Change, error) {
+	var (
+		changes     []Change
+		changedDirs = make(map[string]struct{})
+	)
+
+	err := filepath.Walk(rw, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Rebase path
+		path, err = filepath.Rel(rw, path)
+		if err != nil {
+			return err
+		}
+
+		// As this runs on the daemon side, file paths are OS specific.
+		path = filepath.Join(string(os.PathSeparator), path)
+
+		// Skip root
+		if path == string(os.PathSeparator) {
+			return nil
+		}
+
+		// Skip AUFS metadata
+		if matched, err := filepath.Match(string(os.PathSeparator)+".wh..wh.*", path); err != nil || matched {
+			return err
+		}
+
+		change := Change{
+			Path: path,
+		}
+
+		// Find out what kind of modification happened
+		file := filepath.Base(path)
+		// If there is a whiteout, then the file was removed
+		if strings.HasPrefix(file, ".wh.") {
+			originalFile := file[len(".wh."):]
+			change.Path = filepath.Join(filepath.Dir(path), originalFile)
+			change.Kind = ChangeDelete
+		} else {
+			// Otherwise, the file was added
+			change.Kind = ChangeAdd
+
+			// ...Unless it already existed in a top layer, in which case, it's a modification
+			for _, layer := range layers {
+				stat, err := os.Stat(filepath.Join(layer, path))
+				if err != nil && !os.IsNotExist(err) {
+					return err
+				}
+				if err == nil {
+					// The file existed in the top layer, so that's a modification
+
+					// However, if it's a directory, maybe it wasn't actually modified.
+					// If you modify /foo/bar/baz, then /foo will be part of the changed files only because it's the parent of bar
+					if stat.IsDir() && f.IsDir() {
+						if f.Size() == stat.Size() && f.Mode() == stat.Mode() && sameFsTime(f.ModTime(), stat.ModTime()) {
+							// Both directories are the same, don't record the change
+							return nil
+						}
+					}
+					change.Kind = ChangeModify
+					break
+				}
+			}
+		}
+
+		// If /foo/bar/file.txt is modified, then /foo/bar must be part of the changed files.
+		// This block is here to ensure the change is recorded even if the
+		// modify time, mode and size of the parent directoriy in the rw and ro layers are all equal.
+		// Check https://github.com/docker/docker/pull/13590 for details.
+		if f.IsDir() {
+			changedDirs[path] = struct{}{}
+		}
+		if change.Kind == ChangeAdd || change.Kind == ChangeDelete {
+			parent := filepath.Dir(path)
+			if _, ok := changedDirs[parent]; !ok && parent != "/" {
+				changes = append(changes, Change{Path: parent, Kind: ChangeModify})
+				changedDirs[parent] = struct{}{}
+			}
+		}
+
+		// Record change
+		changes = append(changes, change)
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return changes, nil
+}
+
+type FileInfo struct {
+	parent     *FileInfo
+	name       string
+	stat       *system.Stat_t
+	children   map[string]*FileInfo
+	capability []byte
+	added      bool
+}
+
+func (root *FileInfo) LookUp(path string) *FileInfo {
+	// As this runs on the daemon side, file paths are OS specific.
+	parent := root
+	if path == string(os.PathSeparator) {
+		return root
+	}
+
+	pathElements := strings.Split(path, string(os.PathSeparator))
+	for _, elem := range pathElements {
+		if elem != "" {
+			child := parent.children[elem]
+			if child == nil {
+				return nil
+			}
+			parent = child
+		}
+	}
+	return parent
+}
+
+func (info *FileInfo) path() string {
+	if info.parent == nil {
+		// As this runs on the daemon side, file paths are OS specific.
+		return string(os.PathSeparator)
+	}
+	return filepath.Join(info.parent.path(), info.name)
+}
+
+func (info *FileInfo) addChanges(oldInfo *FileInfo, changes *[]Change) {
+
+	sizeAtEntry := len(*changes)
+
+	if oldInfo == nil {
+		// add
+		change := Change{
+			Path: info.path(),
+			Kind: ChangeAdd,
+		}
+		*changes = append(*changes, change)
+		info.added = true
+	}
+
+	// We make a copy so we can modify it to detect additions
+	// also, we only recurse on the old dir if the new info is a directory
+	// otherwise any previous delete/change is considered recursive
+	oldChildren := make(map[string]*FileInfo)
+	if oldInfo != nil && info.isDir() {
+		for k, v := range oldInfo.children {
+			oldChildren[k] = v
+		}
+	}
+
+	for name, newChild := range info.children {
+		oldChild, _ := oldChildren[name]
+		if oldChild != nil {
+			// change?
+			oldStat := oldChild.stat
+			newStat := newChild.stat
+			// Note: We can't compare inode or ctime or blocksize here, because these change
+			// when copying a file into a container. However, that is not generally a problem
+			// because any content change will change mtime, and any status change should
+			// be visible when actually comparing the stat fields. The only time this
+			// breaks down is if some code intentionally hides a change by setting
+			// back mtime
+			if statDifferent(oldStat, newStat) ||
+				bytes.Compare(oldChild.capability, newChild.capability) != 0 {
+				change := Change{
+					Path: newChild.path(),
+					Kind: ChangeModify,
+				}
+				*changes = append(*changes, change)
+				newChild.added = true
+			}
+
+			// Remove from copy so we can detect deletions
+			delete(oldChildren, name)
+		}
+
+		newChild.addChanges(oldChild, changes)
+	}
+	for _, oldChild := range oldChildren {
+		// delete
+		change := Change{
+			Path: oldChild.path(),
+			Kind: ChangeDelete,
+		}
+		*changes = append(*changes, change)
+	}
+
+	// If there were changes inside this directory, we need to add it, even if the directory
+	// itself wasn't changed. This is needed to properly save and restore filesystem permissions.
+	// As this runs on the daemon side, file paths are OS specific.
+	if len(*changes) > sizeAtEntry && info.isDir() && !info.added && info.path() != string(os.PathSeparator) {
+		change := Change{
+			Path: info.path(),
+			Kind: ChangeModify,
+		}
+		// Let's insert the directory entry before the recently added entries located inside this dir
+		*changes = append(*changes, change) // just to resize the slice, will be overwritten
+		copy((*changes)[sizeAtEntry+1:], (*changes)[sizeAtEntry:])
+		(*changes)[sizeAtEntry] = change
+	}
+
+}
+
+func (info *FileInfo) Changes(oldInfo *FileInfo) []Change {
+	var changes []Change
+
+	info.addChanges(oldInfo, &changes)
+
+	return changes
+}
+
+func newRootFileInfo() *FileInfo {
+	// As this runs on the daemon side, file paths are OS specific.
+	root := &FileInfo{
+		name:     string(os.PathSeparator),
+		children: make(map[string]*FileInfo),
+	}
+	return root
+}
+
+// ChangesDirs compares two directories and generates an array of Change objects describing the changes.
+// If oldDir is "", then all files in newDir will be Add-Changes.
+func ChangesDirs(newDir, oldDir string) ([]Change, error) {
+	var (
+		oldRoot, newRoot *FileInfo
+	)
+	if oldDir == "" {
+		emptyDir, err := ioutil.TempDir("", "empty")
+		if err != nil {
+			return nil, err
+		}
+		defer os.Remove(emptyDir)
+		oldDir = emptyDir
+	}
+	oldRoot, newRoot, err := collectFileInfoForChanges(oldDir, newDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return newRoot.Changes(oldRoot), nil
+}
+
+// ChangesSize calculates the size in bytes of the provided changes, based on newDir.
+func ChangesSize(newDir string, changes []Change) int64 {
+	var size int64
+	for _, change := range changes {
+		if change.Kind == ChangeModify || change.Kind == ChangeAdd {
+			file := filepath.Join(newDir, change.Path)
+			fileInfo, _ := os.Lstat(file)
+			if fileInfo != nil && !fileInfo.IsDir() {
+				size += fileInfo.Size()
+			}
+		}
+	}
+	return size
+}
+
+// ExportChanges produces an Archive from the provided changes, relative to dir.
+func ExportChanges(dir string, changes []Change) (Archive, error) {
+	reader, writer := io.Pipe()
+	go func() {
+		ta := &tarAppender{
+			TarWriter: tar.NewWriter(writer),
+			Buffer:    pools.BufioWriter32KPool.Get(nil),
+			SeenFiles: make(map[uint64]string),
+		}
+		// this buffer is needed for the duration of this piped stream
+		defer pools.BufioWriter32KPool.Put(ta.Buffer)
+
+		sort.Sort(changesByPath(changes))
+
+		// In general we log errors here but ignore them because
+		// during e.g. a diff operation the container can continue
+		// mutating the filesystem and we can see transient errors
+		// from this
+		for _, change := range changes {
+			if change.Kind == ChangeDelete {
+				whiteOutDir := filepath.Dir(change.Path)
+				whiteOutBase := filepath.Base(change.Path)
+				whiteOut := filepath.Join(whiteOutDir, ".wh."+whiteOutBase)
+				timestamp := time.Now()
+				hdr := &tar.Header{
+					Name:       whiteOut[1:],
+					Size:       0,
+					ModTime:    timestamp,
+					AccessTime: timestamp,
+					ChangeTime: timestamp,
+				}
+				if err := ta.TarWriter.WriteHeader(hdr); err != nil {
+					logrus.Debugf("Can't write whiteout header: %s", err)
+				}
+			} else {
+				path := filepath.Join(dir, change.Path)
+				if err := ta.addTarFile(path, change.Path[1:]); err != nil {
+					logrus.Debugf("Can't add file %s to tar: %s", path, err)
+				}
+			}
+		}
+
+		// Make sure to check the error on Close.
+		if err := ta.TarWriter.Close(); err != nil {
+			logrus.Debugf("Can't close layer: %s", err)
+		}
+		if err := writer.Close(); err != nil {
+			logrus.Debugf("failed close Changes writer: %s", err)
+		}
+	}()
+	return reader, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_linux.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_linux.go
@@ -1,0 +1,285 @@
+package archive
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"syscall"
+	"unsafe"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+// walker is used to implement collectFileInfoForChanges on linux. Where this
+// method in general returns the entire contents of two directory trees, we
+// optimize some FS calls out on linux. In particular, we take advantage of the
+// fact that getdents(2) returns the inode of each file in the directory being
+// walked, which, when walking two trees in parallel to generate a list of
+// changes, can be used to prune subtrees without ever having to lstat(2) them
+// directly. Eliminating stat calls in this way can save up to seconds on large
+// images.
+type walker struct {
+	dir1  string
+	dir2  string
+	root1 *FileInfo
+	root2 *FileInfo
+}
+
+// collectFileInfoForChanges returns a complete representation of the trees
+// rooted at dir1 and dir2, with one important exception: any subtree or
+// leaf where the inode and device numbers are an exact match between dir1
+// and dir2 will be pruned from the results. This method is *only* to be used
+// to generating a list of changes between the two directories, as it does not
+// reflect the full contents.
+func collectFileInfoForChanges(dir1, dir2 string) (*FileInfo, *FileInfo, error) {
+	w := &walker{
+		dir1:  dir1,
+		dir2:  dir2,
+		root1: newRootFileInfo(),
+		root2: newRootFileInfo(),
+	}
+
+	i1, err := os.Lstat(w.dir1)
+	if err != nil {
+		return nil, nil, err
+	}
+	i2, err := os.Lstat(w.dir2)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := w.walk("/", i1, i2); err != nil {
+		return nil, nil, err
+	}
+
+	return w.root1, w.root2, nil
+}
+
+// Given a FileInfo, its path info, and a reference to the root of the tree
+// being constructed, register this file with the tree.
+func walkchunk(path string, fi os.FileInfo, dir string, root *FileInfo) error {
+	if fi == nil {
+		return nil
+	}
+	parent := root.LookUp(filepath.Dir(path))
+	if parent == nil {
+		return fmt.Errorf("collectFileInfoForChanges: Unexpectedly no parent for %s", path)
+	}
+	info := &FileInfo{
+		name:     filepath.Base(path),
+		children: make(map[string]*FileInfo),
+		parent:   parent,
+	}
+	cpath := filepath.Join(dir, path)
+	stat, err := system.FromStatT(fi.Sys().(*syscall.Stat_t))
+	if err != nil {
+		return err
+	}
+	info.stat = stat
+	info.capability, _ = system.Lgetxattr(cpath, "security.capability") // lgetxattr(2): fs access
+	parent.children[info.name] = info
+	return nil
+}
+
+// Walk a subtree rooted at the same path in both trees being iterated. For
+// example, /docker/overlay/1234/a/b/c/d and /docker/overlay/8888/a/b/c/d
+func (w *walker) walk(path string, i1, i2 os.FileInfo) (err error) {
+	// Register these nodes with the return trees, unless we're still at the
+	// (already-created) roots:
+	if path != "/" {
+		if err := walkchunk(path, i1, w.dir1, w.root1); err != nil {
+			return err
+		}
+		if err := walkchunk(path, i2, w.dir2, w.root2); err != nil {
+			return err
+		}
+	}
+
+	is1Dir := i1 != nil && i1.IsDir()
+	is2Dir := i2 != nil && i2.IsDir()
+
+	sameDevice := false
+	if i1 != nil && i2 != nil {
+		si1 := i1.Sys().(*syscall.Stat_t)
+		si2 := i2.Sys().(*syscall.Stat_t)
+		if si1.Dev == si2.Dev {
+			sameDevice = true
+		}
+	}
+
+	// If these files are both non-existent, or leaves (non-dirs), we are done.
+	if !is1Dir && !is2Dir {
+		return nil
+	}
+
+	// Fetch the names of all the files contained in both directories being walked:
+	var names1, names2 []nameIno
+	if is1Dir {
+		names1, err = readdirnames(filepath.Join(w.dir1, path)) // getdents(2): fs access
+		if err != nil {
+			return err
+		}
+	}
+	if is2Dir {
+		names2, err = readdirnames(filepath.Join(w.dir2, path)) // getdents(2): fs access
+		if err != nil {
+			return err
+		}
+	}
+
+	// We have lists of the files contained in both parallel directories, sorted
+	// in the same order. Walk them in parallel, generating a unique merged list
+	// of all items present in either or both directories.
+	var names []string
+	ix1 := 0
+	ix2 := 0
+
+	for {
+		if ix1 >= len(names1) {
+			break
+		}
+		if ix2 >= len(names2) {
+			break
+		}
+
+		ni1 := names1[ix1]
+		ni2 := names2[ix2]
+
+		switch bytes.Compare([]byte(ni1.name), []byte(ni2.name)) {
+		case -1: // ni1 < ni2 -- advance ni1
+			// we will not encounter ni1 in names2
+			names = append(names, ni1.name)
+			ix1++
+		case 0: // ni1 == ni2
+			if ni1.ino != ni2.ino || !sameDevice {
+				names = append(names, ni1.name)
+			}
+			ix1++
+			ix2++
+		case 1: // ni1 > ni2 -- advance ni2
+			// we will not encounter ni2 in names1
+			names = append(names, ni2.name)
+			ix2++
+		}
+	}
+	for ix1 < len(names1) {
+		names = append(names, names1[ix1].name)
+		ix1++
+	}
+	for ix2 < len(names2) {
+		names = append(names, names2[ix2].name)
+		ix2++
+	}
+
+	// For each of the names present in either or both of the directories being
+	// iterated, stat the name under each root, and recurse the pair of them:
+	for _, name := range names {
+		fname := filepath.Join(path, name)
+		var cInfo1, cInfo2 os.FileInfo
+		if is1Dir {
+			cInfo1, err = os.Lstat(filepath.Join(w.dir1, fname)) // lstat(2): fs access
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+		if is2Dir {
+			cInfo2, err = os.Lstat(filepath.Join(w.dir2, fname)) // lstat(2): fs access
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+		if err = w.walk(fname, cInfo1, cInfo2); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// {name,inode} pairs used to support the early-pruning logic of the walker type
+type nameIno struct {
+	name string
+	ino  uint64
+}
+
+type nameInoSlice []nameIno
+
+func (s nameInoSlice) Len() int           { return len(s) }
+func (s nameInoSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s nameInoSlice) Less(i, j int) bool { return s[i].name < s[j].name }
+
+// readdirnames is a hacked-apart version of the Go stdlib code, exposing inode
+// numbers further up the stack when reading directory contents. Unlike
+// os.Readdirnames, which returns a list of filenames, this function returns a
+// list of {filename,inode} pairs.
+func readdirnames(dirname string) (names []nameIno, err error) {
+	var (
+		size = 100
+		buf  = make([]byte, 4096)
+		nbuf int
+		bufp int
+		nb   int
+	)
+
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	names = make([]nameIno, 0, size) // Empty with room to grow.
+	for {
+		// Refill the buffer if necessary
+		if bufp >= nbuf {
+			bufp = 0
+			nbuf, err = syscall.ReadDirent(int(f.Fd()), buf) // getdents on linux
+			if nbuf < 0 {
+				nbuf = 0
+			}
+			if err != nil {
+				return nil, os.NewSyscallError("readdirent", err)
+			}
+			if nbuf <= 0 {
+				break // EOF
+			}
+		}
+
+		// Drain the buffer
+		nb, names = parseDirent(buf[bufp:nbuf], names)
+		bufp += nb
+	}
+
+	sl := nameInoSlice(names)
+	sort.Sort(sl)
+	return sl, nil
+}
+
+// parseDirent is a minor modification of syscall.ParseDirent (linux version)
+// which returns {name,inode} pairs instead of just names.
+func parseDirent(buf []byte, names []nameIno) (consumed int, newnames []nameIno) {
+	origlen := len(buf)
+	for len(buf) > 0 {
+		dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[0]))
+		buf = buf[dirent.Reclen:]
+		if dirent.Ino == 0 { // File absent in directory.
+			continue
+		}
+		bytes := (*[10000]byte)(unsafe.Pointer(&dirent.Name[0]))
+		var name = string(bytes[0:clen(bytes[:])])
+		if name == "." || name == ".." { // Useless names
+			continue
+		}
+		names = append(names, nameIno{name, dirent.Ino})
+	}
+	return origlen - len(buf), names
+}
+
+func clen(n []byte) int {
+	for i := 0; i < len(n); i++ {
+		if n[i] == 0 {
+			return i
+		}
+	}
+	return len(n)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_other.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_other.go
@@ -1,0 +1,97 @@
+// +build !linux
+
+package archive
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+func collectFileInfoForChanges(oldDir, newDir string) (*FileInfo, *FileInfo, error) {
+	var (
+		oldRoot, newRoot *FileInfo
+		err1, err2       error
+		errs             = make(chan error, 2)
+	)
+	go func() {
+		oldRoot, err1 = collectFileInfo(oldDir)
+		errs <- err1
+	}()
+	go func() {
+		newRoot, err2 = collectFileInfo(newDir)
+		errs <- err2
+	}()
+
+	// block until both routines have returned
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return oldRoot, newRoot, nil
+}
+
+func collectFileInfo(sourceDir string) (*FileInfo, error) {
+	root := newRootFileInfo()
+
+	err := filepath.Walk(sourceDir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Rebase path
+		relPath, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+
+		// As this runs on the daemon side, file paths are OS specific.
+		relPath = filepath.Join(string(os.PathSeparator), relPath)
+
+		// See https://github.com/golang/go/issues/9168 - bug in filepath.Join.
+		// Temporary workaround. If the returned path starts with two backslashes,
+		// trim it down to a single backslash. Only relevant on Windows.
+		if runtime.GOOS == "windows" {
+			if strings.HasPrefix(relPath, `\\`) {
+				relPath = relPath[1:]
+			}
+		}
+
+		if relPath == string(os.PathSeparator) {
+			return nil
+		}
+
+		parent := root.LookUp(filepath.Dir(relPath))
+		if parent == nil {
+			return fmt.Errorf("collectFileInfo: Unexpectedly no parent for %s", relPath)
+		}
+
+		info := &FileInfo{
+			name:     filepath.Base(relPath),
+			children: make(map[string]*FileInfo),
+			parent:   parent,
+		}
+
+		s, err := system.Lstat(path)
+		if err != nil {
+			return err
+		}
+		info.stat = s
+
+		info.capability, _ = system.Lgetxattr(path, "security.capability")
+
+		parent.children[info.name] = info
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return root, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_posix_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_posix_test.go
@@ -1,0 +1,127 @@
+package archive
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"sort"
+	"testing"
+)
+
+func TestHardLinkOrder(t *testing.T) {
+	names := []string{"file1.txt", "file2.txt", "file3.txt"}
+	msg := []byte("Hey y'all")
+
+	// Create dir
+	src, err := ioutil.TempDir("", "docker-hardlink-test-src-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	//defer os.RemoveAll(src)
+	for _, name := range names {
+		func() {
+			fh, err := os.Create(path.Join(src, name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fh.Close()
+			if _, err = fh.Write(msg); err != nil {
+				t.Fatal(err)
+			}
+		}()
+	}
+	// Create dest, with changes that includes hardlinks
+	dest, err := ioutil.TempDir("", "docker-hardlink-test-dest-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.RemoveAll(dest) // we just want the name, at first
+	if err := copyDir(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dest)
+	for _, name := range names {
+		for i := 0; i < 5; i++ {
+			if err := os.Link(path.Join(dest, name), path.Join(dest, fmt.Sprintf("%s.link%d", name, i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// get changes
+	changes, err := ChangesDirs(dest, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sort
+	sort.Sort(changesByPath(changes))
+
+	// ExportChanges
+	ar, err := ExportChanges(dest, changes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdrs, err := walkHeaders(ar)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// reverse sort
+	sort.Sort(sort.Reverse(changesByPath(changes)))
+	// ExportChanges
+	arRev, err := ExportChanges(dest, changes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdrsRev, err := walkHeaders(arRev)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// line up the two sets
+	sort.Sort(tarHeaders(hdrs))
+	sort.Sort(tarHeaders(hdrsRev))
+
+	// compare Size and LinkName
+	for i := range hdrs {
+		if hdrs[i].Name != hdrsRev[i].Name {
+			t.Errorf("headers - expected name %q; but got %q", hdrs[i].Name, hdrsRev[i].Name)
+		}
+		if hdrs[i].Size != hdrsRev[i].Size {
+			t.Errorf("headers - %q expected size %d; but got %d", hdrs[i].Name, hdrs[i].Size, hdrsRev[i].Size)
+		}
+		if hdrs[i].Typeflag != hdrsRev[i].Typeflag {
+			t.Errorf("headers - %q expected type %d; but got %d", hdrs[i].Name, hdrs[i].Typeflag, hdrsRev[i].Typeflag)
+		}
+		if hdrs[i].Linkname != hdrsRev[i].Linkname {
+			t.Errorf("headers - %q expected linkname %q; but got %q", hdrs[i].Name, hdrs[i].Linkname, hdrsRev[i].Linkname)
+		}
+	}
+
+}
+
+type tarHeaders []tar.Header
+
+func (th tarHeaders) Len() int           { return len(th) }
+func (th tarHeaders) Swap(i, j int)      { th[j], th[i] = th[i], th[j] }
+func (th tarHeaders) Less(i, j int) bool { return th[i].Name < th[j].Name }
+
+func walkHeaders(r io.Reader) ([]tar.Header, error) {
+	t := tar.NewReader(r)
+	headers := []tar.Header{}
+	for {
+		hdr, err := t.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return headers, err
+		}
+		headers = append(headers, *hdr)
+	}
+	return headers, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_test.go
@@ -1,0 +1,495 @@
+package archive
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"sort"
+	"testing"
+	"time"
+)
+
+func max(x, y int) int {
+	if x >= y {
+		return x
+	}
+	return y
+}
+
+func copyDir(src, dst string) error {
+	cmd := exec.Command("cp", "-a", src, dst)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+type FileType uint32
+
+const (
+	Regular FileType = iota
+	Dir
+	Symlink
+)
+
+type FileData struct {
+	filetype    FileType
+	path        string
+	contents    string
+	permissions os.FileMode
+}
+
+func createSampleDir(t *testing.T, root string) {
+	files := []FileData{
+		{Regular, "file1", "file1\n", 0600},
+		{Regular, "file2", "file2\n", 0666},
+		{Regular, "file3", "file3\n", 0404},
+		{Regular, "file4", "file4\n", 0600},
+		{Regular, "file5", "file5\n", 0600},
+		{Regular, "file6", "file6\n", 0600},
+		{Regular, "file7", "file7\n", 0600},
+		{Dir, "dir1", "", 0740},
+		{Regular, "dir1/file1-1", "file1-1\n", 01444},
+		{Regular, "dir1/file1-2", "file1-2\n", 0666},
+		{Dir, "dir2", "", 0700},
+		{Regular, "dir2/file2-1", "file2-1\n", 0666},
+		{Regular, "dir2/file2-2", "file2-2\n", 0666},
+		{Dir, "dir3", "", 0700},
+		{Regular, "dir3/file3-1", "file3-1\n", 0666},
+		{Regular, "dir3/file3-2", "file3-2\n", 0666},
+		{Dir, "dir4", "", 0700},
+		{Regular, "dir4/file3-1", "file4-1\n", 0666},
+		{Regular, "dir4/file3-2", "file4-2\n", 0666},
+		{Symlink, "symlink1", "target1", 0666},
+		{Symlink, "symlink2", "target2", 0666},
+	}
+
+	now := time.Now()
+	for _, info := range files {
+		p := path.Join(root, info.path)
+		if info.filetype == Dir {
+			if err := os.MkdirAll(p, info.permissions); err != nil {
+				t.Fatal(err)
+			}
+		} else if info.filetype == Regular {
+			if err := ioutil.WriteFile(p, []byte(info.contents), info.permissions); err != nil {
+				t.Fatal(err)
+			}
+		} else if info.filetype == Symlink {
+			if err := os.Symlink(info.contents, p); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if info.filetype != Symlink {
+			// Set a consistent ctime, atime for all files and dirs
+			if err := os.Chtimes(p, now, now); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+func TestChangeString(t *testing.T) {
+	modifiyChange := Change{"change", ChangeModify}
+	toString := modifiyChange.String()
+	if toString != "C change" {
+		t.Fatalf("String() of a change with ChangeModifiy Kind should have been %s but was %s", "C change", toString)
+	}
+	addChange := Change{"change", ChangeAdd}
+	toString = addChange.String()
+	if toString != "A change" {
+		t.Fatalf("String() of a change with ChangeAdd Kind should have been %s but was %s", "A change", toString)
+	}
+	deleteChange := Change{"change", ChangeDelete}
+	toString = deleteChange.String()
+	if toString != "D change" {
+		t.Fatalf("String() of a change with ChangeDelete Kind should have been %s but was %s", "D change", toString)
+	}
+}
+
+func TestChangesWithNoChanges(t *testing.T) {
+	rwLayer, err := ioutil.TempDir("", "docker-changes-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(rwLayer)
+	layer, err := ioutil.TempDir("", "docker-changes-test-layer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(layer)
+	createSampleDir(t, layer)
+	changes, err := Changes([]string{layer}, rwLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 0 {
+		t.Fatalf("Changes with no difference should have detect no changes, but detected %d", len(changes))
+	}
+}
+
+func TestChangesWithChanges(t *testing.T) {
+	// Mock the readonly layer
+	layer, err := ioutil.TempDir("", "docker-changes-test-layer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(layer)
+	createSampleDir(t, layer)
+	os.MkdirAll(path.Join(layer, "dir1/subfolder"), 0740)
+
+	// Mock the RW layer
+	rwLayer, err := ioutil.TempDir("", "docker-changes-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(rwLayer)
+
+	// Create a folder in RW layer
+	dir1 := path.Join(rwLayer, "dir1")
+	os.MkdirAll(dir1, 0740)
+	deletedFile := path.Join(dir1, ".wh.file1-2")
+	ioutil.WriteFile(deletedFile, []byte{}, 0600)
+	modifiedFile := path.Join(dir1, "file1-1")
+	ioutil.WriteFile(modifiedFile, []byte{0x00}, 01444)
+	// Let's add a subfolder for a newFile
+	subfolder := path.Join(dir1, "subfolder")
+	os.MkdirAll(subfolder, 0740)
+	newFile := path.Join(subfolder, "newFile")
+	ioutil.WriteFile(newFile, []byte{}, 0740)
+
+	changes, err := Changes([]string{layer}, rwLayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedChanges := []Change{
+		{"/dir1", ChangeModify},
+		{"/dir1/file1-1", ChangeModify},
+		{"/dir1/file1-2", ChangeDelete},
+		{"/dir1/subfolder", ChangeModify},
+		{"/dir1/subfolder/newFile", ChangeAdd},
+	}
+	checkChanges(expectedChanges, changes, t)
+}
+
+// See https://github.com/docker/docker/pull/13590
+func TestChangesWithChangesGH13590(t *testing.T) {
+	baseLayer, err := ioutil.TempDir("", "docker-changes-test.")
+	defer os.RemoveAll(baseLayer)
+
+	dir3 := path.Join(baseLayer, "dir1/dir2/dir3")
+	os.MkdirAll(dir3, 07400)
+
+	file := path.Join(dir3, "file.txt")
+	ioutil.WriteFile(file, []byte("hello"), 0666)
+
+	layer, err := ioutil.TempDir("", "docker-changes-test2.")
+	defer os.RemoveAll(layer)
+
+	// Test creating a new file
+	if err := copyDir(baseLayer+"/dir1", layer+"/"); err != nil {
+		t.Fatalf("Cmd failed: %q", err)
+	}
+
+	os.Remove(path.Join(layer, "dir1/dir2/dir3/file.txt"))
+	file = path.Join(layer, "dir1/dir2/dir3/file1.txt")
+	ioutil.WriteFile(file, []byte("bye"), 0666)
+
+	changes, err := Changes([]string{baseLayer}, layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedChanges := []Change{
+		{"/dir1/dir2/dir3", ChangeModify},
+		{"/dir1/dir2/dir3/file1.txt", ChangeAdd},
+	}
+	checkChanges(expectedChanges, changes, t)
+
+	// Now test changing a file
+	layer, err = ioutil.TempDir("", "docker-changes-test3.")
+	defer os.RemoveAll(layer)
+
+	if err := copyDir(baseLayer+"/dir1", layer+"/"); err != nil {
+		t.Fatalf("Cmd failed: %q", err)
+	}
+
+	file = path.Join(layer, "dir1/dir2/dir3/file.txt")
+	ioutil.WriteFile(file, []byte("bye"), 0666)
+
+	changes, err = Changes([]string{baseLayer}, layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedChanges = []Change{
+		{"/dir1/dir2/dir3/file.txt", ChangeModify},
+	}
+	checkChanges(expectedChanges, changes, t)
+}
+
+// Create an directory, copy it, make sure we report no changes between the two
+func TestChangesDirsEmpty(t *testing.T) {
+	src, err := ioutil.TempDir("", "docker-changes-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(src)
+	createSampleDir(t, src)
+	dst := src + "-copy"
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dst)
+	changes, err := ChangesDirs(dst, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(changes) != 0 {
+		t.Fatalf("Reported changes for identical dirs: %v", changes)
+	}
+	os.RemoveAll(src)
+	os.RemoveAll(dst)
+}
+
+func mutateSampleDir(t *testing.T, root string) {
+	// Remove a regular file
+	if err := os.RemoveAll(path.Join(root, "file1")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove a directory
+	if err := os.RemoveAll(path.Join(root, "dir1")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove a symlink
+	if err := os.RemoveAll(path.Join(root, "symlink1")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite a file
+	if err := ioutil.WriteFile(path.Join(root, "file2"), []byte("fileNN\n"), 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace a file
+	if err := os.RemoveAll(path.Join(root, "file3")); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(path.Join(root, "file3"), []byte("fileMM\n"), 0404); err != nil {
+		t.Fatal(err)
+	}
+
+	// Touch file
+	if err := os.Chtimes(path.Join(root, "file4"), time.Now().Add(time.Second), time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace file with dir
+	if err := os.RemoveAll(path.Join(root, "file5")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(path.Join(root, "file5"), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create new file
+	if err := ioutil.WriteFile(path.Join(root, "filenew"), []byte("filenew\n"), 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create new dir
+	if err := os.MkdirAll(path.Join(root, "dirnew"), 0766); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new symlink
+	if err := os.Symlink("targetnew", path.Join(root, "symlinknew")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change a symlink
+	if err := os.RemoveAll(path.Join(root, "symlink2")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target2change", path.Join(root, "symlink2")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace dir with file
+	if err := os.RemoveAll(path.Join(root, "dir2")); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(path.Join(root, "dir2"), []byte("dir2\n"), 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	// Touch dir
+	if err := os.Chtimes(path.Join(root, "dir3"), time.Now().Add(time.Second), time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestChangesDirsMutated(t *testing.T) {
+	src, err := ioutil.TempDir("", "docker-changes-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	createSampleDir(t, src)
+	dst := src + "-copy"
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(src)
+	defer os.RemoveAll(dst)
+
+	mutateSampleDir(t, dst)
+
+	changes, err := ChangesDirs(dst, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Sort(changesByPath(changes))
+
+	expectedChanges := []Change{
+		{"/dir1", ChangeDelete},
+		{"/dir2", ChangeModify},
+		{"/dirnew", ChangeAdd},
+		{"/file1", ChangeDelete},
+		{"/file2", ChangeModify},
+		{"/file3", ChangeModify},
+		{"/file4", ChangeModify},
+		{"/file5", ChangeModify},
+		{"/filenew", ChangeAdd},
+		{"/symlink1", ChangeDelete},
+		{"/symlink2", ChangeModify},
+		{"/symlinknew", ChangeAdd},
+	}
+
+	for i := 0; i < max(len(changes), len(expectedChanges)); i++ {
+		if i >= len(expectedChanges) {
+			t.Fatalf("unexpected change %s\n", changes[i].String())
+		}
+		if i >= len(changes) {
+			t.Fatalf("no change for expected change %s\n", expectedChanges[i].String())
+		}
+		if changes[i].Path == expectedChanges[i].Path {
+			if changes[i] != expectedChanges[i] {
+				t.Fatalf("Wrong change for %s, expected %s, got %s\n", changes[i].Path, changes[i].String(), expectedChanges[i].String())
+			}
+		} else if changes[i].Path < expectedChanges[i].Path {
+			t.Fatalf("unexpected change %s\n", changes[i].String())
+		} else {
+			t.Fatalf("no change for expected change %s != %s\n", expectedChanges[i].String(), changes[i].String())
+		}
+	}
+}
+
+func TestApplyLayer(t *testing.T) {
+	src, err := ioutil.TempDir("", "docker-changes-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	createSampleDir(t, src)
+	defer os.RemoveAll(src)
+	dst := src + "-copy"
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	mutateSampleDir(t, dst)
+	defer os.RemoveAll(dst)
+
+	changes, err := ChangesDirs(dst, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layer, err := ExportChanges(dst, changes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layerCopy, err := NewTempArchive(layer, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ApplyLayer(src, layerCopy); err != nil {
+		t.Fatal(err)
+	}
+
+	changes2, err := ChangesDirs(src, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(changes2) != 0 {
+		t.Fatalf("Unexpected differences after reapplying mutation: %v", changes2)
+	}
+}
+
+func TestChangesSizeWithNoChanges(t *testing.T) {
+	size := ChangesSize("/tmp", nil)
+	if size != 0 {
+		t.Fatalf("ChangesSizes with no changes should be 0, was %d", size)
+	}
+}
+
+func TestChangesSizeWithOnlyDeleteChanges(t *testing.T) {
+	changes := []Change{
+		{Path: "deletedPath", Kind: ChangeDelete},
+	}
+	size := ChangesSize("/tmp", changes)
+	if size != 0 {
+		t.Fatalf("ChangesSizes with only delete changes should be 0, was %d", size)
+	}
+}
+
+func TestChangesSize(t *testing.T) {
+	parentPath, err := ioutil.TempDir("", "docker-changes-test")
+	defer os.RemoveAll(parentPath)
+	addition := path.Join(parentPath, "addition")
+	if err := ioutil.WriteFile(addition, []byte{0x01, 0x01, 0x01}, 0744); err != nil {
+		t.Fatal(err)
+	}
+	modification := path.Join(parentPath, "modification")
+	if err = ioutil.WriteFile(modification, []byte{0x01, 0x01, 0x01}, 0744); err != nil {
+		t.Fatal(err)
+	}
+	changes := []Change{
+		{Path: "addition", Kind: ChangeAdd},
+		{Path: "modification", Kind: ChangeModify},
+	}
+	size := ChangesSize(parentPath, changes)
+	if size != 6 {
+		t.Fatalf("ChangesSizes with only delete changes should be 0, was %d", size)
+	}
+}
+
+func checkChanges(expectedChanges, changes []Change, t *testing.T) {
+	sort.Sort(changesByPath(expectedChanges))
+	sort.Sort(changesByPath(changes))
+	for i := 0; i < max(len(changes), len(expectedChanges)); i++ {
+		if i >= len(expectedChanges) {
+			t.Fatalf("unexpected change %s\n", changes[i].String())
+		}
+		if i >= len(changes) {
+			t.Fatalf("no change for expected change %s\n", expectedChanges[i].String())
+		}
+		if changes[i].Path == expectedChanges[i].Path {
+			if changes[i] != expectedChanges[i] {
+				t.Fatalf("Wrong change for %s, expected %s, got %s\n", changes[i].Path, changes[i].String(), expectedChanges[i].String())
+			}
+		} else if changes[i].Path < expectedChanges[i].Path {
+			t.Fatalf("unexpected change %s\n", changes[i].String())
+		} else {
+			t.Fatalf("no change for expected change %s != %s\n", expectedChanges[i].String(), changes[i].String())
+		}
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_unix.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_unix.go
@@ -1,0 +1,27 @@
+// +build !windows
+
+package archive
+
+import (
+	"syscall"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+func statDifferent(oldStat *system.Stat_t, newStat *system.Stat_t) bool {
+	// Don't look at size for dirs, its not a good measure of change
+	if oldStat.Mode() != newStat.Mode() ||
+		oldStat.Uid() != newStat.Uid() ||
+		oldStat.Gid() != newStat.Gid() ||
+		oldStat.Rdev() != newStat.Rdev() ||
+		// Don't look at size for dirs, its not a good measure of change
+		(oldStat.Mode()&syscall.S_IFDIR != syscall.S_IFDIR &&
+			(!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) || (oldStat.Size() != newStat.Size()))) {
+		return true
+	}
+	return false
+}
+
+func (info *FileInfo) isDir() bool {
+	return info.parent == nil || info.stat.Mode()&syscall.S_IFDIR != 0
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/changes_windows.go
@@ -1,0 +1,20 @@
+package archive
+
+import (
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+func statDifferent(oldStat *system.Stat_t, newStat *system.Stat_t) bool {
+
+	// Don't look at size for dirs, its not a good measure of change
+	if oldStat.ModTime() != newStat.ModTime() ||
+		oldStat.Mode() != newStat.Mode() ||
+		oldStat.Size() != newStat.Size() && !oldStat.IsDir() {
+		return true
+	}
+	return false
+}
+
+func (info *FileInfo) isDir() bool {
+	return info.parent == nil || info.stat.IsDir()
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/copy.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/copy.go
@@ -1,0 +1,308 @@
+package archive
+
+import (
+	"archive/tar"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+)
+
+// Errors used or returned by this file.
+var (
+	ErrNotDirectory      = errors.New("not a directory")
+	ErrDirNotExists      = errors.New("no such directory")
+	ErrCannotCopyDir     = errors.New("cannot copy directory")
+	ErrInvalidCopySource = errors.New("invalid copy source content")
+)
+
+// PreserveTrailingDotOrSeparator returns the given cleaned path (after
+// processing using any utility functions from the path or filepath stdlib
+// packages) and appends a trailing `/.` or `/` if its corresponding  original
+// path (from before being processed by utility functions from the path or
+// filepath stdlib packages) ends with a trailing `/.` or `/`. If the cleaned
+// path already ends in a `.` path segment, then another is not added. If the
+// clean path already ends in a path separator, then another is not added.
+func PreserveTrailingDotOrSeparator(cleanedPath, originalPath string) string {
+	if !SpecifiesCurrentDir(cleanedPath) && SpecifiesCurrentDir(originalPath) {
+		if !HasTrailingPathSeparator(cleanedPath) {
+			// Add a separator if it doesn't already end with one (a cleaned
+			// path would only end in a separator if it is the root).
+			cleanedPath += string(filepath.Separator)
+		}
+		cleanedPath += "."
+	}
+
+	if !HasTrailingPathSeparator(cleanedPath) && HasTrailingPathSeparator(originalPath) {
+		cleanedPath += string(filepath.Separator)
+	}
+
+	return cleanedPath
+}
+
+// AssertsDirectory returns whether the given path is
+// asserted to be a directory, i.e., the path ends with
+// a trailing '/' or `/.`, assuming a path separator of `/`.
+func AssertsDirectory(path string) bool {
+	return HasTrailingPathSeparator(path) || SpecifiesCurrentDir(path)
+}
+
+// HasTrailingPathSeparator returns whether the given
+// path ends with the system's path separator character.
+func HasTrailingPathSeparator(path string) bool {
+	return len(path) > 0 && os.IsPathSeparator(path[len(path)-1])
+}
+
+// SpecifiesCurrentDir returns whether the given path specifies
+// a "current directory", i.e., the last path segment is `.`.
+func SpecifiesCurrentDir(path string) bool {
+	return filepath.Base(path) == "."
+}
+
+// SplitPathDirEntry splits the given path between its
+// parent directory and its basename in that directory.
+func SplitPathDirEntry(localizedPath string) (dir, base string) {
+	normalizedPath := filepath.ToSlash(localizedPath)
+	vol := filepath.VolumeName(normalizedPath)
+	normalizedPath = normalizedPath[len(vol):]
+
+	if normalizedPath == "/" {
+		// Specifies the root path.
+		return filepath.FromSlash(vol + normalizedPath), "."
+	}
+
+	trimmedPath := vol + strings.TrimRight(normalizedPath, "/")
+
+	dir = filepath.FromSlash(path.Dir(trimmedPath))
+	base = filepath.FromSlash(path.Base(trimmedPath))
+
+	return dir, base
+}
+
+// TarResource archives the resource at the given sourcePath into a Tar
+// archive. A non-nil error is returned if sourcePath does not exist or is
+// asserted to be a directory but exists as another type of file.
+//
+// This function acts as a convenient wrapper around TarWithOptions, which
+// requires a directory as the source path. TarResource accepts either a
+// directory or a file path and correctly sets the Tar options.
+func TarResource(sourcePath string) (content Archive, err error) {
+	if _, err = os.Lstat(sourcePath); err != nil {
+		// Catches the case where the source does not exist or is not a
+		// directory if asserted to be a directory, as this also causes an
+		// error.
+		return
+	}
+
+	if len(sourcePath) > 1 && HasTrailingPathSeparator(sourcePath) {
+		// In the case where the source path is a symbolic link AND it ends
+		// with a path separator, we will want to evaluate the symbolic link.
+		trimmedPath := sourcePath[:len(sourcePath)-1]
+		stat, err := os.Lstat(trimmedPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if stat.Mode()&os.ModeSymlink != 0 {
+			if sourcePath, err = filepath.EvalSymlinks(trimmedPath); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Separate the source path between it's directory and
+	// the entry in that directory which we are archiving.
+	sourceDir, sourceBase := SplitPathDirEntry(sourcePath)
+
+	filter := []string{sourceBase}
+
+	logrus.Debugf("copying %q from %q", sourceBase, sourceDir)
+
+	return TarWithOptions(sourceDir, &TarOptions{
+		Compression:      Uncompressed,
+		IncludeFiles:     filter,
+		IncludeSourceDir: true,
+	})
+}
+
+// CopyInfo holds basic info about the source
+// or destination path of a copy operation.
+type CopyInfo struct {
+	Path   string
+	Exists bool
+	IsDir  bool
+}
+
+// CopyInfoStatPath stats the given path to create a CopyInfo
+// struct representing that resource. If mustExist is true, then
+// it is an error if there is no file or directory at the given path.
+func CopyInfoStatPath(path string, mustExist bool) (CopyInfo, error) {
+	pathInfo := CopyInfo{Path: path}
+
+	fileInfo, err := os.Lstat(path)
+
+	if err == nil {
+		pathInfo.Exists, pathInfo.IsDir = true, fileInfo.IsDir()
+	} else if os.IsNotExist(err) && !mustExist {
+		err = nil
+	}
+
+	return pathInfo, err
+}
+
+// PrepareArchiveCopy prepares the given srcContent archive, which should
+// contain the archived resource described by srcInfo, to the destination
+// described by dstInfo. Returns the possibly modified content archive along
+// with the path to the destination directory which it should be extracted to.
+func PrepareArchiveCopy(srcContent ArchiveReader, srcInfo, dstInfo CopyInfo) (dstDir string, content Archive, err error) {
+	// Separate the destination path between its directory and base
+	// components in case the source archive contents need to be rebased.
+	dstDir, dstBase := SplitPathDirEntry(dstInfo.Path)
+	_, srcBase := SplitPathDirEntry(srcInfo.Path)
+
+	switch {
+	case dstInfo.Exists && dstInfo.IsDir:
+		// The destination exists as a directory. No alteration
+		// to srcContent is needed as its contents can be
+		// simply extracted to the destination directory.
+		return dstInfo.Path, ioutil.NopCloser(srcContent), nil
+	case dstInfo.Exists && srcInfo.IsDir:
+		// The destination exists as some type of file and the source
+		// content is a directory. This is an error condition since
+		// you cannot copy a directory to an existing file location.
+		return "", nil, ErrCannotCopyDir
+	case dstInfo.Exists:
+		// The destination exists as some type of file and the source content
+		// is also a file. The source content entry will have to be renamed to
+		// have a basename which matches the destination path's basename.
+		return dstDir, rebaseArchiveEntries(srcContent, srcBase, dstBase), nil
+	case srcInfo.IsDir:
+		// The destination does not exist and the source content is an archive
+		// of a directory. The archive should be extracted to the parent of
+		// the destination path instead, and when it is, the directory that is
+		// created as a result should take the name of the destination path.
+		// The source content entries will have to be renamed to have a
+		// basename which matches the destination path's basename.
+		return dstDir, rebaseArchiveEntries(srcContent, srcBase, dstBase), nil
+	case AssertsDirectory(dstInfo.Path):
+		// The destination does not exist and is asserted to be created as a
+		// directory, but the source content is not a directory. This is an
+		// error condition since you cannot create a directory from a file
+		// source.
+		return "", nil, ErrDirNotExists
+	default:
+		// The last remaining case is when the destination does not exist, is
+		// not asserted to be a directory, and the source content is not an
+		// archive of a directory. It this case, the destination file will need
+		// to be created when the archive is extracted and the source content
+		// entry will have to be renamed to have a basename which matches the
+		// destination path's basename.
+		return dstDir, rebaseArchiveEntries(srcContent, srcBase, dstBase), nil
+	}
+
+}
+
+// rebaseArchiveEntries rewrites the given srcContent archive replacing
+// an occurance of oldBase with newBase at the beginning of entry names.
+func rebaseArchiveEntries(srcContent ArchiveReader, oldBase, newBase string) Archive {
+	rebased, w := io.Pipe()
+
+	go func() {
+		srcTar := tar.NewReader(srcContent)
+		rebasedTar := tar.NewWriter(w)
+
+		for {
+			hdr, err := srcTar.Next()
+			if err == io.EOF {
+				// Signals end of archive.
+				rebasedTar.Close()
+				w.Close()
+				return
+			}
+			if err != nil {
+				w.CloseWithError(err)
+				return
+			}
+
+			hdr.Name = strings.Replace(hdr.Name, oldBase, newBase, 1)
+
+			if err = rebasedTar.WriteHeader(hdr); err != nil {
+				w.CloseWithError(err)
+				return
+			}
+
+			if _, err = io.Copy(rebasedTar, srcTar); err != nil {
+				w.CloseWithError(err)
+				return
+			}
+		}
+	}()
+
+	return rebased
+}
+
+// CopyResource performs an archive copy from the given source path to the
+// given destination path. The source path MUST exist and the destination
+// path's parent directory must exist.
+func CopyResource(srcPath, dstPath string) error {
+	var (
+		srcInfo CopyInfo
+		err     error
+	)
+
+	// Clean the source and destination paths.
+	srcPath = PreserveTrailingDotOrSeparator(filepath.Clean(srcPath), srcPath)
+	dstPath = PreserveTrailingDotOrSeparator(filepath.Clean(dstPath), dstPath)
+
+	if srcInfo, err = CopyInfoStatPath(srcPath, true); err != nil {
+		return err
+	}
+
+	content, err := TarResource(srcPath)
+	if err != nil {
+		return err
+	}
+	defer content.Close()
+
+	return CopyTo(content, srcInfo, dstPath)
+}
+
+// CopyTo handles extracting the given content whose
+// entries should be sourced from srcInfo to dstPath.
+func CopyTo(content ArchiveReader, srcInfo CopyInfo, dstPath string) error {
+	dstInfo, err := CopyInfoStatPath(dstPath, false)
+	if err != nil {
+		return err
+	}
+
+	if !dstInfo.Exists {
+		// Ensure destination parent dir exists.
+		dstParent, _ := SplitPathDirEntry(dstPath)
+
+		dstStat, err := os.Lstat(dstParent)
+		if err != nil {
+			return err
+		}
+		if !dstStat.IsDir() {
+			return ErrNotDirectory
+		}
+	}
+
+	dstDir, copyArchive, err := PrepareArchiveCopy(content, srcInfo, dstInfo)
+	if err != nil {
+		return err
+	}
+	defer copyArchive.Close()
+
+	options := &TarOptions{
+		NoLchown:             true,
+		NoOverwriteDirNonDir: true,
+	}
+
+	return Untar(copyArchive, dstDir, options)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/copy_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/copy_test.go
@@ -1,0 +1,637 @@
+package archive
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func removeAllPaths(paths ...string) {
+	for _, path := range paths {
+		os.RemoveAll(path)
+	}
+}
+
+func getTestTempDirs(t *testing.T) (tmpDirA, tmpDirB string) {
+	var err error
+
+	if tmpDirA, err = ioutil.TempDir("", "archive-copy-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	if tmpDirB, err = ioutil.TempDir("", "archive-copy-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	return
+}
+
+func isNotDir(err error) bool {
+	return strings.Contains(err.Error(), "not a directory")
+}
+
+func joinTrailingSep(pathElements ...string) string {
+	joined := filepath.Join(pathElements...)
+
+	return fmt.Sprintf("%s%c", joined, filepath.Separator)
+}
+
+func fileContentsEqual(t *testing.T, filenameA, filenameB string) (err error) {
+	t.Logf("checking for equal file contents: %q and %q\n", filenameA, filenameB)
+
+	fileA, err := os.Open(filenameA)
+	if err != nil {
+		return
+	}
+	defer fileA.Close()
+
+	fileB, err := os.Open(filenameB)
+	if err != nil {
+		return
+	}
+	defer fileB.Close()
+
+	hasher := sha256.New()
+
+	if _, err = io.Copy(hasher, fileA); err != nil {
+		return
+	}
+
+	hashA := hasher.Sum(nil)
+	hasher.Reset()
+
+	if _, err = io.Copy(hasher, fileB); err != nil {
+		return
+	}
+
+	hashB := hasher.Sum(nil)
+
+	if !bytes.Equal(hashA, hashB) {
+		err = fmt.Errorf("file content hashes not equal - expected %s, got %s", hex.EncodeToString(hashA), hex.EncodeToString(hashB))
+	}
+
+	return
+}
+
+func dirContentsEqual(t *testing.T, newDir, oldDir string) (err error) {
+	t.Logf("checking for equal directory contents: %q and %q\n", newDir, oldDir)
+
+	var changes []Change
+
+	if changes, err = ChangesDirs(newDir, oldDir); err != nil {
+		return
+	}
+
+	if len(changes) != 0 {
+		err = fmt.Errorf("expected no changes between directories, but got: %v", changes)
+	}
+
+	return
+}
+
+func logDirContents(t *testing.T, dirPath string) {
+	logWalkedPaths := filepath.WalkFunc(func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			t.Errorf("stat error for path %q: %s", path, err)
+			return nil
+		}
+
+		if info.IsDir() {
+			path = joinTrailingSep(path)
+		}
+
+		t.Logf("\t%s", path)
+
+		return nil
+	})
+
+	t.Logf("logging directory contents: %q", dirPath)
+
+	if err := filepath.Walk(dirPath, logWalkedPaths); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testCopyHelper(t *testing.T, srcPath, dstPath string) (err error) {
+	t.Logf("copying from %q to %q", srcPath, dstPath)
+
+	return CopyResource(srcPath, dstPath)
+}
+
+// Basic assumptions about SRC and DST:
+// 1. SRC must exist.
+// 2. If SRC ends with a trailing separator, it must be a directory.
+// 3. DST parent directory must exist.
+// 4. If DST exists as a file, it must not end with a trailing separator.
+
+// First get these easy error cases out of the way.
+
+// Test for error when SRC does not exist.
+func TestCopyErrSrcNotExists(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	content, err := TarResource(filepath.Join(tmpDirA, "file1"))
+	if err == nil {
+		content.Close()
+		t.Fatal("expected IsNotExist error, but got nil instead")
+	}
+
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist error, but got %T: %s", err, err)
+	}
+}
+
+// Test for error when SRC ends in a trailing
+// path separator but it exists as a file.
+func TestCopyErrSrcNotDir(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+
+	content, err := TarResource(joinTrailingSep(tmpDirA, "file1"))
+	if err == nil {
+		content.Close()
+		t.Fatal("expected IsNotDir error, but got nil instead")
+	}
+
+	if !isNotDir(err) {
+		t.Fatalf("expected IsNotDir error, but got %T: %s", err, err)
+	}
+}
+
+// Test for error when SRC is a valid file or directory,
+// but the DST parent directory does not exist.
+func TestCopyErrDstParentNotExists(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+
+	srcInfo := CopyInfo{Path: filepath.Join(tmpDirA, "file1"), Exists: true, IsDir: false}
+
+	// Try with a file source.
+	content, err := TarResource(srcInfo.Path)
+	if err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+	defer content.Close()
+
+	// Copy to a file whose parent does not exist.
+	if err = CopyTo(content, srcInfo, filepath.Join(tmpDirB, "fakeParentDir", "file1")); err == nil {
+		t.Fatal("expected IsNotExist error, but got nil instead")
+	}
+
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist error, but got %T: %s", err, err)
+	}
+
+	// Try with a directory source.
+	srcInfo = CopyInfo{Path: filepath.Join(tmpDirA, "dir1"), Exists: true, IsDir: true}
+
+	content, err = TarResource(srcInfo.Path)
+	if err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+	defer content.Close()
+
+	// Copy to a directory whose parent does not exist.
+	if err = CopyTo(content, srcInfo, joinTrailingSep(tmpDirB, "fakeParentDir", "fakeDstDir")); err == nil {
+		t.Fatal("expected IsNotExist error, but got nil instead")
+	}
+
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist error, but got %T: %s", err, err)
+	}
+}
+
+// Test for error when DST ends in a trailing
+// path separator but exists as a file.
+func TestCopyErrDstNotDir(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A and B with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+	createSampleDir(t, tmpDirB)
+
+	// Try with a file source.
+	srcInfo := CopyInfo{Path: filepath.Join(tmpDirA, "file1"), Exists: true, IsDir: false}
+
+	content, err := TarResource(srcInfo.Path)
+	if err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+	defer content.Close()
+
+	if err = CopyTo(content, srcInfo, joinTrailingSep(tmpDirB, "file1")); err == nil {
+		t.Fatal("expected IsNotDir error, but got nil instead")
+	}
+
+	if !isNotDir(err) {
+		t.Fatalf("expected IsNotDir error, but got %T: %s", err, err)
+	}
+
+	// Try with a directory source.
+	srcInfo = CopyInfo{Path: filepath.Join(tmpDirA, "dir1"), Exists: true, IsDir: true}
+
+	content, err = TarResource(srcInfo.Path)
+	if err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+	defer content.Close()
+
+	if err = CopyTo(content, srcInfo, joinTrailingSep(tmpDirB, "file1")); err == nil {
+		t.Fatal("expected IsNotDir error, but got nil instead")
+	}
+
+	if !isNotDir(err) {
+		t.Fatalf("expected IsNotDir error, but got %T: %s", err, err)
+	}
+}
+
+// Possibilities are reduced to the remaining 10 cases:
+//
+//  case | srcIsDir | onlyDirContents | dstExists | dstIsDir | dstTrSep | action
+// ===================================================================================================
+//   A   |  no      |  -              |  no       |  -       |  no      |  create file
+//   B   |  no      |  -              |  no       |  -       |  yes     |  error
+//   C   |  no      |  -              |  yes      |  no      |  -       |  overwrite file
+//   D   |  no      |  -              |  yes      |  yes     |  -       |  create file in dst dir
+//   E   |  yes     |  no             |  no       |  -       |  -       |  create dir, copy contents
+//   F   |  yes     |  no             |  yes      |  no      |  -       |  error
+//   G   |  yes     |  no             |  yes      |  yes     |  -       |  copy dir and contents
+//   H   |  yes     |  yes            |  no       |  -       |  -       |  create dir, copy contents
+//   I   |  yes     |  yes            |  yes      |  no      |  -       |  error
+//   J   |  yes     |  yes            |  yes      |  yes     |  -       |  copy dir contents
+//
+
+// A. SRC specifies a file and DST (no trailing path separator) doesn't
+//    exist. This should create a file with the name DST and copy the
+//    contents of the source file into it.
+func TestCopyCaseA(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+
+	srcPath := filepath.Join(tmpDirA, "file1")
+	dstPath := filepath.Join(tmpDirB, "itWorks.txt")
+
+	var err error
+
+	if err = testCopyHelper(t, srcPath, dstPath); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = fileContentsEqual(t, srcPath, dstPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// B. SRC specifies a file and DST (with trailing path separator) doesn't
+//    exist. This should cause an error because the copy operation cannot
+//    create a directory when copying a single file.
+func TestCopyCaseB(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+
+	srcPath := filepath.Join(tmpDirA, "file1")
+	dstDir := joinTrailingSep(tmpDirB, "testDir")
+
+	var err error
+
+	if err = testCopyHelper(t, srcPath, dstDir); err == nil {
+		t.Fatal("expected ErrDirNotExists error, but got nil instead")
+	}
+
+	if err != ErrDirNotExists {
+		t.Fatalf("expected ErrDirNotExists error, but got %T: %s", err, err)
+	}
+}
+
+// C. SRC specifies a file and DST exists as a file. This should overwrite
+//    the file at DST with the contents of the source file.
+func TestCopyCaseC(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A and B with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+	createSampleDir(t, tmpDirB)
+
+	srcPath := filepath.Join(tmpDirA, "file1")
+	dstPath := filepath.Join(tmpDirB, "file2")
+
+	var err error
+
+	// Ensure they start out different.
+	if err = fileContentsEqual(t, srcPath, dstPath); err == nil {
+		t.Fatal("expected different file contents")
+	}
+
+	if err = testCopyHelper(t, srcPath, dstPath); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = fileContentsEqual(t, srcPath, dstPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// D. SRC specifies a file and DST exists as a directory. This should place
+//    a copy of the source file inside it using the basename from SRC. Ensure
+//    this works whether DST has a trailing path separator or not.
+func TestCopyCaseD(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A and B with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+	createSampleDir(t, tmpDirB)
+
+	srcPath := filepath.Join(tmpDirA, "file1")
+	dstDir := filepath.Join(tmpDirB, "dir1")
+	dstPath := filepath.Join(dstDir, "file1")
+
+	var err error
+
+	// Ensure that dstPath doesn't exist.
+	if _, err = os.Stat(dstPath); !os.IsNotExist(err) {
+		t.Fatalf("did not expect dstPath %q to exist", dstPath)
+	}
+
+	if err = testCopyHelper(t, srcPath, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = fileContentsEqual(t, srcPath, dstPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now try again but using a trailing path separator for dstDir.
+
+	if err = os.RemoveAll(dstDir); err != nil {
+		t.Fatalf("unable to remove dstDir: %s", err)
+	}
+
+	if err = os.MkdirAll(dstDir, os.FileMode(0755)); err != nil {
+		t.Fatalf("unable to make dstDir: %s", err)
+	}
+
+	dstDir = joinTrailingSep(tmpDirB, "dir1")
+
+	if err = testCopyHelper(t, srcPath, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = fileContentsEqual(t, srcPath, dstPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// E. SRC specifies a directory and DST does not exist. This should create a
+//    directory at DST and copy the contents of the SRC directory into the DST
+//    directory. Ensure this works whether DST has a trailing path separator or
+//    not.
+func TestCopyCaseE(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+
+	srcDir := filepath.Join(tmpDirA, "dir1")
+	dstDir := filepath.Join(tmpDirB, "testDir")
+
+	var err error
+
+	if err = testCopyHelper(t, srcDir, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = dirContentsEqual(t, dstDir, srcDir); err != nil {
+		t.Log("dir contents not equal")
+		logDirContents(t, tmpDirA)
+		logDirContents(t, tmpDirB)
+		t.Fatal(err)
+	}
+
+	// Now try again but using a trailing path separator for dstDir.
+
+	if err = os.RemoveAll(dstDir); err != nil {
+		t.Fatalf("unable to remove dstDir: %s", err)
+	}
+
+	dstDir = joinTrailingSep(tmpDirB, "testDir")
+
+	if err = testCopyHelper(t, srcDir, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = dirContentsEqual(t, dstDir, srcDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// F. SRC specifies a directory and DST exists as a file. This should cause an
+//    error as it is not possible to overwrite a file with a directory.
+func TestCopyCaseF(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A and B with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+	createSampleDir(t, tmpDirB)
+
+	srcDir := filepath.Join(tmpDirA, "dir1")
+	dstFile := filepath.Join(tmpDirB, "file1")
+
+	var err error
+
+	if err = testCopyHelper(t, srcDir, dstFile); err == nil {
+		t.Fatal("expected ErrCannotCopyDir error, but got nil instead")
+	}
+
+	if err != ErrCannotCopyDir {
+		t.Fatalf("expected ErrCannotCopyDir error, but got %T: %s", err, err)
+	}
+}
+
+// G. SRC specifies a directory and DST exists as a directory. This should copy
+//    the SRC directory and all its contents to the DST directory. Ensure this
+//    works whether DST has a trailing path separator or not.
+func TestCopyCaseG(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A and B with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+	createSampleDir(t, tmpDirB)
+
+	srcDir := filepath.Join(tmpDirA, "dir1")
+	dstDir := filepath.Join(tmpDirB, "dir2")
+	resultDir := filepath.Join(dstDir, "dir1")
+
+	var err error
+
+	if err = testCopyHelper(t, srcDir, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = dirContentsEqual(t, resultDir, srcDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now try again but using a trailing path separator for dstDir.
+
+	if err = os.RemoveAll(dstDir); err != nil {
+		t.Fatalf("unable to remove dstDir: %s", err)
+	}
+
+	if err = os.MkdirAll(dstDir, os.FileMode(0755)); err != nil {
+		t.Fatalf("unable to make dstDir: %s", err)
+	}
+
+	dstDir = joinTrailingSep(tmpDirB, "dir2")
+
+	if err = testCopyHelper(t, srcDir, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = dirContentsEqual(t, resultDir, srcDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// H. SRC specifies a directory's contents only and DST does not exist. This
+//    should create a directory at DST and copy the contents of the SRC
+//    directory (but not the directory itself) into the DST directory. Ensure
+//    this works whether DST has a trailing path separator or not.
+func TestCopyCaseH(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+
+	srcDir := joinTrailingSep(tmpDirA, "dir1") + "."
+	dstDir := filepath.Join(tmpDirB, "testDir")
+
+	var err error
+
+	if err = testCopyHelper(t, srcDir, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = dirContentsEqual(t, dstDir, srcDir); err != nil {
+		t.Log("dir contents not equal")
+		logDirContents(t, tmpDirA)
+		logDirContents(t, tmpDirB)
+		t.Fatal(err)
+	}
+
+	// Now try again but using a trailing path separator for dstDir.
+
+	if err = os.RemoveAll(dstDir); err != nil {
+		t.Fatalf("unable to remove dstDir: %s", err)
+	}
+
+	dstDir = joinTrailingSep(tmpDirB, "testDir")
+
+	if err = testCopyHelper(t, srcDir, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = dirContentsEqual(t, dstDir, srcDir); err != nil {
+		t.Log("dir contents not equal")
+		logDirContents(t, tmpDirA)
+		logDirContents(t, tmpDirB)
+		t.Fatal(err)
+	}
+}
+
+// I. SRC specifies a directory's contents only and DST exists as a file. This
+//    should cause an error as it is not possible to overwrite a file with a
+//    directory.
+func TestCopyCaseI(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A and B with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+	createSampleDir(t, tmpDirB)
+
+	srcDir := joinTrailingSep(tmpDirA, "dir1") + "."
+	dstFile := filepath.Join(tmpDirB, "file1")
+
+	var err error
+
+	if err = testCopyHelper(t, srcDir, dstFile); err == nil {
+		t.Fatal("expected ErrCannotCopyDir error, but got nil instead")
+	}
+
+	if err != ErrCannotCopyDir {
+		t.Fatalf("expected ErrCannotCopyDir error, but got %T: %s", err, err)
+	}
+}
+
+// J. SRC specifies a directory's contents only and DST exists as a directory.
+//    This should copy the contents of the SRC directory (but not the directory
+//    itself) into the DST directory. Ensure this works whether DST has a
+//    trailing path separator or not.
+func TestCopyCaseJ(t *testing.T) {
+	tmpDirA, tmpDirB := getTestTempDirs(t)
+	defer removeAllPaths(tmpDirA, tmpDirB)
+
+	// Load A and B with some sample files and directories.
+	createSampleDir(t, tmpDirA)
+	createSampleDir(t, tmpDirB)
+
+	srcDir := joinTrailingSep(tmpDirA, "dir1") + "."
+	dstDir := filepath.Join(tmpDirB, "dir5")
+
+	var err error
+
+	if err = testCopyHelper(t, srcDir, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = dirContentsEqual(t, dstDir, srcDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now try again but using a trailing path separator for dstDir.
+
+	if err = os.RemoveAll(dstDir); err != nil {
+		t.Fatalf("unable to remove dstDir: %s", err)
+	}
+
+	if err = os.MkdirAll(dstDir, os.FileMode(0755)); err != nil {
+		t.Fatalf("unable to make dstDir: %s", err)
+	}
+
+	dstDir = joinTrailingSep(tmpDirB, "dir5")
+
+	if err = testCopyHelper(t, srcDir, dstDir); err != nil {
+		t.Fatalf("unexpected error %T: %s", err, err)
+	}
+
+	if err = dirContentsEqual(t, dstDir, srcDir); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/copy_unix.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/copy_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package archive
+
+import (
+	"path/filepath"
+)
+
+func normalizePath(path string) string {
+	return filepath.ToSlash(path)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/copy_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/copy_windows.go
@@ -1,0 +1,9 @@
+package archive
+
+import (
+	"path/filepath"
+)
+
+func normalizePath(path string) string {
+	return filepath.FromSlash(path)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/diff.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/diff.go
@@ -1,0 +1,210 @@
+package archive
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system"
+)
+
+func UnpackLayer(dest string, layer ArchiveReader) (size int64, err error) {
+	tr := tar.NewReader(layer)
+	trBuf := pools.BufioReader32KPool.Get(tr)
+	defer pools.BufioReader32KPool.Put(trBuf)
+
+	var dirs []*tar.Header
+
+	aufsTempdir := ""
+	aufsHardlinks := make(map[string]*tar.Header)
+
+	// Iterate through the files in the archive.
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		size += hdr.Size
+
+		// Normalize name, for safety and for a simple is-root check
+		hdr.Name = filepath.Clean(hdr.Name)
+
+		// Windows does not support filenames with colons in them. Ignore
+		// these files. This is not a problem though (although it might
+		// appear that it is). Let's suppose a client is running docker pull.
+		// The daemon it points to is Windows. Would it make sense for the
+		// client to be doing a docker pull Ubuntu for example (which has files
+		// with colons in the name under /usr/share/man/man3)? No, absolutely
+		// not as it would really only make sense that they were pulling a
+		// Windows image. However, for development, it is necessary to be able
+		// to pull Linux images which are in the repository.
+		//
+		// TODO Windows. Once the registry is aware of what images are Windows-
+		// specific or Linux-specific, this warning should be changed to an error
+		// to cater for the situation where someone does manage to upload a Linux
+		// image but have it tagged as Windows inadvertantly.
+		if runtime.GOOS == "windows" {
+			if strings.Contains(hdr.Name, ":") {
+				logrus.Warnf("Windows: Ignoring %s (is this a Linux image?)", hdr.Name)
+				continue
+			}
+		}
+
+		// Note as these operations are platform specific, so must the slash be.
+		if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
+			// Not the root directory, ensure that the parent directory exists.
+			// This happened in some tests where an image had a tarfile without any
+			// parent directories.
+			parent := filepath.Dir(hdr.Name)
+			parentPath := filepath.Join(dest, parent)
+
+			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
+				err = system.MkdirAll(parentPath, 0600)
+				if err != nil {
+					return 0, err
+				}
+			}
+		}
+
+		// Skip AUFS metadata dirs
+		if strings.HasPrefix(hdr.Name, ".wh..wh.") {
+			// Regular files inside /.wh..wh.plnk can be used as hardlink targets
+			// We don't want this directory, but we need the files in them so that
+			// such hardlinks can be resolved.
+			if strings.HasPrefix(hdr.Name, ".wh..wh.plnk") && hdr.Typeflag == tar.TypeReg {
+				basename := filepath.Base(hdr.Name)
+				aufsHardlinks[basename] = hdr
+				if aufsTempdir == "" {
+					if aufsTempdir, err = ioutil.TempDir("", "dockerplnk"); err != nil {
+						return 0, err
+					}
+					defer os.RemoveAll(aufsTempdir)
+				}
+				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil); err != nil {
+					return 0, err
+				}
+			}
+			continue
+		}
+		path := filepath.Join(dest, hdr.Name)
+		rel, err := filepath.Rel(dest, path)
+		if err != nil {
+			return 0, err
+		}
+
+		// Note as these operations are platform specific, so must the slash be.
+		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return 0, breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
+		}
+		base := filepath.Base(path)
+
+		if strings.HasPrefix(base, ".wh.") {
+			originalBase := base[len(".wh."):]
+			originalPath := filepath.Join(filepath.Dir(path), originalBase)
+			if err := os.RemoveAll(originalPath); err != nil {
+				return 0, err
+			}
+		} else {
+			// If path exits we almost always just want to remove and replace it.
+			// The only exception is when it is a directory *and* the file from
+			// the layer is also a directory. Then we want to merge them (i.e.
+			// just apply the metadata from the layer).
+			if fi, err := os.Lstat(path); err == nil {
+				if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
+					if err := os.RemoveAll(path); err != nil {
+						return 0, err
+					}
+				}
+			}
+
+			trBuf.Reset(tr)
+			srcData := io.Reader(trBuf)
+			srcHdr := hdr
+
+			// Hard links into /.wh..wh.plnk don't work, as we don't extract that directory, so
+			// we manually retarget these into the temporary files we extracted them into
+			if hdr.Typeflag == tar.TypeLink && strings.HasPrefix(filepath.Clean(hdr.Linkname), ".wh..wh.plnk") {
+				linkBasename := filepath.Base(hdr.Linkname)
+				srcHdr = aufsHardlinks[linkBasename]
+				if srcHdr == nil {
+					return 0, fmt.Errorf("Invalid aufs hardlink")
+				}
+				tmpFile, err := os.Open(filepath.Join(aufsTempdir, linkBasename))
+				if err != nil {
+					return 0, err
+				}
+				defer tmpFile.Close()
+				srcData = tmpFile
+			}
+
+			if err := createTarFile(path, dest, srcHdr, srcData, true, nil); err != nil {
+				return 0, err
+			}
+
+			// Directory mtimes must be handled at the end to avoid further
+			// file creation in them to modify the directory mtime
+			if hdr.Typeflag == tar.TypeDir {
+				dirs = append(dirs, hdr)
+			}
+		}
+	}
+
+	for _, hdr := range dirs {
+		path := filepath.Join(dest, hdr.Name)
+		ts := []syscall.Timespec{timeToTimespec(hdr.AccessTime), timeToTimespec(hdr.ModTime)}
+		if err := syscall.UtimesNano(path, ts); err != nil {
+			return 0, err
+		}
+	}
+
+	return size, nil
+}
+
+// ApplyLayer parses a diff in the standard layer format from `layer`,
+// and applies it to the directory `dest`. The stream `layer` can be
+// compressed or uncompressed.
+// Returns the size in bytes of the contents of the layer.
+func ApplyLayer(dest string, layer ArchiveReader) (int64, error) {
+	return applyLayerHandler(dest, layer, true)
+}
+
+// ApplyUncompressedLayer parses a diff in the standard layer format from
+// `layer`, and applies it to the directory `dest`. The stream `layer`
+// can only be uncompressed.
+// Returns the size in bytes of the contents of the layer.
+func ApplyUncompressedLayer(dest string, layer ArchiveReader) (int64, error) {
+	return applyLayerHandler(dest, layer, false)
+}
+
+// do the bulk load of ApplyLayer, but allow for not calling DecompressStream
+func applyLayerHandler(dest string, layer ArchiveReader, decompress bool) (int64, error) {
+	dest = filepath.Clean(dest)
+
+	// We need to be able to set any perms
+	oldmask, err := system.Umask(0)
+	if err != nil {
+		return 0, err
+	}
+	defer system.Umask(oldmask) // ignore err, ErrNotSupportedPlatform
+
+	if decompress {
+		layer, err = DecompressStream(layer)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return UnpackLayer(dest, layer)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/diff_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/diff_test.go
@@ -1,0 +1,190 @@
+package archive
+
+import (
+	"archive/tar"
+	"testing"
+)
+
+func TestApplyLayerInvalidFilenames(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{
+			{
+				Name:     "../victim/dotdot",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{
+			{
+				// Note the leading slash
+				Name:     "/../victim/slash-dotdot",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("applylayer", "docker-TestApplyLayerInvalidFilenames", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
+func TestApplyLayerInvalidHardlink(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{ // try reading victim/hello (../)
+			{
+				Name:     "dotdot",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (/../)
+			{
+				Name:     "slash-dotdot",
+				Typeflag: tar.TypeLink,
+				// Note the leading slash
+				Linkname: "/../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try writing victim/file
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim/file",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (hardlink, symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "symlink",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // Try reading victim/hello (hardlink, hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "hardlink",
+				Typeflag: tar.TypeLink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // Try removing victim directory (hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("applylayer", "docker-TestApplyLayerInvalidHardlink", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
+func TestApplyLayerInvalidSymlink(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{ // try reading victim/hello (../)
+			{
+				Name:     "dotdot",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (/../)
+			{
+				Name:     "slash-dotdot",
+				Typeflag: tar.TypeSymlink,
+				// Note the leading slash
+				Linkname: "/../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try writing victim/file
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim/file",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (symlink, symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "symlink",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (symlink, hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "hardlink",
+				Typeflag: tar.TypeLink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try removing victim directory (symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("applylayer", "docker-TestApplyLayerInvalidSymlink", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/example_changes.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/example_changes.go
@@ -1,0 +1,97 @@
+// +build ignore
+
+// Simple tool to create an archive stream from an old and new directory
+//
+// By default it will stream the comparison of two temporary directories with junk files
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive"
+)
+
+var (
+	flDebug  = flag.Bool("D", false, "debugging output")
+	flNewDir = flag.String("newdir", "", "")
+	flOldDir = flag.String("olddir", "", "")
+	log      = logrus.New()
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Println("Produce a tar from comparing two directory paths. By default a demo tar is created of around 200 files (including hardlinks)")
+		fmt.Printf("%s [OPTIONS]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	log.Out = os.Stderr
+	if (len(os.Getenv("DEBUG")) > 0) || *flDebug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	var newDir, oldDir string
+
+	if len(*flNewDir) == 0 {
+		var err error
+		newDir, err = ioutil.TempDir("", "docker-test-newDir")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer os.RemoveAll(newDir)
+		if _, err := prepareUntarSourceDirectory(100, newDir, true); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		newDir = *flNewDir
+	}
+
+	if len(*flOldDir) == 0 {
+		oldDir, err := ioutil.TempDir("", "docker-test-oldDir")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer os.RemoveAll(oldDir)
+	} else {
+		oldDir = *flOldDir
+	}
+
+	changes, err := archive.ChangesDirs(newDir, oldDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	a, err := archive.ExportChanges(newDir, changes)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer a.Close()
+
+	i, err := io.Copy(os.Stdout, a)
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+	}
+	fmt.Fprintf(os.Stderr, "wrote archive of %d bytes", i)
+}
+
+func prepareUntarSourceDirectory(numberOfFiles int, targetPath string, makeLinks bool) (int, error) {
+	fileData := []byte("fooo")
+	for n := 0; n < numberOfFiles; n++ {
+		fileName := fmt.Sprintf("file-%d", n)
+		if err := ioutil.WriteFile(path.Join(targetPath, fileName), fileData, 0700); err != nil {
+			return 0, err
+		}
+		if makeLinks {
+			if err := os.Link(path.Join(targetPath, fileName), path.Join(targetPath, fileName+"-link")); err != nil {
+				return 0, err
+			}
+		}
+	}
+	totalSize := numberOfFiles * len(fileData)
+	return totalSize, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/time_linux.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/time_linux.go
@@ -1,0 +1,16 @@
+package archive
+
+import (
+	"syscall"
+	"time"
+)
+
+func timeToTimespec(time time.Time) (ts syscall.Timespec) {
+	if time.IsZero() {
+		// Return UTIME_OMIT special value
+		ts.Sec = 0
+		ts.Nsec = ((1 << 30) - 2)
+		return
+	}
+	return syscall.NsecToTimespec(time.UnixNano())
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/time_unsupported.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/time_unsupported.go
@@ -1,0 +1,16 @@
+// +build !linux
+
+package archive
+
+import (
+	"syscall"
+	"time"
+)
+
+func timeToTimespec(time time.Time) (ts syscall.Timespec) {
+	nsec := int64(0)
+	if !time.IsZero() {
+		nsec = time.UnixNano()
+	}
+	return syscall.NsecToTimespec(nsec)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/utils_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/utils_test.go
@@ -1,0 +1,166 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var testUntarFns = map[string]func(string, io.Reader) error{
+	"untar": func(dest string, r io.Reader) error {
+		return Untar(r, dest, nil)
+	},
+	"applylayer": func(dest string, r io.Reader) error {
+		_, err := ApplyLayer(dest, ArchiveReader(r))
+		return err
+	},
+}
+
+// testBreakout is a helper function that, within the provided `tmpdir` directory,
+// creates a `victim` folder with a generated `hello` file in it.
+// `untar` extracts to a directory named `dest`, the tar file created from `headers`.
+//
+// Here are the tested scenarios:
+// - removed `victim` folder				(write)
+// - removed files from `victim` folder			(write)
+// - new files in `victim` folder			(write)
+// - modified files in `victim` folder			(write)
+// - file in `dest` with same content as `victim/hello` (read)
+//
+// When using testBreakout make sure you cover one of the scenarios listed above.
+func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
+	tmpdir, err := ioutil.TempDir("", tmpdir)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	dest := filepath.Join(tmpdir, "dest")
+	if err := os.Mkdir(dest, 0755); err != nil {
+		return err
+	}
+
+	victim := filepath.Join(tmpdir, "victim")
+	if err := os.Mkdir(victim, 0755); err != nil {
+		return err
+	}
+	hello := filepath.Join(victim, "hello")
+	helloData, err := time.Now().MarshalText()
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(hello, helloData, 0644); err != nil {
+		return err
+	}
+	helloStat, err := os.Stat(hello)
+	if err != nil {
+		return err
+	}
+
+	reader, writer := io.Pipe()
+	go func() {
+		t := tar.NewWriter(writer)
+		for _, hdr := range headers {
+			t.WriteHeader(hdr)
+		}
+		t.Close()
+	}()
+
+	untar := testUntarFns[untarFn]
+	if untar == nil {
+		return fmt.Errorf("could not find untar function %q in testUntarFns", untarFn)
+	}
+	if err := untar(dest, reader); err != nil {
+		if _, ok := err.(breakoutError); !ok {
+			// If untar returns an error unrelated to an archive breakout,
+			// then consider this an unexpected error and abort.
+			return err
+		}
+		// Here, untar detected the breakout.
+		// Let's move on verifying that indeed there was no breakout.
+		fmt.Printf("breakoutError: %v\n", err)
+	}
+
+	// Check victim folder
+	f, err := os.Open(victim)
+	if err != nil {
+		// codepath taken if victim folder was removed
+		return fmt.Errorf("archive breakout: error reading %q: %v", victim, err)
+	}
+	defer f.Close()
+
+	// Check contents of victim folder
+	//
+	// We are only interested in getting 2 files from the victim folder, because if all is well
+	// we expect only one result, the `hello` file. If there is a second result, it cannot
+	// hold the same name `hello` and we assume that a new file got created in the victim folder.
+	// That is enough to detect an archive breakout.
+	names, err := f.Readdirnames(2)
+	if err != nil {
+		// codepath taken if victim is not a folder
+		return fmt.Errorf("archive breakout: error reading directory content of %q: %v", victim, err)
+	}
+	for _, name := range names {
+		if name != "hello" {
+			// codepath taken if new file was created in victim folder
+			return fmt.Errorf("archive breakout: new file %q", name)
+		}
+	}
+
+	// Check victim/hello
+	f, err = os.Open(hello)
+	if err != nil {
+		// codepath taken if read permissions were removed
+		return fmt.Errorf("archive breakout: could not lstat %q: %v", hello, err)
+	}
+	defer f.Close()
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if helloStat.IsDir() != fi.IsDir() ||
+		// TODO: cannot check for fi.ModTime() change
+		helloStat.Mode() != fi.Mode() ||
+		helloStat.Size() != fi.Size() ||
+		!bytes.Equal(helloData, b) {
+		// codepath taken if hello has been modified
+		return fmt.Errorf("archive breakout: file %q has been modified. Contents: expected=%q, got=%q. FileInfo: expected=%#v, got=%#v", hello, helloData, b, helloStat, fi)
+	}
+
+	// Check that nothing in dest/ has the same content as victim/hello.
+	// Since victim/hello was generated with time.Now(), it is safe to assume
+	// that any file whose content matches exactly victim/hello, managed somehow
+	// to access victim/hello.
+	return filepath.Walk(dest, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			if err != nil {
+				// skip directory if error
+				return filepath.SkipDir
+			}
+			// enter directory
+			return nil
+		}
+		if err != nil {
+			// skip file if error
+			return nil
+		}
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			// Houston, we have a problem. Aborting (space)walk.
+			return err
+		}
+		if bytes.Equal(helloData, b) {
+			return fmt.Errorf("archive breakout: file %q has been accessed via %q", hello, path)
+		}
+		return nil
+	})
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/wrap.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/wrap.go
@@ -1,0 +1,59 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"io/ioutil"
+)
+
+// Generate generates a new archive from the content provided
+// as input.
+//
+// `files` is a sequence of path/content pairs. A new file is
+// added to the archive for each pair.
+// If the last pair is incomplete, the file is created with an
+// empty content. For example:
+//
+// Generate("foo.txt", "hello world", "emptyfile")
+//
+// The above call will return an archive with 2 files:
+//  * ./foo.txt with content "hello world"
+//  * ./empty with empty content
+//
+// FIXME: stream content instead of buffering
+// FIXME: specify permissions and other archive metadata
+func Generate(input ...string) (Archive, error) {
+	files := parseStringPairs(input...)
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+	for _, file := range files {
+		name, content := file[0], file[1]
+		hdr := &tar.Header{
+			Name: name,
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return ioutil.NopCloser(buf), nil
+}
+
+func parseStringPairs(input ...string) (output [][2]string) {
+	output = make([][2]string, 0, len(input)/2+1)
+	for i := 0; i < len(input); i += 2 {
+		var pair [2]string
+		pair[0] = input[i]
+		if i+1 < len(input) {
+			pair[1] = input[i+1]
+		}
+		output = append(output, pair)
+	}
+	return
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/wrap_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive/wrap_test.go
@@ -1,0 +1,98 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestGenerateEmptyFile(t *testing.T) {
+	archive, err := Generate("emptyFile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archive == nil {
+		t.Fatal("The generated archive should not be nil.")
+	}
+
+	expectedFiles := [][]string{
+		{"emptyFile", ""},
+	}
+
+	tr := tar.NewReader(archive)
+	actualFiles := make([][]string, 0, 10)
+	i := 0
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(tr)
+		content := buf.String()
+		actualFiles = append(actualFiles, []string{hdr.Name, content})
+		i++
+	}
+	if len(actualFiles) != len(expectedFiles) {
+		t.Fatalf("Number of expected file %d, got %d.", len(expectedFiles), len(actualFiles))
+	}
+	for i := 0; i < len(expectedFiles); i++ {
+		actual := actualFiles[i]
+		expected := expectedFiles[i]
+		if actual[0] != expected[0] {
+			t.Fatalf("Expected name '%s', Actual name '%s'", expected[0], actual[0])
+		}
+		if actual[1] != expected[1] {
+			t.Fatalf("Expected content '%s', Actual content '%s'", expected[1], actual[1])
+		}
+	}
+}
+
+func TestGenerateWithContent(t *testing.T) {
+	archive, err := Generate("file", "content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archive == nil {
+		t.Fatal("The generated archive should not be nil.")
+	}
+
+	expectedFiles := [][]string{
+		{"file", "content"},
+	}
+
+	tr := tar.NewReader(archive)
+	actualFiles := make([][]string, 0, 10)
+	i := 0
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(tr)
+		content := buf.String()
+		actualFiles = append(actualFiles, []string{hdr.Name, content})
+		i++
+	}
+	if len(actualFiles) != len(expectedFiles) {
+		t.Fatalf("Number of expected file %d, got %d.", len(expectedFiles), len(actualFiles))
+	}
+	for i := 0; i < len(expectedFiles); i++ {
+		actual := actualFiles[i]
+		expected := expectedFiles[i]
+		if actual[0] != expected[0] {
+			t.Fatalf("Expected name '%s', Actual name '%s'", expected[0], actual[0])
+		}
+		if actual[1] != expected[1] {
+			t.Fatalf("Expected content '%s', Actual content '%s'", expected[1], actual[1])
+		}
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils/fileutils.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils/fileutils.go
@@ -1,0 +1,196 @@
+package fileutils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+)
+
+// exclusion return true if the specified pattern is an exclusion
+func exclusion(pattern string) bool {
+	return pattern[0] == '!'
+}
+
+// empty return true if the specified pattern is empty
+func empty(pattern string) bool {
+	return pattern == ""
+}
+
+// CleanPatterns takes a slice of patterns returns a new
+// slice of patterns cleaned with filepath.Clean, stripped
+// of any empty patterns and lets the caller know whether the
+// slice contains any exception patterns (prefixed with !).
+func CleanPatterns(patterns []string) ([]string, [][]string, bool, error) {
+	// Loop over exclusion patterns and:
+	// 1. Clean them up.
+	// 2. Indicate whether we are dealing with any exception rules.
+	// 3. Error if we see a single exclusion marker on it's own (!).
+	cleanedPatterns := []string{}
+	patternDirs := [][]string{}
+	exceptions := false
+	for _, pattern := range patterns {
+		// Eliminate leading and trailing whitespace.
+		pattern = strings.TrimSpace(pattern)
+		if empty(pattern) {
+			continue
+		}
+		if exclusion(pattern) {
+			if len(pattern) == 1 {
+				return nil, nil, false, errors.New("Illegal exclusion pattern: !")
+			}
+			exceptions = true
+		}
+		pattern = filepath.Clean(pattern)
+		cleanedPatterns = append(cleanedPatterns, pattern)
+		if exclusion(pattern) {
+			pattern = pattern[1:]
+		}
+		patternDirs = append(patternDirs, strings.Split(pattern, "/"))
+	}
+
+	return cleanedPatterns, patternDirs, exceptions, nil
+}
+
+// Matches returns true if file matches any of the patterns
+// and isn't excluded by any of the subsequent patterns.
+func Matches(file string, patterns []string) (bool, error) {
+	file = filepath.Clean(file)
+
+	if file == "." {
+		// Don't let them exclude everything, kind of silly.
+		return false, nil
+	}
+
+	patterns, patDirs, _, err := CleanPatterns(patterns)
+	if err != nil {
+		return false, err
+	}
+
+	return OptimizedMatches(file, patterns, patDirs)
+}
+
+// OptimizedMatches is basically the same as fileutils.Matches() but optimized for archive.go.
+// It will assume that the inputs have been preprocessed and therefore the function
+// doen't need to do as much error checking and clean-up. This was done to avoid
+// repeating these steps on each file being checked during the archive process.
+// The more generic fileutils.Matches() can't make these assumptions.
+func OptimizedMatches(file string, patterns []string, patDirs [][]string) (bool, error) {
+	matched := false
+	parentPath := filepath.Dir(file)
+	parentPathDirs := strings.Split(parentPath, "/")
+
+	for i, pattern := range patterns {
+		negative := false
+
+		if exclusion(pattern) {
+			negative = true
+			pattern = pattern[1:]
+		}
+
+		match, err := filepath.Match(pattern, file)
+		if err != nil {
+			return false, err
+		}
+
+		if !match && parentPath != "." {
+			// Check to see if the pattern matches one of our parent dirs.
+			if len(patDirs[i]) <= len(parentPathDirs) {
+				match, _ = filepath.Match(strings.Join(patDirs[i], "/"),
+					strings.Join(parentPathDirs[:len(patDirs[i])], "/"))
+			}
+		}
+
+		if match {
+			matched = !negative
+		}
+	}
+
+	if matched {
+		logrus.Debugf("Skipping excluded path: %s", file)
+	}
+
+	return matched, nil
+}
+
+// CopyFile copies from src to dst until either EOF is reached
+// on src or an error occurs. It verifies src exists and remove
+// the dst if it exists.
+func CopyFile(src, dst string) (int64, error) {
+	cleanSrc := filepath.Clean(src)
+	cleanDst := filepath.Clean(dst)
+	if cleanSrc == cleanDst {
+		return 0, nil
+	}
+	sf, err := os.Open(cleanSrc)
+	if err != nil {
+		return 0, err
+	}
+	defer sf.Close()
+	if err := os.Remove(cleanDst); err != nil && !os.IsNotExist(err) {
+		return 0, err
+	}
+	df, err := os.Create(cleanDst)
+	if err != nil {
+		return 0, err
+	}
+	defer df.Close()
+	return io.Copy(df, sf)
+}
+
+// GetTotalUsedFds Returns the number of used File Descriptors by
+// reading it via /proc filesystem.
+func GetTotalUsedFds() int {
+	if fds, err := ioutil.ReadDir(fmt.Sprintf("/proc/%d/fd", os.Getpid())); err != nil {
+		logrus.Errorf("Error opening /proc/%d/fd: %s", os.Getpid(), err)
+	} else {
+		return len(fds)
+	}
+	return -1
+}
+
+// ReadSymlinkedDirectory returns the target directory of a symlink.
+// The target of the symbolic link may not be a file.
+func ReadSymlinkedDirectory(path string) (string, error) {
+	var realPath string
+	var err error
+	if realPath, err = filepath.Abs(path); err != nil {
+		return "", fmt.Errorf("unable to get absolute path for %s: %s", path, err)
+	}
+	if realPath, err = filepath.EvalSymlinks(realPath); err != nil {
+		return "", fmt.Errorf("failed to canonicalise path for %s: %s", path, err)
+	}
+	realPathInfo, err := os.Stat(realPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat target '%s' of '%s': %s", realPath, path, err)
+	}
+	if !realPathInfo.Mode().IsDir() {
+		return "", fmt.Errorf("canonical path points to a file '%s'", realPath)
+	}
+	return realPath, nil
+}
+
+// CreateIfNotExists creates a file or a directory only if it does not already exist.
+func CreateIfNotExists(path string, isDir bool) error {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			if isDir {
+				return os.MkdirAll(path, 0755)
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(path, os.O_CREATE, 0755)
+			if err != nil {
+				return err
+			}
+			f.Close()
+		}
+	}
+	return nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils/fileutils_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils/fileutils_test.go
@@ -1,0 +1,402 @@
+package fileutils
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+)
+
+// CopyFile with invalid src
+func TestCopyFileWithInvalidSrc(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-fileutils-test")
+	defer os.RemoveAll(tempFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := CopyFile("/invalid/file/path", path.Join(tempFolder, "dest"))
+	if err == nil {
+		t.Fatal("Should have fail to copy an invalid src file")
+	}
+	if bytes != 0 {
+		t.Fatal("Should have written 0 bytes")
+	}
+
+}
+
+// CopyFile with invalid dest
+func TestCopyFileWithInvalidDest(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-fileutils-test")
+	defer os.RemoveAll(tempFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := path.Join(tempFolder, "file")
+	err = ioutil.WriteFile(src, []byte("content"), 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := CopyFile(src, path.Join(tempFolder, "/invalid/dest/path"))
+	if err == nil {
+		t.Fatal("Should have fail to copy an invalid src file")
+	}
+	if bytes != 0 {
+		t.Fatal("Should have written 0 bytes")
+	}
+
+}
+
+// CopyFile with same src and dest
+func TestCopyFileWithSameSrcAndDest(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-fileutils-test")
+	defer os.RemoveAll(tempFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := path.Join(tempFolder, "file")
+	err = ioutil.WriteFile(file, []byte("content"), 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := CopyFile(file, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes != 0 {
+		t.Fatal("Should have written 0 bytes as it is the same file.")
+	}
+}
+
+// CopyFile with same src and dest but path is different and not clean
+func TestCopyFileWithSameSrcAndDestWithPathNameDifferent(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-fileutils-test")
+	defer os.RemoveAll(tempFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testFolder := path.Join(tempFolder, "test")
+	err = os.MkdirAll(testFolder, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := path.Join(testFolder, "file")
+	sameFile := testFolder + "/../test/file"
+	err = ioutil.WriteFile(file, []byte("content"), 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := CopyFile(file, sameFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes != 0 {
+		t.Fatal("Should have written 0 bytes as it is the same file.")
+	}
+}
+
+func TestCopyFile(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-fileutils-test")
+	defer os.RemoveAll(tempFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := path.Join(tempFolder, "src")
+	dest := path.Join(tempFolder, "dest")
+	ioutil.WriteFile(src, []byte("content"), 0777)
+	ioutil.WriteFile(dest, []byte("destContent"), 0777)
+	bytes, err := CopyFile(src, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes != 7 {
+		t.Fatalf("Should have written %d bytes but wrote %d", 7, bytes)
+	}
+	actual, err := ioutil.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(actual) != "content" {
+		t.Fatalf("Dest content was '%s', expected '%s'", string(actual), "content")
+	}
+}
+
+// Reading a symlink to a directory must return the directory
+func TestReadSymlinkedDirectoryExistingDirectory(t *testing.T) {
+	var err error
+	if err = os.Mkdir("/tmp/testReadSymlinkToExistingDirectory", 0777); err != nil {
+		t.Errorf("failed to create directory: %s", err)
+	}
+
+	if err = os.Symlink("/tmp/testReadSymlinkToExistingDirectory", "/tmp/dirLinkTest"); err != nil {
+		t.Errorf("failed to create symlink: %s", err)
+	}
+
+	var path string
+	if path, err = ReadSymlinkedDirectory("/tmp/dirLinkTest"); err != nil {
+		t.Fatalf("failed to read symlink to directory: %s", err)
+	}
+
+	if path != "/tmp/testReadSymlinkToExistingDirectory" {
+		t.Fatalf("symlink returned unexpected directory: %s", path)
+	}
+
+	if err = os.Remove("/tmp/testReadSymlinkToExistingDirectory"); err != nil {
+		t.Errorf("failed to remove temporary directory: %s", err)
+	}
+
+	if err = os.Remove("/tmp/dirLinkTest"); err != nil {
+		t.Errorf("failed to remove symlink: %s", err)
+	}
+}
+
+// Reading a non-existing symlink must fail
+func TestReadSymlinkedDirectoryNonExistingSymlink(t *testing.T) {
+	var path string
+	var err error
+	if path, err = ReadSymlinkedDirectory("/tmp/test/foo/Non/ExistingPath"); err == nil {
+		t.Fatalf("error expected for non-existing symlink")
+	}
+
+	if path != "" {
+		t.Fatalf("expected empty path, but '%s' was returned", path)
+	}
+}
+
+// Reading a symlink to a file must fail
+func TestReadSymlinkedDirectoryToFile(t *testing.T) {
+	var err error
+	var file *os.File
+
+	if file, err = os.Create("/tmp/testReadSymlinkToFile"); err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+
+	file.Close()
+
+	if err = os.Symlink("/tmp/testReadSymlinkToFile", "/tmp/fileLinkTest"); err != nil {
+		t.Errorf("failed to create symlink: %s", err)
+	}
+
+	var path string
+	if path, err = ReadSymlinkedDirectory("/tmp/fileLinkTest"); err == nil {
+		t.Fatalf("ReadSymlinkedDirectory on a symlink to a file should've failed")
+	}
+
+	if path != "" {
+		t.Fatalf("path should've been empty: %s", path)
+	}
+
+	if err = os.Remove("/tmp/testReadSymlinkToFile"); err != nil {
+		t.Errorf("failed to remove file: %s", err)
+	}
+
+	if err = os.Remove("/tmp/fileLinkTest"); err != nil {
+		t.Errorf("failed to remove symlink: %s", err)
+	}
+}
+
+func TestWildcardMatches(t *testing.T) {
+	match, _ := Matches("fileutils.go", []string{"*"})
+	if match != true {
+		t.Errorf("failed to get a wildcard match, got %v", match)
+	}
+}
+
+// A simple pattern match should return true.
+func TestPatternMatches(t *testing.T) {
+	match, _ := Matches("fileutils.go", []string{"*.go"})
+	if match != true {
+		t.Errorf("failed to get a match, got %v", match)
+	}
+}
+
+// An exclusion followed by an inclusion should return true.
+func TestExclusionPatternMatchesPatternBefore(t *testing.T) {
+	match, _ := Matches("fileutils.go", []string{"!fileutils.go", "*.go"})
+	if match != true {
+		t.Errorf("failed to get true match on exclusion pattern, got %v", match)
+	}
+}
+
+// A folder pattern followed by an exception should return false.
+func TestPatternMatchesFolderExclusions(t *testing.T) {
+	match, _ := Matches("docs/README.md", []string{"docs", "!docs/README.md"})
+	if match != false {
+		t.Errorf("failed to get a false match on exclusion pattern, got %v", match)
+	}
+}
+
+// A folder pattern followed by an exception should return false.
+func TestPatternMatchesFolderWithSlashExclusions(t *testing.T) {
+	match, _ := Matches("docs/README.md", []string{"docs/", "!docs/README.md"})
+	if match != false {
+		t.Errorf("failed to get a false match on exclusion pattern, got %v", match)
+	}
+}
+
+// A folder pattern followed by an exception should return false.
+func TestPatternMatchesFolderWildcardExclusions(t *testing.T) {
+	match, _ := Matches("docs/README.md", []string{"docs/*", "!docs/README.md"})
+	if match != false {
+		t.Errorf("failed to get a false match on exclusion pattern, got %v", match)
+	}
+}
+
+// A pattern followed by an exclusion should return false.
+func TestExclusionPatternMatchesPatternAfter(t *testing.T) {
+	match, _ := Matches("fileutils.go", []string{"*.go", "!fileutils.go"})
+	if match != false {
+		t.Errorf("failed to get false match on exclusion pattern, got %v", match)
+	}
+}
+
+// A filename evaluating to . should return false.
+func TestExclusionPatternMatchesWholeDirectory(t *testing.T) {
+	match, _ := Matches(".", []string{"*.go"})
+	if match != false {
+		t.Errorf("failed to get false match on ., got %v", match)
+	}
+}
+
+// A single ! pattern should return an error.
+func TestSingleExclamationError(t *testing.T) {
+	_, err := Matches("fileutils.go", []string{"!"})
+	if err == nil {
+		t.Errorf("failed to get an error for a single exclamation point, got %v", err)
+	}
+}
+
+// A string preceded with a ! should return true from Exclusion.
+func TestExclusion(t *testing.T) {
+	exclusion := exclusion("!")
+	if !exclusion {
+		t.Errorf("failed to get true for a single !, got %v", exclusion)
+	}
+}
+
+// Matches with no patterns
+func TestMatchesWithNoPatterns(t *testing.T) {
+	matches, err := Matches("/any/path/there", []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matches {
+		t.Fatalf("Should not have match anything")
+	}
+}
+
+// Matches with malformed patterns
+func TestMatchesWithMalformedPatterns(t *testing.T) {
+	matches, err := Matches("/any/path/there", []string{"["})
+	if err == nil {
+		t.Fatal("Should have failed because of a malformed syntax in the pattern")
+	}
+	if matches {
+		t.Fatalf("Should not have match anything")
+	}
+}
+
+// An empty string should return true from Empty.
+func TestEmpty(t *testing.T) {
+	empty := empty("")
+	if !empty {
+		t.Errorf("failed to get true for an empty string, got %v", empty)
+	}
+}
+
+func TestCleanPatterns(t *testing.T) {
+	cleaned, _, _, _ := CleanPatterns([]string{"docs", "config"})
+	if len(cleaned) != 2 {
+		t.Errorf("expected 2 element slice, got %v", len(cleaned))
+	}
+}
+
+func TestCleanPatternsStripEmptyPatterns(t *testing.T) {
+	cleaned, _, _, _ := CleanPatterns([]string{"docs", "config", ""})
+	if len(cleaned) != 2 {
+		t.Errorf("expected 2 element slice, got %v", len(cleaned))
+	}
+}
+
+func TestCleanPatternsExceptionFlag(t *testing.T) {
+	_, _, exceptions, _ := CleanPatterns([]string{"docs", "!docs/README.md"})
+	if !exceptions {
+		t.Errorf("expected exceptions to be true, got %v", exceptions)
+	}
+}
+
+func TestCleanPatternsLeadingSpaceTrimmed(t *testing.T) {
+	_, _, exceptions, _ := CleanPatterns([]string{"docs", "  !docs/README.md"})
+	if !exceptions {
+		t.Errorf("expected exceptions to be true, got %v", exceptions)
+	}
+}
+
+func TestCleanPatternsTrailingSpaceTrimmed(t *testing.T) {
+	_, _, exceptions, _ := CleanPatterns([]string{"docs", "!docs/README.md  "})
+	if !exceptions {
+		t.Errorf("expected exceptions to be true, got %v", exceptions)
+	}
+}
+
+func TestCleanPatternsErrorSingleException(t *testing.T) {
+	_, _, _, err := CleanPatterns([]string{"!"})
+	if err == nil {
+		t.Errorf("expected error on single exclamation point, got %v", err)
+	}
+}
+
+func TestCleanPatternsFolderSplit(t *testing.T) {
+	_, dirs, _, _ := CleanPatterns([]string{"docs/config/CONFIG.md"})
+	if dirs[0][0] != "docs" {
+		t.Errorf("expected first element in dirs slice to be docs, got %v", dirs[0][1])
+	}
+	if dirs[0][1] != "config" {
+		t.Errorf("expected first element in dirs slice to be config, got %v", dirs[0][1])
+	}
+}
+
+func TestCreateIfNotExistsDir(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-fileutils-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempFolder)
+
+	folderToCreate := filepath.Join(tempFolder, "tocreate")
+
+	if err := CreateIfNotExists(folderToCreate, true); err != nil {
+		t.Fatal(err)
+	}
+	fileinfo, err := os.Stat(folderToCreate)
+	if err != nil {
+		t.Fatalf("Should have create a folder, got %v", err)
+	}
+
+	if !fileinfo.IsDir() {
+		t.Fatalf("Should have been a dir, seems it's not")
+	}
+}
+
+func TestCreateIfNotExistsFile(t *testing.T) {
+	tempFolder, err := ioutil.TempDir("", "docker-fileutils-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempFolder)
+
+	fileToCreate := filepath.Join(tempFolder, "file/to/create")
+
+	if err := CreateIfNotExists(fileToCreate, false); err != nil {
+		t.Fatal(err)
+	}
+	fileinfo, err := os.Stat(fileToCreate)
+	if err != nil {
+		t.Fatalf("Should have create a file, got %v", err)
+	}
+
+	if fileinfo.IsDir() {
+		t.Fatalf("Should have been a file, seems it's not")
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/homedir/homedir.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/homedir/homedir.go
@@ -1,0 +1,39 @@
+package homedir
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/opencontainers/runc/libcontainer/user"
+)
+
+// Key returns the env var name for the user's home dir based on
+// the platform being run on
+func Key() string {
+	if runtime.GOOS == "windows" {
+		return "USERPROFILE"
+	}
+	return "HOME"
+}
+
+// Get returns the home directory of the current user with the help of
+// environment variables depending on the target operating system.
+// Returned path should be used with "path/filepath" to form new paths.
+func Get() string {
+	home := os.Getenv(Key())
+	if home == "" && runtime.GOOS != "windows" {
+		if u, err := user.CurrentUser(); err == nil {
+			return u.Home
+		}
+	}
+	return home
+}
+
+// GetShortcutString returns the string that is shortcut to user's home directory
+// in the native shell of the platform running on.
+func GetShortcutString() string {
+	if runtime.GOOS == "windows" {
+		return "%USERPROFILE%" // be careful while using in format functions
+	}
+	return "~"
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/homedir/homedir_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/homedir/homedir_test.go
@@ -1,0 +1,24 @@
+package homedir
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	home := Get()
+	if home == "" {
+		t.Fatal("returned home directory is empty")
+	}
+
+	if !filepath.IsAbs(home) {
+		t.Fatalf("returned path is not absolute: %s", home)
+	}
+}
+
+func TestGetShortcutString(t *testing.T) {
+	shortcut := GetShortcutString()
+	if shortcut == "" {
+		t.Fatal("returned shortcut string is empty")
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/fmt.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/fmt.go
@@ -1,0 +1,14 @@
+package ioutils
+
+import (
+	"fmt"
+	"io"
+)
+
+// FprintfIfNotEmpty prints the string value if it's not empty
+func FprintfIfNotEmpty(w io.Writer, format, value string) (int, error) {
+	if value != "" {
+		return fmt.Fprintf(w, format, value)
+	}
+	return 0, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/fmt_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/fmt_test.go
@@ -1,0 +1,17 @@
+package ioutils
+
+import "testing"
+
+func TestFprintfIfNotEmpty(t *testing.T) {
+	wc := NewWriteCounter(&NopWriter{})
+	n, _ := FprintfIfNotEmpty(wc, "foo%s", "")
+
+	if wc.Count != 0 || n != 0 {
+		t.Errorf("Wrong count: %v vs. %v vs. 0", wc.Count, n)
+	}
+
+	n, _ = FprintfIfNotEmpty(wc, "foo%s", "bar")
+	if wc.Count != 6 || n != 6 {
+		t.Errorf("Wrong count: %v vs. %v vs. 6", wc.Count, n)
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/multireader.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/multireader.go
@@ -1,0 +1,226 @@
+package ioutils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+)
+
+type pos struct {
+	idx    int
+	offset int64
+}
+
+type multiReadSeeker struct {
+	readers []io.ReadSeeker
+	pos     *pos
+	posIdx  map[io.ReadSeeker]int
+}
+
+func (r *multiReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	var tmpOffset int64
+	switch whence {
+	case os.SEEK_SET:
+		for i, rdr := range r.readers {
+			// get size of the current reader
+			s, err := rdr.Seek(0, os.SEEK_END)
+			if err != nil {
+				return -1, err
+			}
+
+			if offset > tmpOffset+s {
+				if i == len(r.readers)-1 {
+					rdrOffset := s + (offset - tmpOffset)
+					if _, err := rdr.Seek(rdrOffset, os.SEEK_SET); err != nil {
+						return -1, err
+					}
+					r.pos = &pos{i, rdrOffset}
+					return offset, nil
+				}
+
+				tmpOffset += s
+				continue
+			}
+
+			rdrOffset := offset - tmpOffset
+			idx := i
+
+			rdr.Seek(rdrOffset, os.SEEK_SET)
+			// make sure all following readers are at 0
+			for _, rdr := range r.readers[i+1:] {
+				rdr.Seek(0, os.SEEK_SET)
+			}
+
+			if rdrOffset == s && i != len(r.readers)-1 {
+				idx += 1
+				rdrOffset = 0
+			}
+			r.pos = &pos{idx, rdrOffset}
+			return offset, nil
+		}
+	case os.SEEK_END:
+		for _, rdr := range r.readers {
+			s, err := rdr.Seek(0, os.SEEK_END)
+			if err != nil {
+				return -1, err
+			}
+			tmpOffset += s
+		}
+		r.Seek(tmpOffset+offset, os.SEEK_SET)
+		return tmpOffset + offset, nil
+	case os.SEEK_CUR:
+		if r.pos == nil {
+			return r.Seek(offset, os.SEEK_SET)
+		}
+		// Just return the current offset
+		if offset == 0 {
+			return r.getCurOffset()
+		}
+
+		curOffset, err := r.getCurOffset()
+		if err != nil {
+			return -1, err
+		}
+		rdr, rdrOffset, err := r.getReaderForOffset(curOffset + offset)
+		if err != nil {
+			return -1, err
+		}
+
+		r.pos = &pos{r.posIdx[rdr], rdrOffset}
+		return curOffset + offset, nil
+	default:
+		return -1, fmt.Errorf("Invalid whence: %d", whence)
+	}
+
+	return -1, fmt.Errorf("Error seeking for whence: %d, offset: %d", whence, offset)
+}
+
+func (r *multiReadSeeker) getReaderForOffset(offset int64) (io.ReadSeeker, int64, error) {
+	var rdr io.ReadSeeker
+	var rdrOffset int64
+
+	for i, rdr := range r.readers {
+		offsetTo, err := r.getOffsetToReader(rdr)
+		if err != nil {
+			return nil, -1, err
+		}
+		if offsetTo > offset {
+			rdr = r.readers[i-1]
+			rdrOffset = offsetTo - offset
+			break
+		}
+
+		if rdr == r.readers[len(r.readers)-1] {
+			rdrOffset = offsetTo + offset
+			break
+		}
+	}
+
+	return rdr, rdrOffset, nil
+}
+
+func (r *multiReadSeeker) getCurOffset() (int64, error) {
+	var totalSize int64
+	for _, rdr := range r.readers[:r.pos.idx+1] {
+		if r.posIdx[rdr] == r.pos.idx {
+			totalSize += r.pos.offset
+			break
+		}
+
+		size, err := getReadSeekerSize(rdr)
+		if err != nil {
+			return -1, fmt.Errorf("error getting seeker size: %v", err)
+		}
+		totalSize += size
+	}
+	return totalSize, nil
+}
+
+func (r *multiReadSeeker) getOffsetToReader(rdr io.ReadSeeker) (int64, error) {
+	var offset int64
+	for _, r := range r.readers {
+		if r == rdr {
+			break
+		}
+
+		size, err := getReadSeekerSize(rdr)
+		if err != nil {
+			return -1, err
+		}
+		offset += size
+	}
+	return offset, nil
+}
+
+func (r *multiReadSeeker) Read(b []byte) (int, error) {
+	if r.pos == nil {
+		r.pos = &pos{0, 0}
+	}
+
+	bCap := int64(cap(b))
+	buf := bytes.NewBuffer(nil)
+	var rdr io.ReadSeeker
+
+	for _, rdr = range r.readers[r.pos.idx:] {
+		readBytes, err := io.CopyN(buf, rdr, bCap)
+		if err != nil && err != io.EOF {
+			return -1, err
+		}
+		bCap -= readBytes
+
+		if bCap == 0 {
+			break
+		}
+	}
+
+	rdrPos, err := rdr.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		return -1, err
+	}
+	r.pos = &pos{r.posIdx[rdr], rdrPos}
+	return buf.Read(b)
+}
+
+func getReadSeekerSize(rdr io.ReadSeeker) (int64, error) {
+	// save the current position
+	pos, err := rdr.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		return -1, err
+	}
+
+	// get the size
+	size, err := rdr.Seek(0, os.SEEK_END)
+	if err != nil {
+		return -1, err
+	}
+
+	// reset the position
+	if _, err := rdr.Seek(pos, os.SEEK_SET); err != nil {
+		return -1, err
+	}
+	return size, nil
+}
+
+// MultiReadSeeker returns a ReadSeeker that's the logical concatenation of the provided
+// input readseekers. After calling this method the initial position is set to the
+// beginning of the first ReadSeeker. At the end of a ReadSeeker, Read always advances
+// to the beginning of the next ReadSeeker and returns EOF at the end of the last ReadSeeker.
+// Seek can be used over the sum of lengths of all readseekers.
+//
+// When a MultiReadSeeker is used, no Read and Seek operations should be made on
+// its ReadSeeker components. Also, users should make no assumption on the state
+// of individual readseekers while the MultiReadSeeker is used.
+func MultiReadSeeker(readers ...io.ReadSeeker) io.ReadSeeker {
+	if len(readers) == 1 {
+		return readers[0]
+	}
+	idx := make(map[io.ReadSeeker]int)
+	for i, rdr := range readers {
+		idx[rdr] = i
+	}
+	return &multiReadSeeker{
+		readers: readers,
+		posIdx:  idx,
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/multireader_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/multireader_test.go
@@ -1,0 +1,149 @@
+package ioutils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMultiReadSeekerReadAll(t *testing.T) {
+	str := "hello world"
+	s1 := strings.NewReader(str + " 1")
+	s2 := strings.NewReader(str + " 2")
+	s3 := strings.NewReader(str + " 3")
+	mr := MultiReadSeeker(s1, s2, s3)
+
+	expectedSize := int64(s1.Len() + s2.Len() + s3.Len())
+
+	b, err := ioutil.ReadAll(mr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "hello world 1hello world 2hello world 3"
+	if string(b) != expected {
+		t.Fatalf("ReadAll failed, got: %q, expected %q", string(b), expected)
+	}
+
+	size, err := mr.Seek(0, os.SEEK_END)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != expectedSize {
+		t.Fatalf("reader size does not match, got %d, expected %d", size, expectedSize)
+	}
+
+	// Reset the position and read again
+	pos, err := mr.Seek(0, os.SEEK_SET)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 0 {
+		t.Fatalf("expected position to be set to 0, got %d", pos)
+	}
+
+	b, err = ioutil.ReadAll(mr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(b) != expected {
+		t.Fatalf("ReadAll failed, got: %q, expected %q", string(b), expected)
+	}
+}
+
+func TestMultiReadSeekerReadEach(t *testing.T) {
+	str := "hello world"
+	s1 := strings.NewReader(str + " 1")
+	s2 := strings.NewReader(str + " 2")
+	s3 := strings.NewReader(str + " 3")
+	mr := MultiReadSeeker(s1, s2, s3)
+
+	var totalBytes int64
+	for i, s := range []*strings.Reader{s1, s2, s3} {
+		sLen := int64(s.Len())
+		buf := make([]byte, s.Len())
+		expected := []byte(fmt.Sprintf("%s %d", str, i+1))
+
+		if _, err := mr.Read(buf); err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(buf, expected) {
+			t.Fatalf("expected %q to be %q", string(buf), string(expected))
+		}
+
+		pos, err := mr.Seek(0, os.SEEK_CUR)
+		if err != nil {
+			t.Fatalf("iteration: %d, error: %v", i+1, err)
+		}
+
+		// check that the total bytes read is the current position of the seeker
+		totalBytes += sLen
+		if pos != totalBytes {
+			t.Fatalf("expected current position to be: %d, got: %d, iteration: %d", totalBytes, pos, i+1)
+		}
+
+		// This tests not only that SEEK_SET and SEEK_CUR give the same values, but that the next iteration is in the expected position as well
+		newPos, err := mr.Seek(pos, os.SEEK_SET)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if newPos != pos {
+			t.Fatalf("expected to get same position when calling SEEK_SET with value from SEEK_CUR, cur: %d, set: %d", pos, newPos)
+		}
+	}
+}
+
+func TestMultiReadSeekerReadSpanningChunks(t *testing.T) {
+	str := "hello world"
+	s1 := strings.NewReader(str + " 1")
+	s2 := strings.NewReader(str + " 2")
+	s3 := strings.NewReader(str + " 3")
+	mr := MultiReadSeeker(s1, s2, s3)
+
+	buf := make([]byte, s1.Len()+3)
+	_, err := mr.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// expected is the contents of s1 + 3 bytes from s2, ie, the `hel` at the end of this string
+	expected := "hello world 1hel"
+	if string(buf) != expected {
+		t.Fatalf("expected %s to be %s", string(buf), expected)
+	}
+}
+
+func TestMultiReadSeekerNegativeSeek(t *testing.T) {
+	str := "hello world"
+	s1 := strings.NewReader(str + " 1")
+	s2 := strings.NewReader(str + " 2")
+	s3 := strings.NewReader(str + " 3")
+	mr := MultiReadSeeker(s1, s2, s3)
+
+	s1Len := s1.Len()
+	s2Len := s2.Len()
+	s3Len := s3.Len()
+
+	s, err := mr.Seek(int64(-1*s3.Len()), os.SEEK_END)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != int64(s1Len+s2Len) {
+		t.Fatalf("expected %d to be %d", s, s1.Len()+s2.Len())
+	}
+
+	buf := make([]byte, s3Len)
+	if _, err := mr.Read(buf); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	expected := fmt.Sprintf("%s %d", str, 3)
+	if string(buf) != fmt.Sprintf("%s %d", str, 3) {
+		t.Fatalf("expected %q to be %q", string(buf), expected)
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/readers.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/readers.go
@@ -1,0 +1,254 @@
+package ioutils
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"math/big"
+	"sync"
+	"time"
+)
+
+type readCloserWrapper struct {
+	io.Reader
+	closer func() error
+}
+
+func (r *readCloserWrapper) Close() error {
+	return r.closer()
+}
+
+func NewReadCloserWrapper(r io.Reader, closer func() error) io.ReadCloser {
+	return &readCloserWrapper{
+		Reader: r,
+		closer: closer,
+	}
+}
+
+type readerErrWrapper struct {
+	reader io.Reader
+	closer func()
+}
+
+func (r *readerErrWrapper) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err != nil {
+		r.closer()
+	}
+	return n, err
+}
+
+func NewReaderErrWrapper(r io.Reader, closer func()) io.Reader {
+	return &readerErrWrapper{
+		reader: r,
+		closer: closer,
+	}
+}
+
+// bufReader allows the underlying reader to continue to produce
+// output by pre-emptively reading from the wrapped reader.
+// This is achieved by buffering this data in bufReader's
+// expanding buffer.
+type bufReader struct {
+	sync.Mutex
+	buf                  *bytes.Buffer
+	reader               io.Reader
+	err                  error
+	wait                 sync.Cond
+	drainBuf             []byte
+	reuseBuf             []byte
+	maxReuse             int64
+	resetTimeout         time.Duration
+	bufLenResetThreshold int64
+	maxReadDataReset     int64
+}
+
+func NewBufReader(r io.Reader) *bufReader {
+	var timeout int
+	if randVal, err := rand.Int(rand.Reader, big.NewInt(120)); err == nil {
+		timeout = int(randVal.Int64()) + 180
+	} else {
+		timeout = 300
+	}
+	reader := &bufReader{
+		buf:                  &bytes.Buffer{},
+		drainBuf:             make([]byte, 1024),
+		reuseBuf:             make([]byte, 4096),
+		maxReuse:             1000,
+		resetTimeout:         time.Second * time.Duration(timeout),
+		bufLenResetThreshold: 100 * 1024,
+		maxReadDataReset:     10 * 1024 * 1024,
+		reader:               r,
+	}
+	reader.wait.L = &reader.Mutex
+	go reader.drain()
+	return reader
+}
+
+func NewBufReaderWithDrainbufAndBuffer(r io.Reader, drainBuffer []byte, buffer *bytes.Buffer) *bufReader {
+	reader := &bufReader{
+		buf:      buffer,
+		drainBuf: drainBuffer,
+		reader:   r,
+	}
+	reader.wait.L = &reader.Mutex
+	go reader.drain()
+	return reader
+}
+
+func (r *bufReader) drain() {
+	var (
+		duration       time.Duration
+		lastReset      time.Time
+		now            time.Time
+		reset          bool
+		bufLen         int64
+		dataSinceReset int64
+		maxBufLen      int64
+		reuseBufLen    int64
+		reuseCount     int64
+	)
+	reuseBufLen = int64(len(r.reuseBuf))
+	lastReset = time.Now()
+	for {
+		n, err := r.reader.Read(r.drainBuf)
+		dataSinceReset += int64(n)
+		r.Lock()
+		bufLen = int64(r.buf.Len())
+		if bufLen > maxBufLen {
+			maxBufLen = bufLen
+		}
+
+		// Avoid unbounded growth of the buffer over time.
+		// This has been discovered to be the only non-intrusive
+		// solution to the unbounded growth of the buffer.
+		// Alternative solutions such as compression, multiple
+		// buffers, channels and other similar pieces of code
+		// were reducing throughput, overall Docker performance
+		// or simply crashed Docker.
+		// This solution releases the buffer when specific
+		// conditions are met to avoid the continuous resizing
+		// of the buffer for long lived containers.
+		//
+		// Move data to the front of the buffer if it's
+		// smaller than what reuseBuf can store
+		if bufLen > 0 && reuseBufLen >= bufLen {
+			n, _ := r.buf.Read(r.reuseBuf)
+			r.buf.Write(r.reuseBuf[0:n])
+			// Take action if the buffer has been reused too many
+			// times and if there's data in the buffer.
+			// The timeout is also used as means to avoid doing
+			// these operations more often or less often than
+			// required.
+			// The various conditions try to detect heavy activity
+			// in the buffer which might be indicators of heavy
+			// growth of the buffer.
+		} else if reuseCount >= r.maxReuse && bufLen > 0 {
+			now = time.Now()
+			duration = now.Sub(lastReset)
+			timeoutReached := duration >= r.resetTimeout
+
+			// The timeout has been reached and the
+			// buffered data couldn't be moved to the front
+			// of the buffer, so the buffer gets reset.
+			if timeoutReached && bufLen > reuseBufLen {
+				reset = true
+			}
+			// The amount of buffered data is too high now,
+			// reset the buffer.
+			if timeoutReached && maxBufLen >= r.bufLenResetThreshold {
+				reset = true
+			}
+			// Reset the buffer if a certain amount of
+			// data has gone through the buffer since the
+			// last reset.
+			if timeoutReached && dataSinceReset >= r.maxReadDataReset {
+				reset = true
+			}
+			// The buffered data is moved to a fresh buffer,
+			// swap the old buffer with the new one and
+			// reset all counters.
+			if reset {
+				newbuf := &bytes.Buffer{}
+				newbuf.ReadFrom(r.buf)
+				r.buf = newbuf
+				lastReset = now
+				reset = false
+				dataSinceReset = 0
+				maxBufLen = 0
+				reuseCount = 0
+			}
+		}
+		if err != nil {
+			r.err = err
+		} else {
+			r.buf.Write(r.drainBuf[0:n])
+		}
+		reuseCount++
+		r.wait.Signal()
+		r.Unlock()
+		callSchedulerIfNecessary()
+		if err != nil {
+			break
+		}
+	}
+}
+
+func (r *bufReader) Read(p []byte) (n int, err error) {
+	r.Lock()
+	defer r.Unlock()
+	for {
+		n, err = r.buf.Read(p)
+		if n > 0 {
+			return n, err
+		}
+		if r.err != nil {
+			return 0, r.err
+		}
+		r.wait.Wait()
+	}
+}
+
+func (r *bufReader) Close() error {
+	closer, ok := r.reader.(io.ReadCloser)
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func HashData(src io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, src); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+type OnEOFReader struct {
+	Rc io.ReadCloser
+	Fn func()
+}
+
+func (r *OnEOFReader) Read(p []byte) (n int, err error) {
+	n, err = r.Rc.Read(p)
+	if err == io.EOF {
+		r.runFunc()
+	}
+	return
+}
+
+func (r *OnEOFReader) Close() error {
+	err := r.Rc.Close()
+	r.runFunc()
+	return err
+}
+
+func (r *OnEOFReader) runFunc() {
+	if fn := r.Fn; fn != nil {
+		fn()
+		r.Fn = nil
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/readers_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/readers_test.go
@@ -1,0 +1,216 @@
+package ioutils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+// Implement io.Reader
+type errorReader struct{}
+
+func (r *errorReader) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf("Error reader always fail.")
+}
+
+func TestReadCloserWrapperClose(t *testing.T) {
+	reader := strings.NewReader("A string reader")
+	wrapper := NewReadCloserWrapper(reader, func() error {
+		return fmt.Errorf("This will be called when closing")
+	})
+	err := wrapper.Close()
+	if err == nil || !strings.Contains(err.Error(), "This will be called when closing") {
+		t.Fatalf("readCloserWrapper should have call the anonymous func and thus, fail.")
+	}
+}
+
+func TestReaderErrWrapperReadOnError(t *testing.T) {
+	called := false
+	reader := &errorReader{}
+	wrapper := NewReaderErrWrapper(reader, func() {
+		called = true
+	})
+	_, err := wrapper.Read([]byte{})
+	if err == nil || !strings.Contains(err.Error(), "Error reader always fail.") {
+		t.Fatalf("readErrWrapper should returned an error")
+	}
+	if !called {
+		t.Fatalf("readErrWrapper should have call the anonymous function on failure")
+	}
+}
+
+func TestReaderErrWrapperRead(t *testing.T) {
+	reader := strings.NewReader("a string reader.")
+	wrapper := NewReaderErrWrapper(reader, func() {
+		t.Fatalf("readErrWrapper should not have called the anonymous function")
+	})
+	// Read 20 byte (should be ok with the string above)
+	num, err := wrapper.Read(make([]byte, 20))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if num != 16 {
+		t.Fatalf("readerErrWrapper should have read 16 byte, but read %d", num)
+	}
+}
+
+func TestNewBufReaderWithDrainbufAndBuffer(t *testing.T) {
+	reader, writer := io.Pipe()
+
+	drainBuffer := make([]byte, 1024)
+	buffer := bytes.Buffer{}
+	bufreader := NewBufReaderWithDrainbufAndBuffer(reader, drainBuffer, &buffer)
+
+	// Write everything down to a Pipe
+	// Usually, a pipe should block but because of the buffered reader,
+	// the writes will go through
+	done := make(chan bool)
+	go func() {
+		writer.Write([]byte("hello world"))
+		writer.Close()
+		done <- true
+	}()
+
+	// Drain the reader *after* everything has been written, just to verify
+	// it is indeed buffering
+	<-done
+
+	output, err := ioutil.ReadAll(bufreader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, []byte("hello world")) {
+		t.Error(string(output))
+	}
+}
+
+func TestBufReader(t *testing.T) {
+	reader, writer := io.Pipe()
+	bufreader := NewBufReader(reader)
+
+	// Write everything down to a Pipe
+	// Usually, a pipe should block but because of the buffered reader,
+	// the writes will go through
+	done := make(chan bool)
+	go func() {
+		writer.Write([]byte("hello world"))
+		writer.Close()
+		done <- true
+	}()
+
+	// Drain the reader *after* everything has been written, just to verify
+	// it is indeed buffering
+	<-done
+	output, err := ioutil.ReadAll(bufreader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, []byte("hello world")) {
+		t.Error(string(output))
+	}
+}
+
+func TestBufReaderCloseWithNonReaderCloser(t *testing.T) {
+	reader := strings.NewReader("buffer")
+	bufreader := NewBufReader(reader)
+
+	if err := bufreader.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+// implements io.ReadCloser
+type simpleReaderCloser struct{}
+
+func (r *simpleReaderCloser) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (r *simpleReaderCloser) Close() error {
+	return nil
+}
+
+func TestBufReaderCloseWithReaderCloser(t *testing.T) {
+	reader := &simpleReaderCloser{}
+	bufreader := NewBufReader(reader)
+
+	err := bufreader.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestHashData(t *testing.T) {
+	reader := strings.NewReader("hash-me")
+	actual, err := HashData(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "sha256:4d11186aed035cc624d553e10db358492c84a7cd6b9670d92123c144930450aa"
+	if actual != expected {
+		t.Fatalf("Expecting %s, got %s", expected, actual)
+	}
+}
+
+type repeatedReader struct {
+	readCount int
+	maxReads  int
+	data      []byte
+}
+
+func newRepeatedReader(max int, data []byte) *repeatedReader {
+	return &repeatedReader{0, max, data}
+}
+
+func (r *repeatedReader) Read(p []byte) (int, error) {
+	if r.readCount >= r.maxReads {
+		return 0, io.EOF
+	}
+	r.readCount++
+	n := copy(p, r.data)
+	return n, nil
+}
+
+func testWithData(data []byte, reads int) {
+	reader := newRepeatedReader(reads, data)
+	bufReader := NewBufReader(reader)
+	io.Copy(ioutil.Discard, bufReader)
+}
+
+func Benchmark1M10BytesReads(b *testing.B) {
+	reads := 1000000
+	readSize := int64(10)
+	data := make([]byte, readSize)
+	b.SetBytes(readSize * int64(reads))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		testWithData(data, reads)
+	}
+}
+
+func Benchmark1M1024BytesReads(b *testing.B) {
+	reads := 1000000
+	readSize := int64(1024)
+	data := make([]byte, readSize)
+	b.SetBytes(readSize * int64(reads))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		testWithData(data, reads)
+	}
+}
+
+func Benchmark10k32KBytesReads(b *testing.B) {
+	reads := 10000
+	readSize := int64(32 * 1024)
+	data := make([]byte, readSize)
+	b.SetBytes(readSize * int64(reads))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		testWithData(data, reads)
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/scheduler.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/scheduler.go
@@ -1,0 +1,6 @@
+// +build !gccgo
+
+package ioutils
+
+func callSchedulerIfNecessary() {
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/scheduler_gccgo.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/scheduler_gccgo.go
@@ -1,0 +1,13 @@
+// +build gccgo
+
+package ioutils
+
+import (
+	"runtime"
+)
+
+func callSchedulerIfNecessary() {
+	//allow or force Go scheduler to switch context, without explicitly
+	//forcing this will make it hang when using gccgo implementation
+	runtime.Gosched()
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/writeflusher.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/writeflusher.go
@@ -1,0 +1,47 @@
+package ioutils
+
+import (
+	"io"
+	"net/http"
+	"sync"
+)
+
+type WriteFlusher struct {
+	sync.Mutex
+	w       io.Writer
+	flusher http.Flusher
+	flushed bool
+}
+
+func (wf *WriteFlusher) Write(b []byte) (n int, err error) {
+	wf.Lock()
+	defer wf.Unlock()
+	n, err = wf.w.Write(b)
+	wf.flushed = true
+	wf.flusher.Flush()
+	return n, err
+}
+
+// Flush the stream immediately.
+func (wf *WriteFlusher) Flush() {
+	wf.Lock()
+	defer wf.Unlock()
+	wf.flushed = true
+	wf.flusher.Flush()
+}
+
+func (wf *WriteFlusher) Flushed() bool {
+	wf.Lock()
+	defer wf.Unlock()
+	return wf.flushed
+}
+
+func NewWriteFlusher(w io.Writer) *WriteFlusher {
+	var flusher http.Flusher
+	if f, ok := w.(http.Flusher); ok {
+		flusher = f
+	} else {
+		flusher = &NopFlusher{}
+	}
+	return &WriteFlusher{w: w, flusher: flusher}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/writers.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/writers.go
@@ -1,0 +1,60 @@
+package ioutils
+
+import "io"
+
+type NopWriter struct{}
+
+func (*NopWriter) Write(buf []byte) (int, error) {
+	return len(buf), nil
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (w *nopWriteCloser) Close() error { return nil }
+
+func NopWriteCloser(w io.Writer) io.WriteCloser {
+	return &nopWriteCloser{w}
+}
+
+type NopFlusher struct{}
+
+func (f *NopFlusher) Flush() {}
+
+type writeCloserWrapper struct {
+	io.Writer
+	closer func() error
+}
+
+func (r *writeCloserWrapper) Close() error {
+	return r.closer()
+}
+
+func NewWriteCloserWrapper(r io.Writer, closer func() error) io.WriteCloser {
+	return &writeCloserWrapper{
+		Writer: r,
+		closer: closer,
+	}
+}
+
+// Wrap a concrete io.Writer and hold a count of the number
+// of bytes written to the writer during a "session".
+// This can be convenient when write return is masked
+// (e.g., json.Encoder.Encode())
+type WriteCounter struct {
+	Count  int64
+	Writer io.Writer
+}
+
+func NewWriteCounter(w io.Writer) *WriteCounter {
+	return &WriteCounter{
+		Writer: w,
+	}
+}
+
+func (wc *WriteCounter) Write(p []byte) (count int, err error) {
+	count, err = wc.Writer.Write(p)
+	wc.Count += int64(count)
+	return
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/writers_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils/writers_test.go
@@ -1,0 +1,65 @@
+package ioutils
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWriteCloserWrapperClose(t *testing.T) {
+	called := false
+	writer := bytes.NewBuffer([]byte{})
+	wrapper := NewWriteCloserWrapper(writer, func() error {
+		called = true
+		return nil
+	})
+	if err := wrapper.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatalf("writeCloserWrapper should have call the anonymous function.")
+	}
+}
+
+func TestNopWriteCloser(t *testing.T) {
+	writer := bytes.NewBuffer([]byte{})
+	wrapper := NopWriteCloser(writer)
+	if err := wrapper.Close(); err != nil {
+		t.Fatal("NopWriteCloser always return nil on Close.")
+	}
+
+}
+
+func TestNopWriter(t *testing.T) {
+	nw := &NopWriter{}
+	l, err := nw.Write([]byte{'c'})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l != 1 {
+		t.Fatalf("Expected 1 got %d", l)
+	}
+}
+
+func TestWriteCounter(t *testing.T) {
+	dummy1 := "This is a dummy string."
+	dummy2 := "This is another dummy string."
+	totalLength := int64(len(dummy1) + len(dummy2))
+
+	reader1 := strings.NewReader(dummy1)
+	reader2 := strings.NewReader(dummy2)
+
+	var buffer bytes.Buffer
+	wc := NewWriteCounter(&buffer)
+
+	reader1.WriteTo(wc)
+	reader2.WriteTo(wc)
+
+	if wc.Count != totalLength {
+		t.Errorf("Wrong count: %d vs. %d", wc.Count, totalLength)
+	}
+
+	if buffer.String() != dummy1+dummy2 {
+		t.Error("Wrong message written")
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/mflag/LICENSE
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/mflag/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014-2015 The Docker & Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/mflag/README.md
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/mflag/README.md
@@ -1,0 +1,40 @@
+Package mflag (aka multiple-flag) implements command-line flag parsing.  
+It's an **hacky** fork of the [official golang package](http://golang.org/pkg/flag/)
+
+It adds:
+
+* both short and long flag version  
+`./example -s red` `./example --string blue`
+
+* multiple names for the same option  
+```
+$>./example -h
+Usage of example:
+  -s, --string="": a simple string
+```
+
+___
+It is very flexible on purpose, so you can do things like:  
+```
+$>./example -h
+Usage of example:
+  -s, -string, --string="": a simple string
+```
+
+Or:  
+```
+$>./example -h
+Usage of example:
+  -oldflag, --newflag="": a simple string
+```
+
+You can also hide some flags from the usage, so if we want only `--newflag`:  
+```
+$>./example -h
+Usage of example:
+  --newflag="": a simple string
+$>./example -oldflag str
+str
+```
+
+See [example.go](example/example.go) for more details.

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/mflag/flag.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/mflag/flag.go
@@ -1,0 +1,1201 @@
+// Copyright 2014-2015 The Docker & Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//	Package mflag implements command-line flag parsing.
+//
+//	Usage:
+//
+//	Define flags using flag.String(), Bool(), Int(), etc.
+//
+//	This declares an integer flag, -f or --flagname, stored in the pointer ip, with type *int.
+//		import "flag /github.com/docker/docker/pkg/mflag"
+//		var ip = flag.Int([]string{"f", "-flagname"}, 1234, "help message for flagname")
+//	If you like, you can bind the flag to a variable using the Var() functions.
+//		var flagvar int
+//		func init() {
+//			// -flaghidden will work, but will be hidden from the usage
+//			flag.IntVar(&flagvar, []string{"f", "#flaghidden", "-flagname"}, 1234, "help message for flagname")
+//		}
+//	Or you can create custom flags that satisfy the Value interface (with
+//	pointer receivers) and couple them to flag parsing by
+//		flag.Var(&flagVal, []string{"name"}, "help message for flagname")
+//	For such flags, the default value is just the initial value of the variable.
+//
+//	You can also add "deprecated" flags, they are still usable, but are not shown
+//	in the usage and will display a warning when you try to use them. `#` before
+//	an option means this option is deprecated, if there is an following option
+//	without `#` ahead, then that's the replacement, if not, it will just be removed:
+//		var ip = flag.Int([]string{"#f", "#flagname", "-flagname"}, 1234, "help message for flagname")
+//	this will display: `Warning: '-f' is deprecated, it will be replaced by '--flagname' soon. See usage.` or
+//	this will display: `Warning: '-flagname' is deprecated, it will be replaced by '--flagname' soon. See usage.`
+//		var ip = flag.Int([]string{"f", "#flagname"}, 1234, "help message for flagname")
+//	will display: `Warning: '-flagname' is deprecated, it will be removed soon. See usage.`
+//	so you can only use `-f`.
+//
+//	You can also group one letter flags, bif you declare
+//		var v = flag.Bool([]string{"v", "-verbose"}, false, "help message for verbose")
+//		var s = flag.Bool([]string{"s", "-slow"}, false, "help message for slow")
+//	you will be able to use the -vs or -sv
+//
+//	After all flags are defined, call
+//		flag.Parse()
+//	to parse the command line into the defined flags.
+//
+//	Flags may then be used directly. If you're using the flags themselves,
+//	they are all pointers; if you bind to variables, they're values.
+//		fmt.Println("ip has value ", *ip)
+//		fmt.Println("flagvar has value ", flagvar)
+//
+//	After parsing, the arguments after the flag are available as the
+//	slice flag.Args() or individually as flag.Arg(i).
+//	The arguments are indexed from 0 through flag.NArg()-1.
+//
+//	Command line flag syntax:
+//		-flag
+//		-flag=x
+//		-flag="x"
+//		-flag='x'
+//		-flag x  // non-boolean flags only
+//	One or two minus signs may be used; they are equivalent.
+//	The last form is not permitted for boolean flags because the
+//	meaning of the command
+//		cmd -x *
+//	will change if there is a file called 0, false, etc.  You must
+//	use the -flag=false form to turn off a boolean flag.
+//
+//	Flag parsing stops just before the first non-flag argument
+//	("-" is a non-flag argument) or after the terminator "--".
+//
+//	Integer flags accept 1234, 0664, 0x1234 and may be negative.
+//	Boolean flags may be 1, 0, t, f, true, false, TRUE, FALSE, True, False.
+//	Duration flags accept any input valid for time.ParseDuration.
+//
+//	The default set of command-line flags is controlled by
+//	top-level functions.  The FlagSet type allows one to define
+//	independent sets of flags, such as to implement subcommands
+//	in a command-line interface. The methods of FlagSet are
+//	analogous to the top-level functions for the command-line
+//	flag set.
+
+package mflag
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/homedir"
+)
+
+// ErrHelp is the error returned if the flag -help is invoked but no such flag is defined.
+var ErrHelp = errors.New("flag: help requested")
+
+// ErrRetry is the error returned if you need to try letter by letter
+var ErrRetry = errors.New("flag: retry")
+
+// -- bool Value
+type boolValue bool
+
+func newBoolValue(val bool, p *bool) *boolValue {
+	*p = val
+	return (*boolValue)(p)
+}
+
+func (b *boolValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	*b = boolValue(v)
+	return err
+}
+
+func (b *boolValue) Get() interface{} { return bool(*b) }
+
+func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+
+func (b *boolValue) IsBoolFlag() bool { return true }
+
+// optional interface to indicate boolean flags that can be
+// supplied without "=value" text
+type boolFlag interface {
+	Value
+	IsBoolFlag() bool
+}
+
+// -- int Value
+type intValue int
+
+func newIntValue(val int, p *int) *intValue {
+	*p = val
+	return (*intValue)(p)
+}
+
+func (i *intValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = intValue(v)
+	return err
+}
+
+func (i *intValue) Get() interface{} { return int(*i) }
+
+func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- int64 Value
+type int64Value int64
+
+func newInt64Value(val int64, p *int64) *int64Value {
+	*p = val
+	return (*int64Value)(p)
+}
+
+func (i *int64Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = int64Value(v)
+	return err
+}
+
+func (i *int64Value) Get() interface{} { return int64(*i) }
+
+func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- uint Value
+type uintValue uint
+
+func newUintValue(val uint, p *uint) *uintValue {
+	*p = val
+	return (*uintValue)(p)
+}
+
+func (i *uintValue) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uintValue(v)
+	return err
+}
+
+func (i *uintValue) Get() interface{} { return uint(*i) }
+
+func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- uint64 Value
+type uint64Value uint64
+
+func newUint64Value(val uint64, p *uint64) *uint64Value {
+	*p = val
+	return (*uint64Value)(p)
+}
+
+func (i *uint64Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uint64Value(v)
+	return err
+}
+
+func (i *uint64Value) Get() interface{} { return uint64(*i) }
+
+func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- string Value
+type stringValue string
+
+func newStringValue(val string, p *string) *stringValue {
+	*p = val
+	return (*stringValue)(p)
+}
+
+func (s *stringValue) Set(val string) error {
+	*s = stringValue(val)
+	return nil
+}
+
+func (s *stringValue) Get() interface{} { return string(*s) }
+
+func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+
+// -- float64 Value
+type float64Value float64
+
+func newFloat64Value(val float64, p *float64) *float64Value {
+	*p = val
+	return (*float64Value)(p)
+}
+
+func (f *float64Value) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 64)
+	*f = float64Value(v)
+	return err
+}
+
+func (f *float64Value) Get() interface{} { return float64(*f) }
+
+func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+
+// -- time.Duration Value
+type durationValue time.Duration
+
+func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
+	*p = val
+	return (*durationValue)(p)
+}
+
+func (d *durationValue) Set(s string) error {
+	v, err := time.ParseDuration(s)
+	*d = durationValue(v)
+	return err
+}
+
+func (d *durationValue) Get() interface{} { return time.Duration(*d) }
+
+func (d *durationValue) String() string { return (*time.Duration)(d).String() }
+
+// Value is the interface to the dynamic value stored in a flag.
+// (The default value is represented as a string.)
+//
+// If a Value has an IsBoolFlag() bool method returning true,
+// the command-line parser makes -name equivalent to -name=true
+// rather than using the next command-line argument.
+type Value interface {
+	String() string
+	Set(string) error
+}
+
+// Getter is an interface that allows the contents of a Value to be retrieved.
+// It wraps the Value interface, rather than being part of it, because it
+// appeared after Go 1 and its compatibility rules. All Value types provided
+// by this package satisfy the Getter interface.
+type Getter interface {
+	Value
+	Get() interface{}
+}
+
+// ErrorHandling defines how to handle flag parsing errors.
+type ErrorHandling int
+
+// ErrorHandling strategies available when a flag parsing error occurs
+const (
+	ContinueOnError ErrorHandling = iota
+	ExitOnError
+	PanicOnError
+)
+
+// A FlagSet represents a set of defined flags.  The zero value of a FlagSet
+// has no name and has ContinueOnError error handling.
+type FlagSet struct {
+	// Usage is the function called when an error occurs while parsing flags.
+	// The field is a function (not a method) that may be changed to point to
+	// a custom error handler.
+	Usage      func()
+	ShortUsage func()
+
+	name             string
+	parsed           bool
+	actual           map[string]*Flag
+	formal           map[string]*Flag
+	args             []string // arguments after flags
+	errorHandling    ErrorHandling
+	output           io.Writer // nil means stderr; use Out() accessor
+	nArgRequirements []nArgRequirement
+}
+
+// A Flag represents the state of a flag.
+type Flag struct {
+	Names    []string // name as it appears on command line
+	Usage    string   // help message
+	Value    Value    // value as set
+	DefValue string   // default value (as text); for usage message
+}
+
+type flagSlice []string
+
+func (p flagSlice) Len() int { return len(p) }
+func (p flagSlice) Less(i, j int) bool {
+	pi, pj := strings.TrimPrefix(p[i], "-"), strings.TrimPrefix(p[j], "-")
+	lpi, lpj := strings.ToLower(pi), strings.ToLower(pj)
+	if lpi != lpj {
+		return lpi < lpj
+	}
+	return pi < pj
+}
+func (p flagSlice) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+// sortFlags returns the flags as a slice in lexicographical sorted order.
+func sortFlags(flags map[string]*Flag) []*Flag {
+	var list flagSlice
+
+	// The sorted list is based on the first name, when flag map might use the other names.
+	nameMap := make(map[string]string)
+
+	for n, f := range flags {
+		fName := strings.TrimPrefix(f.Names[0], "#")
+		nameMap[fName] = n
+		if len(f.Names) == 1 {
+			list = append(list, fName)
+			continue
+		}
+
+		found := false
+		for _, name := range list {
+			if name == fName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			list = append(list, fName)
+		}
+	}
+	sort.Sort(list)
+	result := make([]*Flag, len(list))
+	for i, name := range list {
+		result[i] = flags[nameMap[name]]
+	}
+	return result
+}
+
+// Name returns the name of the FlagSet.
+func (fs *FlagSet) Name() string {
+	return fs.name
+}
+
+// Out returns the destination for usage and error messages.
+func (fs *FlagSet) Out() io.Writer {
+	if fs.output == nil {
+		return os.Stderr
+	}
+	return fs.output
+}
+
+// SetOutput sets the destination for usage and error messages.
+// If output is nil, os.Stderr is used.
+func (fs *FlagSet) SetOutput(output io.Writer) {
+	fs.output = output
+}
+
+// VisitAll visits the flags in lexicographical order, calling fn for each.
+// It visits all flags, even those not set.
+func (fs *FlagSet) VisitAll(fn func(*Flag)) {
+	for _, flag := range sortFlags(fs.formal) {
+		fn(flag)
+	}
+}
+
+// VisitAll visits the command-line flags in lexicographical order, calling
+// fn for each.  It visits all flags, even those not set.
+func VisitAll(fn func(*Flag)) {
+	CommandLine.VisitAll(fn)
+}
+
+// Visit visits the flags in lexicographical order, calling fn for each.
+// It visits only those flags that have been set.
+func (fs *FlagSet) Visit(fn func(*Flag)) {
+	for _, flag := range sortFlags(fs.actual) {
+		fn(flag)
+	}
+}
+
+// Visit visits the command-line flags in lexicographical order, calling fn
+// for each.  It visits only those flags that have been set.
+func Visit(fn func(*Flag)) {
+	CommandLine.Visit(fn)
+}
+
+// Lookup returns the Flag structure of the named flag, returning nil if none exists.
+func (fs *FlagSet) Lookup(name string) *Flag {
+	return fs.formal[name]
+}
+
+// IsSet indicates whether the specified flag is set in the given FlagSet
+func (fs *FlagSet) IsSet(name string) bool {
+	return fs.actual[name] != nil
+}
+
+// Lookup returns the Flag structure of the named command-line flag,
+// returning nil if none exists.
+func Lookup(name string) *Flag {
+	return CommandLine.formal[name]
+}
+
+// IsSet indicates whether the specified flag was specified at all on the cmd line.
+func IsSet(name string) bool {
+	return CommandLine.IsSet(name)
+}
+
+type nArgRequirementType int
+
+// Indicator used to pass to BadArgs function
+const (
+	Exact nArgRequirementType = iota
+	Max
+	Min
+)
+
+type nArgRequirement struct {
+	Type nArgRequirementType
+	N    int
+}
+
+// Require adds a requirement about the number of arguments for the FlagSet.
+// The first parameter can be Exact, Max, or Min to respectively specify the exact,
+// the maximum, or the minimal number of arguments required.
+// The actual check is done in FlagSet.CheckArgs().
+func (fs *FlagSet) Require(nArgRequirementType nArgRequirementType, nArg int) {
+	fs.nArgRequirements = append(fs.nArgRequirements, nArgRequirement{nArgRequirementType, nArg})
+}
+
+// CheckArgs uses the requirements set by FlagSet.Require() to validate
+// the number of arguments. If the requirements are not met,
+// an error message string is returned.
+func (fs *FlagSet) CheckArgs() (message string) {
+	for _, req := range fs.nArgRequirements {
+		var arguments string
+		if req.N == 1 {
+			arguments = "1 argument"
+		} else {
+			arguments = fmt.Sprintf("%d arguments", req.N)
+		}
+
+		str := func(kind string) string {
+			return fmt.Sprintf("%q requires %s%s", fs.name, kind, arguments)
+		}
+
+		switch req.Type {
+		case Exact:
+			if fs.NArg() != req.N {
+				return str("")
+			}
+		case Max:
+			if fs.NArg() > req.N {
+				return str("a maximum of ")
+			}
+		case Min:
+			if fs.NArg() < req.N {
+				return str("a minimum of ")
+			}
+		}
+	}
+	return ""
+}
+
+// Set sets the value of the named flag.
+func (fs *FlagSet) Set(name, value string) error {
+	flag, ok := fs.formal[name]
+	if !ok {
+		return fmt.Errorf("no such flag -%v", name)
+	}
+	if err := flag.Value.Set(value); err != nil {
+		return err
+	}
+	if fs.actual == nil {
+		fs.actual = make(map[string]*Flag)
+	}
+	fs.actual[name] = flag
+	return nil
+}
+
+// Set sets the value of the named command-line flag.
+func Set(name, value string) error {
+	return CommandLine.Set(name, value)
+}
+
+// PrintDefaults prints, to standard error unless configured
+// otherwise, the default values of all defined flags in the set.
+func (fs *FlagSet) PrintDefaults() {
+	writer := tabwriter.NewWriter(fs.Out(), 20, 1, 3, ' ', 0)
+	home := homedir.Get()
+
+	// Don't substitute when HOME is /
+	if runtime.GOOS != "windows" && home == "/" {
+		home = ""
+	}
+
+	// Add a blank line between cmd description and list of options
+	if fs.FlagCount() > 0 {
+		fmt.Fprintln(writer, "")
+	}
+
+	fs.VisitAll(func(flag *Flag) {
+		format := "  -%s=%s"
+		names := []string{}
+		for _, name := range flag.Names {
+			if name[0] != '#' {
+				names = append(names, name)
+			}
+		}
+		if len(names) > 0 && len(flag.Usage) > 0 {
+			val := flag.DefValue
+
+			if home != "" && strings.HasPrefix(val, home) {
+				val = homedir.GetShortcutString() + val[len(home):]
+			}
+
+			fmt.Fprintf(writer, format, strings.Join(names, ", -"), val)
+			for i, line := range strings.Split(flag.Usage, "\n") {
+				if i != 0 {
+					line = "  " + line
+				}
+				fmt.Fprintln(writer, "\t", line)
+			}
+		}
+	})
+	writer.Flush()
+}
+
+// PrintDefaults prints to standard error the default values of all defined command-line flags.
+func PrintDefaults() {
+	CommandLine.PrintDefaults()
+}
+
+// defaultUsage is the default function to print a usage message.
+func defaultUsage(fs *FlagSet) {
+	if fs.name == "" {
+		fmt.Fprintf(fs.Out(), "Usage:\n")
+	} else {
+		fmt.Fprintf(fs.Out(), "Usage of %s:\n", fs.name)
+	}
+	fs.PrintDefaults()
+}
+
+// NOTE: Usage is not just defaultUsage(CommandLine)
+// because it serves (via godoc flag Usage) as the example
+// for how to write your own usage function.
+
+// Usage prints to standard error a usage message documenting all defined command-line flags.
+// The function is a variable that may be changed to point to a custom function.
+var Usage = func() {
+	fmt.Fprintf(CommandLine.Out(), "Usage of %s:\n", os.Args[0])
+	PrintDefaults()
+}
+
+// Usage prints to standard error a usage message documenting the standard command layout
+// The function is a variable that may be changed to point to a custom function.
+var ShortUsage = func() {
+	fmt.Fprintf(CommandLine.output, "Usage of %s:\n", os.Args[0])
+}
+
+// FlagCount returns the number of flags that have been defined.
+func (fs *FlagSet) FlagCount() int { return len(sortFlags(fs.formal)) }
+
+// FlagCountUndeprecated returns the number of undeprecated flags that have been defined.
+func (fs *FlagSet) FlagCountUndeprecated() int {
+	count := 0
+	for _, flag := range sortFlags(fs.formal) {
+		for _, name := range flag.Names {
+			if name[0] != '#' {
+				count++
+				break
+			}
+		}
+	}
+	return count
+}
+
+// NFlag returns the number of flags that have been set.
+func (fs *FlagSet) NFlag() int { return len(fs.actual) }
+
+// NFlag returns the number of command-line flags that have been set.
+func NFlag() int { return len(CommandLine.actual) }
+
+// Arg returns the i'th argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func (fs *FlagSet) Arg(i int) string {
+	if i < 0 || i >= len(fs.args) {
+		return ""
+	}
+	return fs.args[i]
+}
+
+// Arg returns the i'th command-line argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func Arg(i int) string {
+	return CommandLine.Arg(i)
+}
+
+// NArg is the number of arguments remaining after flags have been processed.
+func (fs *FlagSet) NArg() int { return len(fs.args) }
+
+// NArg is the number of arguments remaining after flags have been processed.
+func NArg() int { return len(CommandLine.args) }
+
+// Args returns the non-flag arguments.
+func (fs *FlagSet) Args() []string { return fs.args }
+
+// Args returns the non-flag command-line arguments.
+func Args() []string { return CommandLine.args }
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func (fs *FlagSet) BoolVar(p *bool, names []string, value bool, usage string) {
+	fs.Var(newBoolValue(value, p), names, usage)
+}
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func BoolVar(p *bool, names []string, value bool, usage string) {
+	CommandLine.Var(newBoolValue(value, p), names, usage)
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func (fs *FlagSet) Bool(names []string, value bool, usage string) *bool {
+	p := new(bool)
+	fs.BoolVar(p, names, value, usage)
+	return p
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func Bool(names []string, value bool, usage string) *bool {
+	return CommandLine.Bool(names, value, usage)
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func (fs *FlagSet) IntVar(p *int, names []string, value int, usage string) {
+	fs.Var(newIntValue(value, p), names, usage)
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func IntVar(p *int, names []string, value int, usage string) {
+	CommandLine.Var(newIntValue(value, p), names, usage)
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func (fs *FlagSet) Int(names []string, value int, usage string) *int {
+	p := new(int)
+	fs.IntVar(p, names, value, usage)
+	return p
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func Int(names []string, value int, usage string) *int {
+	return CommandLine.Int(names, value, usage)
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func (fs *FlagSet) Int64Var(p *int64, names []string, value int64, usage string) {
+	fs.Var(newInt64Value(value, p), names, usage)
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func Int64Var(p *int64, names []string, value int64, usage string) {
+	CommandLine.Var(newInt64Value(value, p), names, usage)
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func (fs *FlagSet) Int64(names []string, value int64, usage string) *int64 {
+	p := new(int64)
+	fs.Int64Var(p, names, value, usage)
+	return p
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func Int64(names []string, value int64, usage string) *int64 {
+	return CommandLine.Int64(names, value, usage)
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint variable in which to store the value of the flag.
+func (fs *FlagSet) UintVar(p *uint, names []string, value uint, usage string) {
+	fs.Var(newUintValue(value, p), names, usage)
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint  variable in which to store the value of the flag.
+func UintVar(p *uint, names []string, value uint, usage string) {
+	CommandLine.Var(newUintValue(value, p), names, usage)
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func (fs *FlagSet) Uint(names []string, value uint, usage string) *uint {
+	p := new(uint)
+	fs.UintVar(p, names, value, usage)
+	return p
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func Uint(names []string, value uint, usage string) *uint {
+	return CommandLine.Uint(names, value, usage)
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func (fs *FlagSet) Uint64Var(p *uint64, names []string, value uint64, usage string) {
+	fs.Var(newUint64Value(value, p), names, usage)
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func Uint64Var(p *uint64, names []string, value uint64, usage string) {
+	CommandLine.Var(newUint64Value(value, p), names, usage)
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func (fs *FlagSet) Uint64(names []string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	fs.Uint64Var(p, names, value, usage)
+	return p
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func Uint64(names []string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64(names, value, usage)
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func (fs *FlagSet) StringVar(p *string, names []string, value string, usage string) {
+	fs.Var(newStringValue(value, p), names, usage)
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func StringVar(p *string, names []string, value string, usage string) {
+	CommandLine.Var(newStringValue(value, p), names, usage)
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func (fs *FlagSet) String(names []string, value string, usage string) *string {
+	p := new(string)
+	fs.StringVar(p, names, value, usage)
+	return p
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func String(names []string, value string, usage string) *string {
+	return CommandLine.String(names, value, usage)
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func (fs *FlagSet) Float64Var(p *float64, names []string, value float64, usage string) {
+	fs.Var(newFloat64Value(value, p), names, usage)
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func Float64Var(p *float64, names []string, value float64, usage string) {
+	CommandLine.Var(newFloat64Value(value, p), names, usage)
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func (fs *FlagSet) Float64(names []string, value float64, usage string) *float64 {
+	p := new(float64)
+	fs.Float64Var(p, names, value, usage)
+	return p
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func Float64(names []string, value float64, usage string) *float64 {
+	return CommandLine.Float64(names, value, usage)
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func (fs *FlagSet) DurationVar(p *time.Duration, names []string, value time.Duration, usage string) {
+	fs.Var(newDurationValue(value, p), names, usage)
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func DurationVar(p *time.Duration, names []string, value time.Duration, usage string) {
+	CommandLine.Var(newDurationValue(value, p), names, usage)
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func (fs *FlagSet) Duration(names []string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	fs.DurationVar(p, names, value, usage)
+	return p
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func Duration(names []string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.Duration(names, value, usage)
+}
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func (fs *FlagSet) Var(value Value, names []string, usage string) {
+	// Remember the default value as a string; it won't change.
+	flag := &Flag{names, usage, value, value.String()}
+	for _, name := range names {
+		name = strings.TrimPrefix(name, "#")
+		_, alreadythere := fs.formal[name]
+		if alreadythere {
+			var msg string
+			if fs.name == "" {
+				msg = fmt.Sprintf("flag redefined: %s", name)
+			} else {
+				msg = fmt.Sprintf("%s flag redefined: %s", fs.name, name)
+			}
+			fmt.Fprintln(fs.Out(), msg)
+			panic(msg) // Happens only if flags are declared with identical names
+		}
+		if fs.formal == nil {
+			fs.formal = make(map[string]*Flag)
+		}
+		fs.formal[name] = flag
+	}
+}
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func Var(value Value, names []string, usage string) {
+	CommandLine.Var(value, names, usage)
+}
+
+// failf prints to standard error a formatted error and usage message and
+// returns the error.
+func (fs *FlagSet) failf(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Fprintln(fs.Out(), err)
+	if os.Args[0] == fs.name {
+		fmt.Fprintf(fs.Out(), "See '%s --help'.\n", os.Args[0])
+	} else {
+		fmt.Fprintf(fs.Out(), "See '%s %s --help'.\n", os.Args[0], fs.name)
+	}
+	return err
+}
+
+// usage calls the Usage method for the flag set, or the usage function if
+// the flag set is CommandLine.
+func (fs *FlagSet) usage() {
+	if fs == CommandLine {
+		Usage()
+	} else if fs.Usage == nil {
+		defaultUsage(fs)
+	} else {
+		fs.Usage()
+	}
+}
+
+func trimQuotes(str string) string {
+	if len(str) == 0 {
+		return str
+	}
+	type quote struct {
+		start, end byte
+	}
+
+	// All valid quote types.
+	quotes := []quote{
+		// Double quotes
+		{
+			start: '"',
+			end:   '"',
+		},
+
+		// Single quotes
+		{
+			start: '\'',
+			end:   '\'',
+		},
+	}
+
+	for _, quote := range quotes {
+		// Only strip if outermost match.
+		if str[0] == quote.start && str[len(str)-1] == quote.end {
+			str = str[1 : len(str)-1]
+			break
+		}
+	}
+
+	return str
+}
+
+// parseOne parses one flag. It reports whether a flag was seen.
+func (fs *FlagSet) parseOne() (bool, string, error) {
+	if len(fs.args) == 0 {
+		return false, "", nil
+	}
+	s := fs.args[0]
+	if len(s) == 0 || s[0] != '-' || len(s) == 1 {
+		return false, "", nil
+	}
+	if s[1] == '-' && len(s) == 2 { // "--" terminates the flags
+		fs.args = fs.args[1:]
+		return false, "", nil
+	}
+	name := s[1:]
+	if len(name) == 0 || name[0] == '=' {
+		return false, "", fs.failf("bad flag syntax: %s", s)
+	}
+
+	// it's a flag. does it have an argument?
+	fs.args = fs.args[1:]
+	hasValue := false
+	value := ""
+	if i := strings.Index(name, "="); i != -1 {
+		value = trimQuotes(name[i+1:])
+		hasValue = true
+		name = name[:i]
+	}
+
+	m := fs.formal
+	flag, alreadythere := m[name] // BUG
+	if !alreadythere {
+		if name == "-help" || name == "help" || name == "h" { // special case for nice help message.
+			fs.usage()
+			return false, "", ErrHelp
+		}
+		if len(name) > 0 && name[0] == '-' {
+			return false, "", fs.failf("flag provided but not defined: -%s", name)
+		}
+		return false, name, ErrRetry
+	}
+	if fv, ok := flag.Value.(boolFlag); ok && fv.IsBoolFlag() { // special case: doesn't need an arg
+		if hasValue {
+			if err := fv.Set(value); err != nil {
+				return false, "", fs.failf("invalid boolean value %q for  -%s: %v", value, name, err)
+			}
+		} else {
+			fv.Set("true")
+		}
+	} else {
+		// It must have a value, which might be the next argument.
+		if !hasValue && len(fs.args) > 0 {
+			// value is the next arg
+			hasValue = true
+			value, fs.args = fs.args[0], fs.args[1:]
+		}
+		if !hasValue {
+			return false, "", fs.failf("flag needs an argument: -%s", name)
+		}
+		if err := flag.Value.Set(value); err != nil {
+			return false, "", fs.failf("invalid value %q for flag -%s: %v", value, name, err)
+		}
+	}
+	if fs.actual == nil {
+		fs.actual = make(map[string]*Flag)
+	}
+	fs.actual[name] = flag
+	for i, n := range flag.Names {
+		if n == fmt.Sprintf("#%s", name) {
+			replacement := ""
+			for j := i; j < len(flag.Names); j++ {
+				if flag.Names[j][0] != '#' {
+					replacement = flag.Names[j]
+					break
+				}
+			}
+			if replacement != "" {
+				fmt.Fprintf(fs.Out(), "Warning: '-%s' is deprecated, it will be replaced by '-%s' soon. See usage.\n", name, replacement)
+			} else {
+				fmt.Fprintf(fs.Out(), "Warning: '-%s' is deprecated, it will be removed soon. See usage.\n", name)
+			}
+		}
+	}
+	return true, "", nil
+}
+
+// Parse parses flag definitions from the argument list, which should not
+// include the command name.  Must be called after all flags in the FlagSet
+// are defined and before flags are accessed by the program.
+// The return value will be ErrHelp if -help was set but not defined.
+func (fs *FlagSet) Parse(arguments []string) error {
+	fs.parsed = true
+	fs.args = arguments
+	for {
+		seen, name, err := fs.parseOne()
+		if seen {
+			continue
+		}
+		if err == nil {
+			break
+		}
+		if err == ErrRetry {
+			if len(name) > 1 {
+				err = nil
+				for _, letter := range strings.Split(name, "") {
+					fs.args = append([]string{"-" + letter}, fs.args...)
+					seen2, _, err2 := fs.parseOne()
+					if seen2 {
+						continue
+					}
+					if err2 != nil {
+						err = fs.failf("flag provided but not defined: -%s", name)
+						break
+					}
+				}
+				if err == nil {
+					continue
+				}
+			} else {
+				err = fs.failf("flag provided but not defined: -%s", name)
+			}
+		}
+		switch fs.errorHandling {
+		case ContinueOnError:
+			return err
+		case ExitOnError:
+			os.Exit(2)
+		case PanicOnError:
+			panic(err)
+		}
+	}
+	return nil
+}
+
+// ParseFlags is a utility function that adds a help flag if withHelp is true,
+// calls fs.Parse(args) and prints a relevant error message if there are
+// incorrect number of arguments. It returns error only if error handling is
+// set to ContinueOnError and parsing fails. If error handling is set to
+// ExitOnError, it's safe to ignore the return value.
+func (fs *FlagSet) ParseFlags(args []string, withHelp bool) error {
+	var help *bool
+	if withHelp {
+		help = fs.Bool([]string{"#help", "-help"}, false, "Print usage")
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if help != nil && *help {
+		fs.SetOutput(os.Stdout)
+		fs.Usage()
+		os.Exit(0)
+	}
+	if str := fs.CheckArgs(); str != "" {
+		fs.SetOutput(os.Stderr)
+		fs.ReportError(str, withHelp)
+		fs.ShortUsage()
+		os.Exit(1)
+	}
+	return nil
+}
+
+// ReportError is a utility method that prints a user-friendly message
+// containing the error that occured during parsing and a suggestion to get help
+func (fs *FlagSet) ReportError(str string, withHelp bool) {
+	if withHelp {
+		if os.Args[0] == fs.Name() {
+			str += ".\nSee '" + os.Args[0] + " --help'"
+		} else {
+			str += ".\nSee '" + os.Args[0] + " " + fs.Name() + " --help'"
+		}
+	}
+	fmt.Fprintf(fs.Out(), "docker: %s.\n", str)
+}
+
+// Parsed reports whether fs.Parse has been called.
+func (fs *FlagSet) Parsed() bool {
+	return fs.parsed
+}
+
+// Parse parses the command-line flags from os.Args[1:].  Must be called
+// after all flags are defined and before flags are accessed by the program.
+func Parse() {
+	// Ignore errors; CommandLine is set for ExitOnError.
+	CommandLine.Parse(os.Args[1:])
+}
+
+// Parsed returns true if the command-line flags have been parsed.
+func Parsed() bool {
+	return CommandLine.Parsed()
+}
+
+// CommandLine is the default set of command-line flags, parsed from os.Args.
+// The top-level functions such as BoolVar, Arg, and on are wrappers for the
+// methods of CommandLine.
+var CommandLine = NewFlagSet(os.Args[0], ExitOnError)
+
+// NewFlagSet returns a new, empty flag set with the specified name and
+// error handling property.
+func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
+	f := &FlagSet{
+		name:          name,
+		errorHandling: errorHandling,
+	}
+	return f
+}
+
+// Init sets the name and error handling property for a flag set.
+// By default, the zero FlagSet uses an empty name and the
+// ContinueOnError error handling policy.
+func (fs *FlagSet) Init(name string, errorHandling ErrorHandling) {
+	fs.name = name
+	fs.errorHandling = errorHandling
+}
+
+type mergeVal struct {
+	Value
+	key  string
+	fset *FlagSet
+}
+
+func (v mergeVal) Set(s string) error {
+	return v.fset.Set(v.key, s)
+}
+
+func (v mergeVal) IsBoolFlag() bool {
+	if b, ok := v.Value.(boolFlag); ok {
+		return b.IsBoolFlag()
+	}
+	return false
+}
+
+// Merge is an helper function that merges n FlagSets into a single dest FlagSet
+// In case of name collision between the flagsets it will apply
+// the destination FlagSet's errorHandling behaviour.
+func Merge(dest *FlagSet, flagsets ...*FlagSet) error {
+	for _, fset := range flagsets {
+		for k, f := range fset.formal {
+			if _, ok := dest.formal[k]; ok {
+				var err error
+				if fset.name == "" {
+					err = fmt.Errorf("flag redefined: %s", k)
+				} else {
+					err = fmt.Errorf("%s flag redefined: %s", fset.name, k)
+				}
+				fmt.Fprintln(fset.Out(), err.Error())
+				// Happens only if flags are declared with identical names
+				switch dest.errorHandling {
+				case ContinueOnError:
+					return err
+				case ExitOnError:
+					os.Exit(2)
+				case PanicOnError:
+					panic(err)
+				}
+			}
+			newF := *f
+			newF.Value = mergeVal{f.Value, k, fset}
+			dest.formal[k] = &newF
+		}
+	}
+	return nil
+}
+
+// IsEmpty reports if the FlagSet is actually empty.
+func (fs *FlagSet) IsEmpty() bool {
+	return len(fs.actual) == 0
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/mflag/flag_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/mflag/flag_test.go
@@ -1,0 +1,516 @@
+// Copyright 2014-2015 The Docker & Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mflag
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ResetForTesting clears all flag state and sets the usage function as directed.
+// After calling ResetForTesting, parse errors in flag handling will not
+// exit the program.
+func ResetForTesting(usage func()) {
+	CommandLine = NewFlagSet(os.Args[0], ContinueOnError)
+	Usage = usage
+}
+func boolString(s string) string {
+	if s == "0" {
+		return "false"
+	}
+	return "true"
+}
+
+func TestEverything(t *testing.T) {
+	ResetForTesting(nil)
+	Bool([]string{"test_bool"}, false, "bool value")
+	Int([]string{"test_int"}, 0, "int value")
+	Int64([]string{"test_int64"}, 0, "int64 value")
+	Uint([]string{"test_uint"}, 0, "uint value")
+	Uint64([]string{"test_uint64"}, 0, "uint64 value")
+	String([]string{"test_string"}, "0", "string value")
+	Float64([]string{"test_float64"}, 0, "float64 value")
+	Duration([]string{"test_duration"}, 0, "time.Duration value")
+
+	m := make(map[string]*Flag)
+	desired := "0"
+	visitor := func(f *Flag) {
+		for _, name := range f.Names {
+			if len(name) > 5 && name[0:5] == "test_" {
+				m[name] = f
+				ok := false
+				switch {
+				case f.Value.String() == desired:
+					ok = true
+				case name == "test_bool" && f.Value.String() == boolString(desired):
+					ok = true
+				case name == "test_duration" && f.Value.String() == desired+"s":
+					ok = true
+				}
+				if !ok {
+					t.Error("Visit: bad value", f.Value.String(), "for", name)
+				}
+			}
+		}
+	}
+	VisitAll(visitor)
+	if len(m) != 8 {
+		t.Error("VisitAll misses some flags")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	m = make(map[string]*Flag)
+	Visit(visitor)
+	if len(m) != 0 {
+		t.Errorf("Visit sees unset flags")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	// Now set all flags
+	Set("test_bool", "true")
+	Set("test_int", "1")
+	Set("test_int64", "1")
+	Set("test_uint", "1")
+	Set("test_uint64", "1")
+	Set("test_string", "1")
+	Set("test_float64", "1")
+	Set("test_duration", "1s")
+	desired = "1"
+	Visit(visitor)
+	if len(m) != 8 {
+		t.Error("Visit fails after set")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	// Now test they're visited in sort order.
+	var flagNames []string
+	Visit(func(f *Flag) {
+		for _, name := range f.Names {
+			flagNames = append(flagNames, name)
+		}
+	})
+	if !sort.StringsAreSorted(flagNames) {
+		t.Errorf("flag names not sorted: %v", flagNames)
+	}
+}
+
+func TestGet(t *testing.T) {
+	ResetForTesting(nil)
+	Bool([]string{"test_bool"}, true, "bool value")
+	Int([]string{"test_int"}, 1, "int value")
+	Int64([]string{"test_int64"}, 2, "int64 value")
+	Uint([]string{"test_uint"}, 3, "uint value")
+	Uint64([]string{"test_uint64"}, 4, "uint64 value")
+	String([]string{"test_string"}, "5", "string value")
+	Float64([]string{"test_float64"}, 6, "float64 value")
+	Duration([]string{"test_duration"}, 7, "time.Duration value")
+
+	visitor := func(f *Flag) {
+		for _, name := range f.Names {
+			if len(name) > 5 && name[0:5] == "test_" {
+				g, ok := f.Value.(Getter)
+				if !ok {
+					t.Errorf("Visit: value does not satisfy Getter: %T", f.Value)
+					return
+				}
+				switch name {
+				case "test_bool":
+					ok = g.Get() == true
+				case "test_int":
+					ok = g.Get() == int(1)
+				case "test_int64":
+					ok = g.Get() == int64(2)
+				case "test_uint":
+					ok = g.Get() == uint(3)
+				case "test_uint64":
+					ok = g.Get() == uint64(4)
+				case "test_string":
+					ok = g.Get() == "5"
+				case "test_float64":
+					ok = g.Get() == float64(6)
+				case "test_duration":
+					ok = g.Get() == time.Duration(7)
+				}
+				if !ok {
+					t.Errorf("Visit: bad value %T(%v) for %s", g.Get(), g.Get(), name)
+				}
+			}
+		}
+	}
+	VisitAll(visitor)
+}
+
+func testParse(f *FlagSet, t *testing.T) {
+	if f.Parsed() {
+		t.Error("f.Parse() = true before Parse")
+	}
+	boolFlag := f.Bool([]string{"bool"}, false, "bool value")
+	bool2Flag := f.Bool([]string{"bool2"}, false, "bool2 value")
+	f.Bool([]string{"bool3"}, false, "bool3 value")
+	bool4Flag := f.Bool([]string{"bool4"}, false, "bool4 value")
+	intFlag := f.Int([]string{"-int"}, 0, "int value")
+	int64Flag := f.Int64([]string{"-int64"}, 0, "int64 value")
+	uintFlag := f.Uint([]string{"uint"}, 0, "uint value")
+	uint64Flag := f.Uint64([]string{"-uint64"}, 0, "uint64 value")
+	stringFlag := f.String([]string{"string"}, "0", "string value")
+	f.String([]string{"string2"}, "0", "string2 value")
+	singleQuoteFlag := f.String([]string{"squote"}, "", "single quoted value")
+	doubleQuoteFlag := f.String([]string{"dquote"}, "", "double quoted value")
+	mixedQuoteFlag := f.String([]string{"mquote"}, "", "mixed quoted value")
+	mixed2QuoteFlag := f.String([]string{"mquote2"}, "", "mixed2 quoted value")
+	nestedQuoteFlag := f.String([]string{"nquote"}, "", "nested quoted value")
+	nested2QuoteFlag := f.String([]string{"nquote2"}, "", "nested2 quoted value")
+	float64Flag := f.Float64([]string{"float64"}, 0, "float64 value")
+	durationFlag := f.Duration([]string{"duration"}, 5*time.Second, "time.Duration value")
+	extra := "one-extra-argument"
+	args := []string{
+		"-bool",
+		"-bool2=true",
+		"-bool4=false",
+		"--int", "22",
+		"--int64", "0x23",
+		"-uint", "24",
+		"--uint64", "25",
+		"-string", "hello",
+		"-squote='single'",
+		`-dquote="double"`,
+		`-mquote='mixed"`,
+		`-mquote2="mixed2'`,
+		`-nquote="'single nested'"`,
+		`-nquote2='"double nested"'`,
+		"-float64", "2718e28",
+		"-duration", "2m",
+		extra,
+	}
+	if err := f.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	if !f.Parsed() {
+		t.Error("f.Parse() = false after Parse")
+	}
+	if *boolFlag != true {
+		t.Error("bool flag should be true, is ", *boolFlag)
+	}
+	if *bool2Flag != true {
+		t.Error("bool2 flag should be true, is ", *bool2Flag)
+	}
+	if !f.IsSet("bool2") {
+		t.Error("bool2 should be marked as set")
+	}
+	if f.IsSet("bool3") {
+		t.Error("bool3 should not be marked as set")
+	}
+	if !f.IsSet("bool4") {
+		t.Error("bool4 should be marked as set")
+	}
+	if *bool4Flag != false {
+		t.Error("bool4 flag should be false, is ", *bool4Flag)
+	}
+	if *intFlag != 22 {
+		t.Error("int flag should be 22, is ", *intFlag)
+	}
+	if *int64Flag != 0x23 {
+		t.Error("int64 flag should be 0x23, is ", *int64Flag)
+	}
+	if *uintFlag != 24 {
+		t.Error("uint flag should be 24, is ", *uintFlag)
+	}
+	if *uint64Flag != 25 {
+		t.Error("uint64 flag should be 25, is ", *uint64Flag)
+	}
+	if *stringFlag != "hello" {
+		t.Error("string flag should be `hello`, is ", *stringFlag)
+	}
+	if !f.IsSet("string") {
+		t.Error("string flag should be marked as set")
+	}
+	if f.IsSet("string2") {
+		t.Error("string2 flag should not be marked as set")
+	}
+	if *singleQuoteFlag != "single" {
+		t.Error("single quote string flag should be `single`, is ", *singleQuoteFlag)
+	}
+	if *doubleQuoteFlag != "double" {
+		t.Error("double quote string flag should be `double`, is ", *doubleQuoteFlag)
+	}
+	if *mixedQuoteFlag != `'mixed"` {
+		t.Error("mixed quote string flag should be `'mixed\"`, is ", *mixedQuoteFlag)
+	}
+	if *mixed2QuoteFlag != `"mixed2'` {
+		t.Error("mixed2 quote string flag should be `\"mixed2'`, is ", *mixed2QuoteFlag)
+	}
+	if *nestedQuoteFlag != "'single nested'" {
+		t.Error("nested quote string flag should be `'single nested'`, is ", *nestedQuoteFlag)
+	}
+	if *nested2QuoteFlag != `"double nested"` {
+		t.Error("double quote string flag should be `\"double nested\"`, is ", *nested2QuoteFlag)
+	}
+	if *float64Flag != 2718e28 {
+		t.Error("float64 flag should be 2718e28, is ", *float64Flag)
+	}
+	if *durationFlag != 2*time.Minute {
+		t.Error("duration flag should be 2m, is ", *durationFlag)
+	}
+	if len(f.Args()) != 1 {
+		t.Error("expected one argument, got", len(f.Args()))
+	} else if f.Args()[0] != extra {
+		t.Errorf("expected argument %q got %q", extra, f.Args()[0])
+	}
+}
+
+func testPanic(f *FlagSet, t *testing.T) {
+	f.Int([]string{"-int"}, 0, "int value")
+	if f.Parsed() {
+		t.Error("f.Parse() = true before Parse")
+	}
+	args := []string{
+		"-int", "21",
+	}
+	f.Parse(args)
+}
+
+func TestParsePanic(t *testing.T) {
+	ResetForTesting(func() {})
+	testPanic(CommandLine, t)
+}
+
+func TestParse(t *testing.T) {
+	ResetForTesting(func() { t.Error("bad parse") })
+	testParse(CommandLine, t)
+}
+
+func TestFlagSetParse(t *testing.T) {
+	testParse(NewFlagSet("test", ContinueOnError), t)
+}
+
+// Declare a user-defined flag type.
+type flagVar []string
+
+func (f *flagVar) String() string {
+	return fmt.Sprint([]string(*f))
+}
+
+func (f *flagVar) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+func TestUserDefined(t *testing.T) {
+	var flags FlagSet
+	flags.Init("test", ContinueOnError)
+	var v flagVar
+	flags.Var(&v, []string{"v"}, "usage")
+	if err := flags.Parse([]string{"-v", "1", "-v", "2", "-v=3"}); err != nil {
+		t.Error(err)
+	}
+	if len(v) != 3 {
+		t.Fatal("expected 3 args; got ", len(v))
+	}
+	expect := "[1 2 3]"
+	if v.String() != expect {
+		t.Errorf("expected value %q got %q", expect, v.String())
+	}
+}
+
+// Declare a user-defined boolean flag type.
+type boolFlagVar struct {
+	count int
+}
+
+func (b *boolFlagVar) String() string {
+	return fmt.Sprintf("%d", b.count)
+}
+
+func (b *boolFlagVar) Set(value string) error {
+	if value == "true" {
+		b.count++
+	}
+	return nil
+}
+
+func (b *boolFlagVar) IsBoolFlag() bool {
+	return b.count < 4
+}
+
+func TestUserDefinedBool(t *testing.T) {
+	var flags FlagSet
+	flags.Init("test", ContinueOnError)
+	var b boolFlagVar
+	var err error
+	flags.Var(&b, []string{"b"}, "usage")
+	if err = flags.Parse([]string{"-b", "-b", "-b", "-b=true", "-b=false", "-b", "barg", "-b"}); err != nil {
+		if b.count < 4 {
+			t.Error(err)
+		}
+	}
+
+	if b.count != 4 {
+		t.Errorf("want: %d; got: %d", 4, b.count)
+	}
+
+	if err == nil {
+		t.Error("expected error; got none")
+	}
+}
+
+func TestSetOutput(t *testing.T) {
+	var flags FlagSet
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+	flags.Init("test", ContinueOnError)
+	flags.Parse([]string{"-unknown"})
+	if out := buf.String(); !strings.Contains(out, "-unknown") {
+		t.Logf("expected output mentioning unknown; got %q", out)
+	}
+}
+
+// This tests that one can reset the flags. This still works but not well, and is
+// superseded by FlagSet.
+func TestChangingArgs(t *testing.T) {
+	ResetForTesting(func() { t.Fatal("bad parse") })
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"cmd", "-before", "subcmd", "-after", "args"}
+	before := Bool([]string{"before"}, false, "")
+	if err := CommandLine.Parse(os.Args[1:]); err != nil {
+		t.Fatal(err)
+	}
+	cmd := Arg(0)
+	os.Args = Args()
+	after := Bool([]string{"after"}, false, "")
+	Parse()
+	args := Args()
+
+	if !*before || cmd != "subcmd" || !*after || len(args) != 1 || args[0] != "args" {
+		t.Fatalf("expected true subcmd true [args] got %v %v %v %v", *before, cmd, *after, args)
+	}
+}
+
+// Test that -help invokes the usage message and returns ErrHelp.
+func TestHelp(t *testing.T) {
+	var helpCalled = false
+	fs := NewFlagSet("help test", ContinueOnError)
+	fs.Usage = func() { helpCalled = true }
+	var flag bool
+	fs.BoolVar(&flag, []string{"flag"}, false, "regular flag")
+	// Regular flag invocation should work
+	err := fs.Parse([]string{"-flag=true"})
+	if err != nil {
+		t.Fatal("expected no error; got ", err)
+	}
+	if !flag {
+		t.Error("flag was not set by -flag")
+	}
+	if helpCalled {
+		t.Error("help called for regular flag")
+		helpCalled = false // reset for next test
+	}
+	// Help flag should work as expected.
+	err = fs.Parse([]string{"-help"})
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != ErrHelp {
+		t.Fatal("expected ErrHelp; got ", err)
+	}
+	if !helpCalled {
+		t.Fatal("help was not called")
+	}
+	// If we define a help flag, that should override.
+	var help bool
+	fs.BoolVar(&help, []string{"help"}, false, "help flag")
+	helpCalled = false
+	err = fs.Parse([]string{"-help"})
+	if err != nil {
+		t.Fatal("expected no error for defined -help; got ", err)
+	}
+	if helpCalled {
+		t.Fatal("help was called; should not have been for defined help flag")
+	}
+}
+
+// Test the flag count functions.
+func TestFlagCounts(t *testing.T) {
+	fs := NewFlagSet("help test", ContinueOnError)
+	var flag bool
+	fs.BoolVar(&flag, []string{"flag1"}, false, "regular flag")
+	fs.BoolVar(&flag, []string{"#deprecated1"}, false, "regular flag")
+	fs.BoolVar(&flag, []string{"f", "flag2"}, false, "regular flag")
+	fs.BoolVar(&flag, []string{"#d", "#deprecated2"}, false, "regular flag")
+	fs.BoolVar(&flag, []string{"flag3"}, false, "regular flag")
+	fs.BoolVar(&flag, []string{"g", "#flag4", "-flag4"}, false, "regular flag")
+
+	if fs.FlagCount() != 6 {
+		t.Fatal("FlagCount wrong. ", fs.FlagCount())
+	}
+	if fs.FlagCountUndeprecated() != 4 {
+		t.Fatal("FlagCountUndeprecated wrong. ", fs.FlagCountUndeprecated())
+	}
+	if fs.NFlag() != 0 {
+		t.Fatal("NFlag wrong. ", fs.NFlag())
+	}
+	err := fs.Parse([]string{"-fd", "-g", "-flag4"})
+	if err != nil {
+		t.Fatal("expected no error for defined -help; got ", err)
+	}
+	if fs.NFlag() != 4 {
+		t.Fatal("NFlag wrong. ", fs.NFlag())
+	}
+}
+
+// Show up bug in sortFlags
+func TestSortFlags(t *testing.T) {
+	fs := NewFlagSet("help TestSortFlags", ContinueOnError)
+
+	var err error
+
+	var b bool
+	fs.BoolVar(&b, []string{"b", "-banana"}, false, "usage")
+
+	err = fs.Parse([]string{"--banana=true"})
+	if err != nil {
+		t.Fatal("expected no error; got ", err)
+	}
+
+	count := 0
+
+	fs.VisitAll(func(flag *Flag) {
+		count++
+		if flag == nil {
+			t.Fatal("VisitAll should not return a nil flag")
+		}
+	})
+	flagcount := fs.FlagCount()
+	if flagcount != count {
+		t.Fatalf("FlagCount (%d) != number (%d) of elements visited", flagcount, count)
+	}
+	// Make sure its idempotent
+	if flagcount != fs.FlagCount() {
+		t.Fatalf("FlagCount (%d) != fs.FlagCount() (%d) of elements visited", flagcount, fs.FlagCount())
+	}
+
+	count = 0
+	fs.Visit(func(flag *Flag) {
+		count++
+		if flag == nil {
+			t.Fatal("Visit should not return a nil flag")
+		}
+	})
+	nflag := fs.NFlag()
+	if nflag != count {
+		t.Fatalf("NFlag (%d) != number (%d) of elements visited", nflag, count)
+	}
+	if nflag != fs.NFlag() {
+		t.Fatalf("NFlag (%d) != fs.NFlag() (%d) of elements visited", nflag, fs.NFlag())
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/parsers/parsers.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/parsers/parsers.go
@@ -1,0 +1,187 @@
+// Package parsers provides helper functions to parse and validate different type
+// of string. It can be hosts, unix addresses, tcp addresses, filters, kernel
+// operating system versions.
+package parsers
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// ParseHost parses the specified address and returns an address that will be used as the host.
+// Depending of the address specified, will use the defaultTCPAddr or defaultUnixAddr
+// FIXME: Change this not to receive default value as parameter
+func ParseHost(defaultTCPAddr, defaultUnixAddr, addr string) (string, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		if runtime.GOOS != "windows" {
+			addr = fmt.Sprintf("unix://%s", defaultUnixAddr)
+		} else {
+			// Note - defaultTCPAddr already includes tcp:// prefix
+			addr = defaultTCPAddr
+		}
+	}
+	addrParts := strings.Split(addr, "://")
+	if len(addrParts) == 1 {
+		addrParts = []string{"tcp", addrParts[0]}
+	}
+
+	switch addrParts[0] {
+	case "tcp":
+		return ParseTCPAddr(addrParts[1], defaultTCPAddr)
+	case "unix":
+		return ParseUnixAddr(addrParts[1], defaultUnixAddr)
+	case "fd":
+		return addr, nil
+	default:
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+}
+
+// ParseUnixAddr parses and validates that the specified address is a valid UNIX
+// socket address. It returns a formatted UNIX socket address, either using the
+// address parsed from addr, or the contents of defaultAddr if addr is a blank
+// string.
+func ParseUnixAddr(addr string, defaultAddr string) (string, error) {
+	addr = strings.TrimPrefix(addr, "unix://")
+	if strings.Contains(addr, "://") {
+		return "", fmt.Errorf("Invalid proto, expected unix: %s", addr)
+	}
+	if addr == "" {
+		addr = defaultAddr
+	}
+	return fmt.Sprintf("unix://%s", addr), nil
+}
+
+// ParseTCPAddr parses and validates that the specified address is a valid TCP
+// address. It returns a formatted TCP address, either using the address parsed
+// from addr, or the contents of defaultAddr if addr is a blank string.
+func ParseTCPAddr(addr string, defaultAddr string) (string, error) {
+	addr = strings.TrimPrefix(addr, "tcp://")
+	if strings.Contains(addr, "://") || addr == "" {
+		return "", fmt.Errorf("Invalid proto, expected tcp: %s", addr)
+	}
+
+	u, err := url.Parse("tcp://" + addr)
+	if err != nil {
+		return "", err
+	}
+	hostParts := strings.Split(u.Host, ":")
+	if len(hostParts) != 2 {
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+	host := hostParts[0]
+	if host == "" {
+		host = defaultAddr
+	}
+
+	p, err := strconv.Atoi(hostParts[1])
+	if err != nil && p == 0 {
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+	return fmt.Sprintf("tcp://%s:%d%s", host, p, u.Path), nil
+}
+
+// ParseRepositoryTag gets a repos name and returns the right reposName + tag|digest
+// The tag can be confusing because of a port in a repository name.
+//     Ex: localhost.localdomain:5000/samalba/hipache:latest
+//     Digest ex: localhost:5000/foo/bar@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb
+func ParseRepositoryTag(repos string) (string, string) {
+	n := strings.Index(repos, "@")
+	if n >= 0 {
+		parts := strings.Split(repos, "@")
+		return parts[0], parts[1]
+	}
+	n = strings.LastIndex(repos, ":")
+	if n < 0 {
+		return repos, ""
+	}
+	if tag := repos[n+1:]; !strings.Contains(tag, "/") {
+		return repos[:n], tag
+	}
+	return repos, ""
+}
+
+// PartParser parses and validates the specified string (data) using the specified template
+// e.g. ip:public:private -> 192.168.0.1:80:8000
+func PartParser(template, data string) (map[string]string, error) {
+	// ip:public:private
+	var (
+		templateParts = strings.Split(template, ":")
+		parts         = strings.Split(data, ":")
+		out           = make(map[string]string, len(templateParts))
+	)
+	if len(parts) != len(templateParts) {
+		return nil, fmt.Errorf("Invalid format to parse.  %s should match template %s", data, template)
+	}
+
+	for i, t := range templateParts {
+		value := ""
+		if len(parts) > i {
+			value = parts[i]
+		}
+		out[t] = value
+	}
+	return out, nil
+}
+
+// ParseKeyValueOpt parses and validates the specified string as a key/value pair (key=value)
+func ParseKeyValueOpt(opt string) (string, string, error) {
+	parts := strings.SplitN(opt, "=", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Unable to parse key/value option: %s", opt)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+// ParsePortRange parses and validates the specified string as a port-range (8000-9000)
+func ParsePortRange(ports string) (uint64, uint64, error) {
+	if ports == "" {
+		return 0, 0, fmt.Errorf("Empty string specified for ports.")
+	}
+	if !strings.Contains(ports, "-") {
+		start, err := strconv.ParseUint(ports, 10, 16)
+		end := start
+		return start, end, err
+	}
+
+	parts := strings.Split(ports, "-")
+	start, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("Invalid range specified for the Port: %s", ports)
+	}
+	return start, end, nil
+}
+
+// ParseLink parses and validates the specified string as a link format (name:alias)
+func ParseLink(val string) (string, string, error) {
+	if val == "" {
+		return "", "", fmt.Errorf("empty string specified for links")
+	}
+	arr := strings.Split(val, ":")
+	if len(arr) > 2 {
+		return "", "", fmt.Errorf("bad format for links: %s", val)
+	}
+	if len(arr) == 1 {
+		return val, val, nil
+	}
+	// This is kept because we can actually get an HostConfig with links
+	// from an already created container and the format is not `foo:bar`
+	// but `/foo:/c1/bar`
+	if strings.HasPrefix(arr[0], "/") {
+		_, alias := path.Split(arr[1])
+		return arr[0][1:], alias, nil
+	}
+	return arr[0], arr[1], nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/parsers/parsers_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/parsers/parsers_test.go
@@ -1,0 +1,210 @@
+package parsers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseHost(t *testing.T) {
+	var (
+		defaultHTTPHost = "127.0.0.1"
+		defaultUnix     = "/var/run/docker.sock"
+	)
+	invalids := map[string]string{
+		"0.0.0.0":              "Invalid bind address format: 0.0.0.0",
+		"tcp://":               "Invalid proto, expected tcp: ",
+		"tcp:a.b.c.d":          "Invalid bind address format: tcp:a.b.c.d",
+		"tcp:a.b.c.d/path":     "Invalid bind address format: tcp:a.b.c.d/path",
+		"udp://127.0.0.1":      "Invalid bind address format: udp://127.0.0.1",
+		"udp://127.0.0.1:2375": "Invalid bind address format: udp://127.0.0.1:2375",
+	}
+	valids := map[string]string{
+		"0.0.0.1:5555":      "tcp://0.0.0.1:5555",
+		"0.0.0.1:5555/path": "tcp://0.0.0.1:5555/path",
+		":6666":             "tcp://127.0.0.1:6666",
+		":6666/path":        "tcp://127.0.0.1:6666/path",
+		"tcp://:7777":       "tcp://127.0.0.1:7777",
+		"tcp://:7777/path":  "tcp://127.0.0.1:7777/path",
+		"":                  "unix:///var/run/docker.sock",
+		"unix:///run/docker.sock": "unix:///run/docker.sock",
+		"unix://":                 "unix:///var/run/docker.sock",
+		"fd://":                   "fd://",
+		"fd://something":          "fd://something",
+	}
+	for invalidAddr, expectedError := range invalids {
+		if addr, err := ParseHost(defaultHTTPHost, defaultUnix, invalidAddr); err == nil || err.Error() != expectedError {
+			t.Errorf("tcp %v address expected error %v return, got %s and addr %v", invalidAddr, expectedError, err, addr)
+		}
+	}
+	for validAddr, expectedAddr := range valids {
+		if addr, err := ParseHost(defaultHTTPHost, defaultUnix, validAddr); err != nil || addr != expectedAddr {
+			t.Errorf("%v -> expected %v, got %v", validAddr, expectedAddr, addr)
+		}
+	}
+}
+
+func TestParseInvalidUnixAddrInvalid(t *testing.T) {
+	if _, err := ParseUnixAddr("unix://tcp://127.0.0.1", "unix:///var/run/docker.sock"); err == nil || err.Error() != "Invalid proto, expected unix: tcp://127.0.0.1" {
+		t.Fatalf("Expected an error, got %v", err)
+	}
+}
+
+func TestParseRepositoryTag(t *testing.T) {
+	if repo, tag := ParseRepositoryTag("root"); repo != "root" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "root", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("root:tag"); repo != "root" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "root", "tag", repo, tag)
+	}
+	if repo, digest := ParseRepositoryTag("root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "root" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "root", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
+	}
+	if repo, tag := ParseRepositoryTag("user/repo"); repo != "user/repo" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "user/repo", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("user/repo:tag"); repo != "user/repo" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "user/repo", "tag", repo, tag)
+	}
+	if repo, digest := ParseRepositoryTag("user/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "user/repo" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "user/repo", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
+	}
+	if repo, tag := ParseRepositoryTag("url:5000/repo"); repo != "url:5000/repo" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("url:5000/repo:tag"); repo != "url:5000/repo" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "tag", repo, tag)
+	}
+	if repo, digest := ParseRepositoryTag("url:5000/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "url:5000/repo" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "url:5000/repo", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
+	}
+}
+
+func TestParsePortMapping(t *testing.T) {
+	if _, err := PartParser("ip:public:private", "192.168.1.1:80"); err == nil {
+		t.Fatalf("Expected an error, got %v", err)
+	}
+	data, err := PartParser("ip:public:private", "192.168.1.1:80:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(data) != 3 {
+		t.FailNow()
+	}
+	if data["ip"] != "192.168.1.1" {
+		t.Fail()
+	}
+	if data["public"] != "80" {
+		t.Fail()
+	}
+	if data["private"] != "8080" {
+		t.Fail()
+	}
+}
+
+func TestParseKeyValueOpt(t *testing.T) {
+	invalids := map[string]string{
+		"":    "Unable to parse key/value option: ",
+		"key": "Unable to parse key/value option: key",
+	}
+	for invalid, expectedError := range invalids {
+		if _, _, err := ParseKeyValueOpt(invalid); err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error %v for %v, got %v", expectedError, invalid, err)
+		}
+	}
+	valids := map[string][]string{
+		"key=value":               {"key", "value"},
+		" key = value ":           {"key", "value"},
+		"key=value1=value2":       {"key", "value1=value2"},
+		" key = value1 = value2 ": {"key", "value1 = value2"},
+	}
+	for valid, expectedKeyValue := range valids {
+		key, value, err := ParseKeyValueOpt(valid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if key != expectedKeyValue[0] || value != expectedKeyValue[1] {
+			t.Fatalf("Expected {%v: %v} got {%v: %v}", expectedKeyValue[0], expectedKeyValue[1], key, value)
+		}
+	}
+}
+
+func TestParsePortRange(t *testing.T) {
+	if start, end, err := ParsePortRange("8000-8080"); err != nil || start != 8000 || end != 8080 {
+		t.Fatalf("Error: %s or Expecting {start,end} values {8000,8080} but found {%d,%d}.", err, start, end)
+	}
+}
+
+func TestParsePortRangeEmpty(t *testing.T) {
+	if _, _, err := ParsePortRange(""); err == nil || err.Error() != "Empty string specified for ports." {
+		t.Fatalf("Expected error 'Empty string specified for ports.', got %v", err)
+	}
+}
+
+func TestParsePortRangeWithNoRange(t *testing.T) {
+	start, end, err := ParsePortRange("8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start != 8080 || end != 8080 {
+		t.Fatalf("Expected start and end to be the same and equal to 8080, but were %v and %v", start, end)
+	}
+}
+
+func TestParsePortRangeIncorrectRange(t *testing.T) {
+	if _, _, err := ParsePortRange("9000-8080"); err == nil || !strings.Contains(err.Error(), "Invalid range specified for the Port") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectEndRange(t *testing.T) {
+	if _, _, err := ParsePortRange("8000-a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("8000-30a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectStartRange(t *testing.T) {
+	if _, _, err := ParsePortRange("a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("30a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParseLink(t *testing.T) {
+	name, alias, err := ParseLink("name:alias")
+	if err != nil {
+		t.Fatalf("Expected not to error out on a valid name:alias format but got: %v", err)
+	}
+	if name != "name" {
+		t.Fatalf("Link name should have been name, got %s instead", name)
+	}
+	if alias != "alias" {
+		t.Fatalf("Link alias should have been alias, got %s instead", alias)
+	}
+	// short format definition
+	name, alias, err = ParseLink("name")
+	if err != nil {
+		t.Fatalf("Expected not to error out on a valid name only format but got: %v", err)
+	}
+	if name != "name" {
+		t.Fatalf("Link name should have been name, got %s instead", name)
+	}
+	if alias != "name" {
+		t.Fatalf("Link alias should have been name, got %s instead", alias)
+	}
+	// empty string link definition is not allowed
+	if _, _, err := ParseLink(""); err == nil || !strings.Contains(err.Error(), "empty string specified for links") {
+		t.Fatalf("Expected error 'empty string specified for links' but got: %v", err)
+	}
+	// more than two colons are not allowed
+	if _, _, err := ParseLink("link:alias:wrong"); err == nil || !strings.Contains(err.Error(), "bad format for links: link:alias:wrong") {
+		t.Fatalf("Expected error 'bad format for links: link:alias:wrong' but got: %v", err)
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools/pools.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools/pools.go
@@ -1,0 +1,119 @@
+// Package pools provides a collection of pools which provide various
+// data types with buffers. These can be used to lower the number of
+// memory allocations and reuse buffers.
+//
+// New pools should be added to this package to allow them to be
+// shared across packages.
+//
+// Utility functions which operate on pools should be added to this
+// package to allow them to be reused.
+package pools
+
+import (
+	"bufio"
+	"io"
+	"sync"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils"
+)
+
+var (
+	// BufioReader32KPool is a pool which returns bufio.Reader with a 32K buffer.
+	BufioReader32KPool *BufioReaderPool
+	// BufioWriter32KPool is a pool which returns bufio.Writer with a 32K buffer.
+	BufioWriter32KPool *BufioWriterPool
+)
+
+const buffer32K = 32 * 1024
+
+// BufioReaderPool is a bufio reader that uses sync.Pool.
+type BufioReaderPool struct {
+	pool sync.Pool
+}
+
+func init() {
+	BufioReader32KPool = newBufioReaderPoolWithSize(buffer32K)
+	BufioWriter32KPool = newBufioWriterPoolWithSize(buffer32K)
+}
+
+// newBufioReaderPoolWithSize is unexported because new pools should be
+// added here to be shared where required.
+func newBufioReaderPoolWithSize(size int) *BufioReaderPool {
+	pool := sync.Pool{
+		New: func() interface{} { return bufio.NewReaderSize(nil, size) },
+	}
+	return &BufioReaderPool{pool: pool}
+}
+
+// Get returns a bufio.Reader which reads from r. The buffer size is that of the pool.
+func (bufPool *BufioReaderPool) Get(r io.Reader) *bufio.Reader {
+	buf := bufPool.pool.Get().(*bufio.Reader)
+	buf.Reset(r)
+	return buf
+}
+
+// Put puts the bufio.Reader back into the pool.
+func (bufPool *BufioReaderPool) Put(b *bufio.Reader) {
+	b.Reset(nil)
+	bufPool.pool.Put(b)
+}
+
+// Copy is a convenience wrapper which uses a buffer to avoid allocation in io.Copy.
+func Copy(dst io.Writer, src io.Reader) (written int64, err error) {
+	buf := BufioReader32KPool.Get(src)
+	written, err = io.Copy(dst, buf)
+	BufioReader32KPool.Put(buf)
+	return
+}
+
+// NewReadCloserWrapper returns a wrapper which puts the bufio.Reader back
+// into the pool and closes the reader if it's an io.ReadCloser.
+func (bufPool *BufioReaderPool) NewReadCloserWrapper(buf *bufio.Reader, r io.Reader) io.ReadCloser {
+	return ioutils.NewReadCloserWrapper(r, func() error {
+		if readCloser, ok := r.(io.ReadCloser); ok {
+			readCloser.Close()
+		}
+		bufPool.Put(buf)
+		return nil
+	})
+}
+
+// BufioWriterPool is a bufio writer that uses sync.Pool.
+type BufioWriterPool struct {
+	pool sync.Pool
+}
+
+// newBufioWriterPoolWithSize is unexported because new pools should be
+// added here to be shared where required.
+func newBufioWriterPoolWithSize(size int) *BufioWriterPool {
+	pool := sync.Pool{
+		New: func() interface{} { return bufio.NewWriterSize(nil, size) },
+	}
+	return &BufioWriterPool{pool: pool}
+}
+
+// Get returns a bufio.Writer which writes to w. The buffer size is that of the pool.
+func (bufPool *BufioWriterPool) Get(w io.Writer) *bufio.Writer {
+	buf := bufPool.pool.Get().(*bufio.Writer)
+	buf.Reset(w)
+	return buf
+}
+
+// Put puts the bufio.Writer back into the pool.
+func (bufPool *BufioWriterPool) Put(b *bufio.Writer) {
+	b.Reset(nil)
+	bufPool.pool.Put(b)
+}
+
+// NewWriteCloserWrapper returns a wrapper which puts the bufio.Writer back
+// into the pool and closes the writer if it's an io.Writecloser.
+func (bufPool *BufioWriterPool) NewWriteCloserWrapper(buf *bufio.Writer, w io.Writer) io.WriteCloser {
+	return ioutils.NewWriteCloserWrapper(w, func() error {
+		buf.Flush()
+		if writeCloser, ok := w.(io.WriteCloser); ok {
+			writeCloser.Close()
+		}
+		bufPool.Put(buf)
+		return nil
+	})
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools/pools_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools/pools_test.go
@@ -1,0 +1,162 @@
+package pools
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestBufioReaderPoolGetWithNoReaderShouldCreateOne(t *testing.T) {
+	reader := BufioReader32KPool.Get(nil)
+	if reader == nil {
+		t.Fatalf("BufioReaderPool should have create a bufio.Reader but did not.")
+	}
+}
+
+func TestBufioReaderPoolPutAndGet(t *testing.T) {
+	sr := bufio.NewReader(strings.NewReader("foobar"))
+	reader := BufioReader32KPool.Get(sr)
+	if reader == nil {
+		t.Fatalf("BufioReaderPool should not return a nil reader.")
+	}
+	// verify the first 3 byte
+	buf1 := make([]byte, 3)
+	_, err := reader.Read(buf1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual := string(buf1); actual != "foo" {
+		t.Fatalf("The first letter should have been 'foo' but was %v", actual)
+	}
+	BufioReader32KPool.Put(reader)
+	// Try to read the next 3 bytes
+	_, err = sr.Read(make([]byte, 3))
+	if err == nil || err != io.EOF {
+		t.Fatalf("The buffer should have been empty, issue an EOF error.")
+	}
+}
+
+type simpleReaderCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *simpleReaderCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestNewReadCloserWrapperWithAReadCloser(t *testing.T) {
+	br := bufio.NewReader(strings.NewReader(""))
+	sr := &simpleReaderCloser{
+		Reader: strings.NewReader("foobar"),
+		closed: false,
+	}
+	reader := BufioReader32KPool.NewReadCloserWrapper(br, sr)
+	if reader == nil {
+		t.Fatalf("NewReadCloserWrapper should not return a nil reader.")
+	}
+	// Verify the content of reader
+	buf := make([]byte, 3)
+	_, err := reader.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual := string(buf); actual != "foo" {
+		t.Fatalf("The first 3 letter should have been 'foo' but were %v", actual)
+	}
+	reader.Close()
+	// Read 3 more bytes "bar"
+	_, err = reader.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual := string(buf); actual != "bar" {
+		t.Fatalf("The first 3 letter should have been 'bar' but were %v", actual)
+	}
+	if !sr.closed {
+		t.Fatalf("The ReaderCloser should have been closed, it is not.")
+	}
+}
+
+func TestBufioWriterPoolGetWithNoReaderShouldCreateOne(t *testing.T) {
+	writer := BufioWriter32KPool.Get(nil)
+	if writer == nil {
+		t.Fatalf("BufioWriterPool should have create a bufio.Writer but did not.")
+	}
+}
+
+func TestBufioWriterPoolPutAndGet(t *testing.T) {
+	buf := new(bytes.Buffer)
+	bw := bufio.NewWriter(buf)
+	writer := BufioWriter32KPool.Get(bw)
+	if writer == nil {
+		t.Fatalf("BufioReaderPool should not return a nil writer.")
+	}
+	written, err := writer.Write([]byte("foobar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != 6 {
+		t.Fatalf("Should have written 6 bytes, but wrote %v bytes", written)
+	}
+	// Make sure we Flush all the way ?
+	writer.Flush()
+	bw.Flush()
+	if len(buf.Bytes()) != 6 {
+		t.Fatalf("The buffer should contain 6 bytes ('foobar') but contains %v ('%v')", buf.Bytes(), string(buf.Bytes()))
+	}
+	// Reset the buffer
+	buf.Reset()
+	BufioWriter32KPool.Put(writer)
+	// Try to write something
+	written, err = writer.Write([]byte("barfoo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// If we now try to flush it, it should panic (the writer is nil)
+	// recover it
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Trying to flush the writter should have 'paniced', did not.")
+		}
+	}()
+	writer.Flush()
+}
+
+type simpleWriterCloser struct {
+	io.Writer
+	closed bool
+}
+
+func (r *simpleWriterCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestNewWriteCloserWrapperWithAWriteCloser(t *testing.T) {
+	buf := new(bytes.Buffer)
+	bw := bufio.NewWriter(buf)
+	sw := &simpleWriterCloser{
+		Writer: new(bytes.Buffer),
+		closed: false,
+	}
+	bw.Flush()
+	writer := BufioWriter32KPool.NewWriteCloserWrapper(bw, sw)
+	if writer == nil {
+		t.Fatalf("BufioReaderPool should not return a nil writer.")
+	}
+	written, err := writer.Write([]byte("foobar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != 6 {
+		t.Fatalf("Should have written 6 bytes, but wrote %v bytes", written)
+	}
+	writer.Close()
+	if !sw.closed {
+		t.Fatalf("The ReaderCloser should have been closed, it is not.")
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/promise/promise.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/promise/promise.go
@@ -1,0 +1,11 @@
+package promise
+
+// Go is a basic promise implementation: it wraps calls a function in a goroutine,
+// and returns a channel which will later return the function's return value.
+func Go(f func() error) chan error {
+	ch := make(chan error, 1)
+	go func() {
+		ch <- f()
+	}()
+	return ch
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/stdcopy/stdcopy.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/stdcopy/stdcopy.go
@@ -1,0 +1,168 @@
+package stdcopy
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus"
+)
+
+const (
+	StdWriterPrefixLen = 8
+	StdWriterFdIndex   = 0
+	StdWriterSizeIndex = 4
+)
+
+type StdType [StdWriterPrefixLen]byte
+
+var (
+	Stdin  StdType = StdType{0: 0}
+	Stdout StdType = StdType{0: 1}
+	Stderr StdType = StdType{0: 2}
+)
+
+type StdWriter struct {
+	io.Writer
+	prefix  StdType
+	sizeBuf []byte
+}
+
+func (w *StdWriter) Write(buf []byte) (n int, err error) {
+	var n1, n2 int
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("Writer not instantiated")
+	}
+	binary.BigEndian.PutUint32(w.prefix[4:], uint32(len(buf)))
+	n1, err = w.Writer.Write(w.prefix[:])
+	if err != nil {
+		n = n1 - StdWriterPrefixLen
+	} else {
+		n2, err = w.Writer.Write(buf)
+		n = n1 + n2 - StdWriterPrefixLen
+	}
+	if n < 0 {
+		n = 0
+	}
+	return
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) *StdWriter {
+	return &StdWriter{
+		Writer:  w,
+		prefix:  t,
+		sizeBuf: make([]byte, 4),
+	}
+}
+
+var ErrInvalidStdHeader = errors.New("Unrecognized input header")
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+	var (
+		buf       = make([]byte, 32*1024+StdWriterPrefixLen+1)
+		bufLen    = len(buf)
+		nr, nw    int
+		er, ew    error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < StdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < StdWriterPrefixLen {
+					logrus.Debugf("Corrupted prefix: %v", buf[:nr])
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				logrus.Debugf("Error reading header: %s", er)
+				return 0, er
+			}
+		}
+
+		// Check the first byte to know where to write
+		switch buf[StdWriterFdIndex] {
+		case 0:
+			fallthrough
+		case 1:
+			// Write on stdout
+			out = dstout
+		case 2:
+			// Write on stderr
+			out = dsterr
+		default:
+			logrus.Debugf("Error selecting output fd: (%d)", buf[StdWriterFdIndex])
+			return 0, ErrInvalidStdHeader
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[StdWriterSizeIndex : StdWriterSizeIndex+4]))
+		logrus.Debugf("framesize: %d", frameSize)
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+StdWriterPrefixLen > bufLen {
+			logrus.Debugf("Extending buffer cap by %d (was %d)", frameSize+StdWriterPrefixLen-bufLen+1, len(buf))
+			buf = append(buf, make([]byte, frameSize+StdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+StdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < frameSize+StdWriterPrefixLen {
+					logrus.Debugf("Corrupted frame: %v", buf[StdWriterPrefixLen:nr])
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				logrus.Debugf("Error reading frame: %s", er)
+				return 0, er
+			}
+		}
+
+		// Write the retrieved frame (without header)
+		nw, ew = out.Write(buf[StdWriterPrefixLen : frameSize+StdWriterPrefixLen])
+		if ew != nil {
+			logrus.Debugf("Error writing frame: %s", ew)
+			return 0, ew
+		}
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			logrus.Debugf("Error Short Write: (%d on %d)", nw, frameSize)
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+StdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + StdWriterPrefixLen
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/stdcopy/stdcopy_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/stdcopy/stdcopy_test.go
@@ -1,0 +1,85 @@
+package stdcopy
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestNewStdWriter(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	if writer == nil {
+		t.Fatalf("NewStdWriter with an invalid StdType should not return nil.")
+	}
+}
+
+func TestWriteWithUnitializedStdWriter(t *testing.T) {
+	writer := StdWriter{
+		Writer:  nil,
+		prefix:  Stdout,
+		sizeBuf: make([]byte, 4),
+	}
+	n, err := writer.Write([]byte("Something here"))
+	if n != 0 || err == nil {
+		t.Fatalf("Should fail when given an uncomplete or uninitialized StdWriter")
+	}
+}
+
+func TestWriteWithNilBytes(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	n, err := writer.Write(nil)
+	if err != nil {
+		t.Fatalf("Shouldn't have fail when given no data")
+	}
+	if n > 0 {
+		t.Fatalf("Write should have written 0 byte, but has written %d", n)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	data := []byte("Test StdWrite.Write")
+	n, err := writer.Write(data)
+	if err != nil {
+		t.Fatalf("Error while writing with StdWrite")
+	}
+	if n != len(data) {
+		t.Fatalf("Write should have writen %d byte but wrote %d.", len(data), n)
+	}
+}
+
+func TestStdCopyWithInvalidInputHeader(t *testing.T) {
+	dstOut := NewStdWriter(ioutil.Discard, Stdout)
+	dstErr := NewStdWriter(ioutil.Discard, Stderr)
+	src := strings.NewReader("Invalid input")
+	_, err := StdCopy(dstOut, dstErr, src)
+	if err == nil {
+		t.Fatal("StdCopy with invalid input header should fail.")
+	}
+}
+
+func TestStdCopyWithCorruptedPrefix(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	src := bytes.NewReader(data)
+	written, err := StdCopy(nil, nil, src)
+	if err != nil {
+		t.Fatalf("StdCopy should not return an error with corrupted prefix.")
+	}
+	if written != 0 {
+		t.Fatalf("StdCopy should have written 0, but has written %d", written)
+	}
+}
+
+func BenchmarkWrite(b *testing.B) {
+	w := NewStdWriter(ioutil.Discard, Stdout)
+	data := []byte("Test line for testing stdwriter performance\n")
+	data = bytes.Repeat(data, 100)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := w.Write(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/errors.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/errors.go
@@ -1,0 +1,9 @@
+package system
+
+import (
+	"errors"
+)
+
+var (
+	ErrNotSupportedPlatform = errors.New("platform and architecture is not supported")
+)

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/events_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/events_windows.go
@@ -1,0 +1,83 @@
+package system
+
+// This file implements syscalls for Win32 events which are not implemented
+// in golang.
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	EVENT_ALL_ACCESS    = 0x1F0003
+	EVENT_MODIFY_STATUS = 0x0002
+)
+
+var (
+	procCreateEvent = modkernel32.NewProc("CreateEventW")
+	procOpenEvent   = modkernel32.NewProc("OpenEventW")
+	procSetEvent    = modkernel32.NewProc("SetEvent")
+	procResetEvent  = modkernel32.NewProc("ResetEvent")
+	procPulseEvent  = modkernel32.NewProc("PulseEvent")
+)
+
+func CreateEvent(eventAttributes *syscall.SecurityAttributes, manualReset bool, initialState bool, name string) (handle syscall.Handle, err error) {
+	namep, _ := syscall.UTF16PtrFromString(name)
+	var _p1 uint32 = 0
+	if manualReset {
+		_p1 = 1
+	}
+	var _p2 uint32 = 0
+	if initialState {
+		_p2 = 1
+	}
+	r0, _, e1 := procCreateEvent.Call(uintptr(unsafe.Pointer(eventAttributes)), uintptr(_p1), uintptr(_p2), uintptr(unsafe.Pointer(namep)))
+	use(unsafe.Pointer(namep))
+	handle = syscall.Handle(r0)
+	if handle == syscall.InvalidHandle {
+		err = e1
+	}
+	return
+}
+
+func OpenEvent(desiredAccess uint32, inheritHandle bool, name string) (handle syscall.Handle, err error) {
+	namep, _ := syscall.UTF16PtrFromString(name)
+	var _p1 uint32 = 0
+	if inheritHandle {
+		_p1 = 1
+	}
+	r0, _, e1 := procOpenEvent.Call(uintptr(desiredAccess), uintptr(_p1), uintptr(unsafe.Pointer(namep)))
+	use(unsafe.Pointer(namep))
+	handle = syscall.Handle(r0)
+	if handle == syscall.InvalidHandle {
+		err = e1
+	}
+	return
+}
+
+func SetEvent(handle syscall.Handle) (err error) {
+	return setResetPulse(handle, procSetEvent)
+}
+
+func ResetEvent(handle syscall.Handle) (err error) {
+	return setResetPulse(handle, procResetEvent)
+}
+
+func PulseEvent(handle syscall.Handle) (err error) {
+	return setResetPulse(handle, procPulseEvent)
+}
+
+func setResetPulse(handle syscall.Handle, proc *syscall.LazyProc) (err error) {
+	r0, _, _ := proc.Call(uintptr(handle))
+	if r0 != 0 {
+		err = syscall.Errno(r0)
+	}
+	return
+}
+
+var temp unsafe.Pointer
+
+// use ensures a variable is kept alive without the GC freeing while still needed
+func use(p unsafe.Pointer) {
+	temp = p
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/filesys.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/filesys.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package system
+
+import (
+	"os"
+)
+
+func MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/filesys_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/filesys_windows.go
@@ -1,0 +1,64 @@
+// +build windows
+
+package system
+
+import (
+	"os"
+	"regexp"
+	"syscall"
+)
+
+// MkdirAll implementation that is volume path aware for Windows.
+func MkdirAll(path string, perm os.FileMode) error {
+	if re := regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}$`); re.MatchString(path) {
+		return nil
+	}
+
+	// The rest of this method is copied from os.MkdirAll and should be kept
+	// as-is to ensure compatibility.
+
+	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
+	dir, err := os.Stat(path)
+	if err == nil {
+		if dir.IsDir() {
+			return nil
+		}
+		return &os.PathError{
+			Op:   "mkdir",
+			Path: path,
+			Err:  syscall.ENOTDIR,
+		}
+	}
+
+	// Slow path: make sure parent exists and then call Mkdir for path.
+	i := len(path)
+	for i > 0 && os.IsPathSeparator(path[i-1]) { // Skip trailing path separator.
+		i--
+	}
+
+	j := i
+	for j > 0 && !os.IsPathSeparator(path[j-1]) { // Scan backward over element.
+		j--
+	}
+
+	if j > 1 {
+		// Create parent
+		err = MkdirAll(path[0:j-1], perm)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Parent now exists; invoke Mkdir and use its result.
+	err = os.Mkdir(path, perm)
+	if err != nil {
+		// Handle arguments like "foo/." by
+		// double-checking that directory doesn't exist.
+		dir, err1 := os.Lstat(path)
+		if err1 == nil && dir.IsDir() {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/lstat.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/lstat.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+// Lstat takes a path to a file and returns
+// a system.Stat_t type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Lstat(path string) (*Stat_t, error) {
+	s := &syscall.Stat_t{}
+	if err := syscall.Lstat(path, s); err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/lstat_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/lstat_test.go
@@ -1,0 +1,28 @@
+package system
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLstat tests Lstat for existing and non existing files
+func TestLstat(t *testing.T) {
+	file, invalid, _, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
+
+	statFile, err := Lstat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statFile == nil {
+		t.Fatal("returned empty stat for existing file")
+	}
+
+	statInvalid, err := Lstat(invalid)
+	if err == nil {
+		t.Fatal("did not return error for non-existing file")
+	}
+	if statInvalid != nil {
+		t.Fatal("returned non-nil stat for non-existing file")
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/lstat_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/lstat_windows.go
@@ -1,0 +1,29 @@
+// +build windows
+
+package system
+
+import (
+	"os"
+)
+
+// Some explanation for my own sanity, and hopefully maintainers in the
+// future.
+//
+// Lstat calls os.Lstat to get a fileinfo interface back.
+// This is then copied into our own locally defined structure.
+// Note the Linux version uses fromStatT to do the copy back,
+// but that not strictly necessary when already in an OS specific module.
+
+func Lstat(path string) (*Stat_t, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Stat_t{
+		name:    fi.Name(),
+		size:    fi.Size(),
+		mode:    fi.Mode(),
+		modTime: fi.ModTime(),
+		isDir:   fi.IsDir()}, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo.go
@@ -1,0 +1,17 @@
+package system
+
+// MemInfo contains memory statistics of the host system.
+type MemInfo struct {
+	// Total usable RAM (i.e. physical RAM minus a few reserved bits and the
+	// kernel binary code).
+	MemTotal int64
+
+	// Amount of free memory.
+	MemFree int64
+
+	// Total amount of swap space available.
+	SwapTotal int64
+
+	// Amount of swap space that is currently unused.
+	SwapFree int64
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo_linux.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo_linux.go
@@ -1,0 +1,71 @@
+package system
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units"
+)
+
+var (
+	ErrMalformed = errors.New("malformed file")
+)
+
+// ReadMemInfo retrieves memory statistics of the host system and returns a
+//  MemInfo type.
+func ReadMemInfo() (*MemInfo, error) {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return parseMemInfo(file)
+}
+
+// parseMemInfo parses the /proc/meminfo file into
+// a MemInfo object given a io.Reader to the file.
+//
+// Throws error if there are problems reading from the file
+func parseMemInfo(reader io.Reader) (*MemInfo, error) {
+	meminfo := &MemInfo{}
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		// Expected format: ["MemTotal:", "1234", "kB"]
+		parts := strings.Fields(scanner.Text())
+
+		// Sanity checks: Skip malformed entries.
+		if len(parts) < 3 || parts[2] != "kB" {
+			continue
+		}
+
+		// Convert to bytes.
+		size, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		bytes := int64(size) * units.KiB
+
+		switch parts[0] {
+		case "MemTotal:":
+			meminfo.MemTotal = bytes
+		case "MemFree:":
+			meminfo.MemFree = bytes
+		case "SwapTotal:":
+			meminfo.SwapTotal = bytes
+		case "SwapFree:":
+			meminfo.SwapFree = bytes
+		}
+
+	}
+
+	// Handle errors that may have occurred during the reading of the file.
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return meminfo, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo_linux_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo_linux_test.go
@@ -1,0 +1,38 @@
+package system
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units"
+)
+
+// TestMemInfo tests parseMemInfo with a static meminfo string
+func TestMemInfo(t *testing.T) {
+	const input = `
+	MemTotal:      1 kB
+	MemFree:       2 kB
+	SwapTotal:     3 kB
+	SwapFree:      4 kB
+	Malformed1:
+	Malformed2:    1
+	Malformed3:    2 MB
+	Malformed4:    X kB
+	`
+	meminfo, err := parseMemInfo(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meminfo.MemTotal != 1*units.KiB {
+		t.Fatalf("Unexpected MemTotal: %d", meminfo.MemTotal)
+	}
+	if meminfo.MemFree != 2*units.KiB {
+		t.Fatalf("Unexpected MemFree: %d", meminfo.MemFree)
+	}
+	if meminfo.SwapTotal != 3*units.KiB {
+		t.Fatalf("Unexpected SwapTotal: %d", meminfo.SwapTotal)
+	}
+	if meminfo.SwapFree != 4*units.KiB {
+		t.Fatalf("Unexpected SwapFree: %d", meminfo.SwapFree)
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo_unsupported.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo_unsupported.go
@@ -1,0 +1,7 @@
+// +build !linux,!windows
+
+package system
+
+func ReadMemInfo() (*MemInfo, error) {
+	return nil, ErrNotSupportedPlatform
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/meminfo_windows.go
@@ -1,0 +1,44 @@
+package system
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366589(v=vs.85).aspx
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366770(v=vs.85).aspx
+type memorystatusex struct {
+	dwLength                uint32
+	dwMemoryLoad            uint32
+	ullTotalPhys            uint64
+	ullAvailPhys            uint64
+	ullTotalPageFile        uint64
+	ullAvailPageFile        uint64
+	ullTotalVirtual         uint64
+	ullAvailVirtual         uint64
+	ullAvailExtendedVirtual uint64
+}
+
+// ReadMemInfo retrieves memory statistics of the host system and returns a
+//  MemInfo type.
+func ReadMemInfo() (*MemInfo, error) {
+	msi := &memorystatusex{
+		dwLength: 64,
+	}
+	r1, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msi)))
+	if r1 == 0 {
+		return &MemInfo{}, nil
+	}
+	return &MemInfo{
+		MemTotal:  int64(msi.ullTotalPhys),
+		MemFree:   int64(msi.ullAvailPhys),
+		SwapTotal: int64(msi.ullTotalPageFile),
+		SwapFree:  int64(msi.ullAvailPageFile),
+	}, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/mknod.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/mknod.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+// Mknod creates a filesystem node (file, device special file or named pipe) named path
+// with attributes specified by mode and dev
+func Mknod(path string, mode uint32, dev int) error {
+	return syscall.Mknod(path, mode, dev)
+}
+
+// Linux device nodes are a bit weird due to backwards compat with 16 bit device nodes.
+// They are, from low to high: the lower 8 bits of the minor, then 12 bits of the major,
+// then the top 12 bits of the minor
+func Mkdev(major int64, minor int64) uint32 {
+	return uint32(((minor & 0xfff00) << 12) | ((major & 0xfff) << 8) | (minor & 0xff))
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/mknod_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/mknod_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package system
+
+func Mknod(path string, mode uint32, dev int) error {
+	return ErrNotSupportedPlatform
+}
+
+func Mkdev(major int64, minor int64) uint32 {
+	panic("Mkdev not implemented on Windows.")
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat.go
@@ -1,0 +1,46 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+// Stat_t type contains status of a file. It contains metadata
+// like permission, owner, group, size, etc about a file
+type Stat_t struct {
+	mode uint32
+	uid  uint32
+	gid  uint32
+	rdev uint64
+	size int64
+	mtim syscall.Timespec
+}
+
+func (s Stat_t) Mode() uint32 {
+	return s.mode
+}
+
+func (s Stat_t) Uid() uint32 {
+	return s.uid
+}
+
+func (s Stat_t) Gid() uint32 {
+	return s.gid
+}
+
+func (s Stat_t) Rdev() uint64 {
+	return s.rdev
+}
+
+func (s Stat_t) Size() int64 {
+	return s.size
+}
+
+func (s Stat_t) Mtim() syscall.Timespec {
+	return s.mtim
+}
+
+func (s Stat_t) GetLastModification() syscall.Timespec {
+	return s.Mtim()
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_freebsd.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_freebsd.go
@@ -1,0 +1,27 @@
+package system
+
+import (
+	"syscall"
+)
+
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*Stat_t, error) {
+	return &Stat_t{size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtimespec}, nil
+}
+
+// Stat takes a path to a file and returns
+// a system.Stat_t type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Stat(path string) (*Stat_t, error) {
+	s := &syscall.Stat_t{}
+	if err := syscall.Stat(path, s); err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_linux.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_linux.go
@@ -1,0 +1,33 @@
+package system
+
+import (
+	"syscall"
+)
+
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*Stat_t, error) {
+	return &Stat_t{size: s.Size,
+		mode: s.Mode,
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: s.Rdev,
+		mtim: s.Mtim}, nil
+}
+
+// FromStatT exists only on linux, and loads a system.Stat_t from a
+// syscal.Stat_t.
+func FromStatT(s *syscall.Stat_t) (*Stat_t, error) {
+	return fromStatT(s)
+}
+
+// Stat takes a path to a file and returns
+// a system.Stat_t type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Stat(path string) (*Stat_t, error) {
+	s := &syscall.Stat_t{}
+	if err := syscall.Stat(path, s); err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_test.go
@@ -1,0 +1,37 @@
+package system
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestFromStatT tests fromStatT for a tempfile
+func TestFromStatT(t *testing.T) {
+	file, _, _, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
+
+	stat := &syscall.Stat_t{}
+	err := syscall.Lstat(file, stat)
+
+	s, err := fromStatT(stat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stat.Mode != s.Mode() {
+		t.Fatal("got invalid mode")
+	}
+	if stat.Uid != s.Uid() {
+		t.Fatal("got invalid uid")
+	}
+	if stat.Gid != s.Gid() {
+		t.Fatal("got invalid gid")
+	}
+	if stat.Rdev != s.Rdev() {
+		t.Fatal("got invalid rdev")
+	}
+	if stat.Mtim != s.Mtim() {
+		t.Fatal("got invalid mtim")
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_unsupported.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_unsupported.go
@@ -1,0 +1,17 @@
+// +build !linux,!windows,!freebsd
+
+package system
+
+import (
+	"syscall"
+)
+
+// fromStatT creates a system.Stat_t type from a syscall.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*Stat_t, error) {
+	return &Stat_t{size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtimespec}, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_windows.go
@@ -1,0 +1,36 @@
+// +build windows
+
+package system
+
+import (
+	"os"
+	"time"
+)
+
+type Stat_t struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+func (s Stat_t) Name() string {
+	return s.name
+}
+
+func (s Stat_t) Size() int64 {
+	return s.size
+}
+
+func (s Stat_t) Mode() os.FileMode {
+	return s.mode
+}
+
+func (s Stat_t) ModTime() time.Time {
+	return s.modTime
+}
+
+func (s Stat_t) IsDir() bool {
+	return s.isDir
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/umask.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/umask.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+func Umask(newmask int) (oldmask int, err error) {
+	return syscall.Umask(newmask), nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/umask_windows.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/umask_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package system
+
+func Umask(newmask int) (oldmask int, err error) {
+	// should not be called on cli code path
+	return 0, ErrNotSupportedPlatform
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_darwin.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_darwin.go
@@ -1,0 +1,11 @@
+package system
+
+import "syscall"
+
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	return ErrNotSupportedPlatform
+}
+
+func UtimesNano(path string, ts []syscall.Timespec) error {
+	return syscall.UtimesNano(path, ts)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_freebsd.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_freebsd.go
@@ -1,0 +1,24 @@
+package system
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	var _path *byte
+	_path, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	if _, _, err := syscall.Syscall(syscall.SYS_LUTIMES, uintptr(unsafe.Pointer(_path)), uintptr(unsafe.Pointer(&ts[0])), 0); err != 0 && err != syscall.ENOSYS {
+		return err
+	}
+
+	return nil
+}
+
+func UtimesNano(path string, ts []syscall.Timespec) error {
+	return syscall.UtimesNano(path, ts)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_linux.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_linux.go
@@ -1,0 +1,28 @@
+package system
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	// These are not currently available in syscall
+	AT_FDCWD := -100
+	AT_SYMLINK_NOFOLLOW := 0x100
+
+	var _path *byte
+	_path, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	if _, _, err := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(AT_FDCWD), uintptr(unsafe.Pointer(_path)), uintptr(unsafe.Pointer(&ts[0])), uintptr(AT_SYMLINK_NOFOLLOW), 0, 0); err != 0 && err != syscall.ENOSYS {
+		return err
+	}
+
+	return nil
+}
+
+func UtimesNano(path string, ts []syscall.Timespec) error {
+	return syscall.UtimesNano(path, ts)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_test.go
@@ -1,0 +1,66 @@
+package system
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// prepareFiles creates files for testing in the temp directory
+func prepareFiles(t *testing.T) (string, string, string, string) {
+	dir, err := ioutil.TempDir("", "docker-system-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file := filepath.Join(dir, "exist")
+	if err := ioutil.WriteFile(file, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	invalid := filepath.Join(dir, "doesnt-exist")
+
+	symlink := filepath.Join(dir, "symlink")
+	if err := os.Symlink(file, symlink); err != nil {
+		t.Fatal(err)
+	}
+
+	return file, invalid, symlink, dir
+}
+
+func TestLUtimesNano(t *testing.T) {
+	file, invalid, symlink, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
+
+	before, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := []syscall.Timespec{{0, 0}, {0, 0}}
+	if err := LUtimesNano(symlink, ts); err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkInfo, err := os.Lstat(symlink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.ModTime().Unix() == symlinkInfo.ModTime().Unix() {
+		t.Fatal("The modification time of the symlink should be different")
+	}
+
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.ModTime().Unix() != fileInfo.ModTime().Unix() {
+		t.Fatal("The modification time of the file should be same")
+	}
+
+	if err := LUtimesNano(invalid, ts); err == nil {
+		t.Fatal("Doesn't return an error on a non-existing file")
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_unsupported.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/utimes_unsupported.go
@@ -1,0 +1,13 @@
+// +build !linux,!freebsd,!darwin
+
+package system
+
+import "syscall"
+
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	return ErrNotSupportedPlatform
+}
+
+func UtimesNano(path string, ts []syscall.Timespec) error {
+	return ErrNotSupportedPlatform
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/xattrs_linux.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/xattrs_linux.go
@@ -1,0 +1,59 @@
+package system
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Returns a nil slice and nil error if the xattr is not set
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return nil, err
+	}
+
+	dest := make([]byte, 128)
+	destBytes := unsafe.Pointer(&dest[0])
+	sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	if errno == syscall.ENODATA {
+		return nil, nil
+	}
+	if errno == syscall.ERANGE {
+		dest = make([]byte, sz)
+		destBytes := unsafe.Pointer(&dest[0])
+		sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	}
+	if errno != 0 {
+		return nil, errno
+	}
+
+	return dest[:sz], nil
+}
+
+var _zero uintptr
+
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return err
+	}
+	var dataBytes unsafe.Pointer
+	if len(data) > 0 {
+		dataBytes = unsafe.Pointer(&data[0])
+	} else {
+		dataBytes = unsafe.Pointer(&_zero)
+	}
+	_, _, errno := syscall.Syscall6(syscall.SYS_LSETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(dataBytes), uintptr(len(data)), uintptr(flags), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/xattrs_unsupported.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/xattrs_unsupported.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package system
+
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	return nil, ErrNotSupportedPlatform
+}
+
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	return ErrNotSupportedPlatform
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ulimit/ulimit.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ulimit/ulimit.go
@@ -1,0 +1,111 @@
+// Package ulimit provides structure and helper function to parse and represent
+// resource limits (Rlimit and Ulimit, its human friendly version).
+package ulimit
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Ulimit is a human friendly version of Rlimit.
+type Ulimit struct {
+	Name string
+	Hard int64
+	Soft int64
+}
+
+// Rlimit specifies the resource limits, such as max open files.
+type Rlimit struct {
+	Type int    `json:"type,omitempty"`
+	Hard uint64 `json:"hard,omitempty"`
+	Soft uint64 `json:"soft,omitempty"`
+}
+
+const (
+	// magic numbers for making the syscall
+	// some of these are defined in the syscall package, but not all.
+	// Also since Windows client doesn't get access to the syscall package, need to
+	//	define these here
+	rlimitAs         = 9
+	rlimitCore       = 4
+	rlimitCPU        = 0
+	rlimitData       = 2
+	rlimitFsize      = 1
+	rlimitLocks      = 10
+	rlimitMemlock    = 8
+	rlimitMsgqueue   = 12
+	rlimitNice       = 13
+	rlimitNofile     = 7
+	rlimitNproc      = 6
+	rlimitRss        = 5
+	rlimitRtprio     = 14
+	rlimitRttime     = 15
+	rlimitSigpending = 11
+	rlimitStack      = 3
+)
+
+var ulimitNameMapping = map[string]int{
+	//"as":         rlimitAs, // Disabled since this doesn't seem usable with the way Docker inits a container.
+	"core":       rlimitCore,
+	"cpu":        rlimitCPU,
+	"data":       rlimitData,
+	"fsize":      rlimitFsize,
+	"locks":      rlimitLocks,
+	"memlock":    rlimitMemlock,
+	"msgqueue":   rlimitMsgqueue,
+	"nice":       rlimitNice,
+	"nofile":     rlimitNofile,
+	"nproc":      rlimitNproc,
+	"rss":        rlimitRss,
+	"rtprio":     rlimitRtprio,
+	"rttime":     rlimitRttime,
+	"sigpending": rlimitSigpending,
+	"stack":      rlimitStack,
+}
+
+// Parse parses and returns a Ulimit from the specified string.
+func Parse(val string) (*Ulimit, error) {
+	parts := strings.SplitN(val, "=", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid ulimit argument: %s", val)
+	}
+
+	if _, exists := ulimitNameMapping[parts[0]]; !exists {
+		return nil, fmt.Errorf("invalid ulimit type: %s", parts[0])
+	}
+
+	limitVals := strings.SplitN(parts[1], ":", 2)
+	if len(limitVals) > 2 {
+		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
+	}
+
+	soft, err := strconv.ParseInt(limitVals[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	hard := soft // in case no hard was set
+	if len(limitVals) == 2 {
+		hard, err = strconv.ParseInt(limitVals[1], 10, 64)
+	}
+	if soft > hard {
+		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, hard)
+	}
+
+	return &Ulimit{Name: parts[0], Soft: soft, Hard: hard}, nil
+}
+
+// GetRlimit returns the RLimit corresponding to Ulimit.
+func (u *Ulimit) GetRlimit() (*Rlimit, error) {
+	t, exists := ulimitNameMapping[u.Name]
+	if !exists {
+		return nil, fmt.Errorf("invalid ulimit name %s", u.Name)
+	}
+
+	return &Rlimit{Type: t, Soft: uint64(u.Soft), Hard: uint64(u.Hard)}, nil
+}
+
+func (u *Ulimit) String() string {
+	return fmt.Sprintf("%s=%d:%d", u.Name, u.Soft, u.Hard)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ulimit/ulimit_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ulimit/ulimit_test.go
@@ -1,0 +1,55 @@
+package ulimit
+
+import "testing"
+
+func TestParseValid(t *testing.T) {
+	u1 := &Ulimit{"nofile", 1024, 512}
+	if u2, _ := Parse("nofile=512:1024"); *u1 != *u2 {
+		t.Fatalf("expected %q, but got %q", u1, u2)
+	}
+}
+
+func TestParseInvalidLimitType(t *testing.T) {
+	if _, err := Parse("notarealtype=1024:1024"); err == nil {
+		t.Fatalf("expected error on invalid ulimit type")
+	}
+}
+
+func TestParseBadFormat(t *testing.T) {
+	if _, err := Parse("nofile:1024:1024"); err == nil {
+		t.Fatal("expected error on bad syntax")
+	}
+
+	if _, err := Parse("nofile"); err == nil {
+		t.Fatal("expected error on bad syntax")
+	}
+
+	if _, err := Parse("nofile="); err == nil {
+		t.Fatal("expected error on bad syntax")
+	}
+	if _, err := Parse("nofile=:"); err == nil {
+		t.Fatal("expected error on bad syntax")
+	}
+	if _, err := Parse("nofile=:1024"); err == nil {
+		t.Fatal("expected error on bad syntax")
+	}
+}
+
+func TestParseHardLessThanSoft(t *testing.T) {
+	if _, err := Parse("nofile:1024:1"); err == nil {
+		t.Fatal("expected error on hard limit less than soft limit")
+	}
+}
+
+func TestParseInvalidValueType(t *testing.T) {
+	if _, err := Parse("nofile:asdf"); err == nil {
+		t.Fatal("expected error on bad value type")
+	}
+}
+
+func TestStringOutput(t *testing.T) {
+	u := &Ulimit{"nofile", 1024, 512}
+	if s := u.String(); s != "nofile=512:1024" {
+		t.Fatal("expected String to return nofile=512:1024, but got", s)
+	}
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units/duration.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units/duration.go
@@ -1,0 +1,33 @@
+// Package units provides helper function to parse and print size and time units
+// in human-readable format.
+package units
+
+import (
+	"fmt"
+	"time"
+)
+
+// HumanDuration returns a human-readable approximation of a duration
+// (eg. "About a minute", "4 hours ago", etc.).
+func HumanDuration(d time.Duration) string {
+	if seconds := int(d.Seconds()); seconds < 1 {
+		return "Less than a second"
+	} else if seconds < 60 {
+		return fmt.Sprintf("%d seconds", seconds)
+	} else if minutes := int(d.Minutes()); minutes == 1 {
+		return "About a minute"
+	} else if minutes < 60 {
+		return fmt.Sprintf("%d minutes", minutes)
+	} else if hours := int(d.Hours()); hours == 1 {
+		return "About an hour"
+	} else if hours < 48 {
+		return fmt.Sprintf("%d hours", hours)
+	} else if hours < 24*7*2 {
+		return fmt.Sprintf("%d days", hours/24)
+	} else if hours < 24*30*3 {
+		return fmt.Sprintf("%d weeks", hours/24/7)
+	} else if hours < 24*365*2 {
+		return fmt.Sprintf("%d months", hours/24/30)
+	}
+	return fmt.Sprintf("%d years", int(d.Hours())/24/365)
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units/duration_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units/duration_test.go
@@ -1,0 +1,46 @@
+package units
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHumanDuration(t *testing.T) {
+	// Useful duration abstractions
+	day := 24 * time.Hour
+	week := 7 * day
+	month := 30 * day
+	year := 365 * day
+
+	assertEquals(t, "Less than a second", HumanDuration(450*time.Millisecond))
+	assertEquals(t, "47 seconds", HumanDuration(47*time.Second))
+	assertEquals(t, "About a minute", HumanDuration(1*time.Minute))
+	assertEquals(t, "3 minutes", HumanDuration(3*time.Minute))
+	assertEquals(t, "35 minutes", HumanDuration(35*time.Minute))
+	assertEquals(t, "35 minutes", HumanDuration(35*time.Minute+40*time.Second))
+	assertEquals(t, "About an hour", HumanDuration(1*time.Hour))
+	assertEquals(t, "About an hour", HumanDuration(1*time.Hour+45*time.Minute))
+	assertEquals(t, "3 hours", HumanDuration(3*time.Hour))
+	assertEquals(t, "3 hours", HumanDuration(3*time.Hour+59*time.Minute))
+	assertEquals(t, "4 hours", HumanDuration(3*time.Hour+60*time.Minute))
+	assertEquals(t, "24 hours", HumanDuration(24*time.Hour))
+	assertEquals(t, "36 hours", HumanDuration(1*day+12*time.Hour))
+	assertEquals(t, "2 days", HumanDuration(2*day))
+	assertEquals(t, "7 days", HumanDuration(7*day))
+	assertEquals(t, "13 days", HumanDuration(13*day+5*time.Hour))
+	assertEquals(t, "2 weeks", HumanDuration(2*week))
+	assertEquals(t, "2 weeks", HumanDuration(2*week+4*day))
+	assertEquals(t, "3 weeks", HumanDuration(3*week))
+	assertEquals(t, "4 weeks", HumanDuration(4*week))
+	assertEquals(t, "4 weeks", HumanDuration(4*week+3*day))
+	assertEquals(t, "4 weeks", HumanDuration(1*month))
+	assertEquals(t, "6 weeks", HumanDuration(1*month+2*week))
+	assertEquals(t, "8 weeks", HumanDuration(2*month))
+	assertEquals(t, "3 months", HumanDuration(3*month+1*week))
+	assertEquals(t, "5 months", HumanDuration(5*month+2*week))
+	assertEquals(t, "13 months", HumanDuration(13*month))
+	assertEquals(t, "23 months", HumanDuration(23*month))
+	assertEquals(t, "24 months", HumanDuration(24*month))
+	assertEquals(t, "2 years", HumanDuration(24*month+2*week))
+	assertEquals(t, "3 years", HumanDuration(3*year+2*month))
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units/size.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units/size.go
@@ -1,0 +1,95 @@
+package units
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// See: http://en.wikipedia.org/wiki/Binary_prefix
+const (
+	// Decimal
+
+	KB = 1000
+	MB = 1000 * KB
+	GB = 1000 * MB
+	TB = 1000 * GB
+	PB = 1000 * TB
+
+	// Binary
+
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+	TiB = 1024 * GiB
+	PiB = 1024 * TiB
+)
+
+type unitMap map[string]int64
+
+var (
+	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
+	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
+	sizeRegex  = regexp.MustCompile(`^(\d+)([kKmMgGtTpP])?[bB]?$`)
+)
+
+var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+
+// CustomSize returns a human-readable approximation of a size
+// using custom format.
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	i := 0
+	for size >= base {
+		size = size / base
+		i++
+	}
+	return fmt.Sprintf(format, size, _map[i])
+}
+
+// HumanSize returns a human-readable approximation of a size
+// using SI standard (eg. "44kB", "17MB").
+func HumanSize(size float64) string {
+	return CustomSize("%.4g %s", size, 1000.0, decimapAbbrs)
+}
+
+// BytesSize returns a human-readable size in bytes, kibibytes,
+// mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
+func BytesSize(size float64) string {
+	return CustomSize("%.4g %s", size, 1024.0, binaryAbbrs)
+}
+
+// FromHumanSize returns an integer from a human-readable specification of a
+// size using SI standard (eg. "44kB", "17MB").
+func FromHumanSize(size string) (int64, error) {
+	return parseSize(size, decimalMap)
+}
+
+// RAMInBytes parses a human-readable string representing an amount of RAM
+// in bytes, kibibytes, mebibytes, gibibytes, or tebibytes and
+// returns the number of bytes, or -1 if the string is unparseable.
+// Units are case-insensitive, and the 'b' suffix is optional.
+func RAMInBytes(size string) (int64, error) {
+	return parseSize(size, binaryMap)
+}
+
+// Parses the human-readable size string into the amount it represents.
+func parseSize(sizeStr string, uMap unitMap) (int64, error) {
+	matches := sizeRegex.FindStringSubmatch(sizeStr)
+	if len(matches) != 3 {
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
+
+	size, err := strconv.ParseInt(matches[1], 10, 0)
+	if err != nil {
+		return -1, err
+	}
+
+	unitPrefix := strings.ToLower(matches[2])
+	if mul, ok := uMap[unitPrefix]; ok {
+		size *= mul
+	}
+
+	return size, nil
+}

--- a/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units/size_test.go
+++ b/services/jobservices/vendor/src/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units/size_test.go
@@ -1,0 +1,108 @@
+package units
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBytesSize(t *testing.T) {
+	assertEquals(t, "1 KiB", BytesSize(1024))
+	assertEquals(t, "1 MiB", BytesSize(1024*1024))
+	assertEquals(t, "1 MiB", BytesSize(1048576))
+	assertEquals(t, "2 MiB", BytesSize(2*MiB))
+	assertEquals(t, "3.42 GiB", BytesSize(3.42*GiB))
+	assertEquals(t, "5.372 TiB", BytesSize(5.372*TiB))
+	assertEquals(t, "2.22 PiB", BytesSize(2.22*PiB))
+}
+
+func TestHumanSize(t *testing.T) {
+	assertEquals(t, "1 kB", HumanSize(1000))
+	assertEquals(t, "1.024 kB", HumanSize(1024))
+	assertEquals(t, "1 MB", HumanSize(1000000))
+	assertEquals(t, "1.049 MB", HumanSize(1048576))
+	assertEquals(t, "2 MB", HumanSize(2*MB))
+	assertEquals(t, "3.42 GB", HumanSize(float64(3.42*GB)))
+	assertEquals(t, "5.372 TB", HumanSize(float64(5.372*TB)))
+	assertEquals(t, "2.22 PB", HumanSize(float64(2.22*PB)))
+}
+
+func TestFromHumanSize(t *testing.T) {
+	assertSuccessEquals(t, 32, FromHumanSize, "32")
+	assertSuccessEquals(t, 32, FromHumanSize, "32b")
+	assertSuccessEquals(t, 32, FromHumanSize, "32B")
+	assertSuccessEquals(t, 32*KB, FromHumanSize, "32k")
+	assertSuccessEquals(t, 32*KB, FromHumanSize, "32K")
+	assertSuccessEquals(t, 32*KB, FromHumanSize, "32kb")
+	assertSuccessEquals(t, 32*KB, FromHumanSize, "32Kb")
+	assertSuccessEquals(t, 32*MB, FromHumanSize, "32Mb")
+	assertSuccessEquals(t, 32*GB, FromHumanSize, "32Gb")
+	assertSuccessEquals(t, 32*TB, FromHumanSize, "32Tb")
+	assertSuccessEquals(t, 32*PB, FromHumanSize, "32Pb")
+
+	assertError(t, FromHumanSize, "")
+	assertError(t, FromHumanSize, "hello")
+	assertError(t, FromHumanSize, "-32")
+	assertError(t, FromHumanSize, "32.3")
+	assertError(t, FromHumanSize, " 32 ")
+	assertError(t, FromHumanSize, "32.3Kb")
+	assertError(t, FromHumanSize, "32 mb")
+	assertError(t, FromHumanSize, "32m b")
+	assertError(t, FromHumanSize, "32bm")
+}
+
+func TestRAMInBytes(t *testing.T) {
+	assertSuccessEquals(t, 32, RAMInBytes, "32")
+	assertSuccessEquals(t, 32, RAMInBytes, "32b")
+	assertSuccessEquals(t, 32, RAMInBytes, "32B")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32k")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32K")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32kb")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32Kb")
+	assertSuccessEquals(t, 32*MiB, RAMInBytes, "32Mb")
+	assertSuccessEquals(t, 32*GiB, RAMInBytes, "32Gb")
+	assertSuccessEquals(t, 32*TiB, RAMInBytes, "32Tb")
+	assertSuccessEquals(t, 32*PiB, RAMInBytes, "32Pb")
+	assertSuccessEquals(t, 32*PiB, RAMInBytes, "32PB")
+	assertSuccessEquals(t, 32*PiB, RAMInBytes, "32P")
+
+	assertError(t, RAMInBytes, "")
+	assertError(t, RAMInBytes, "hello")
+	assertError(t, RAMInBytes, "-32")
+	assertError(t, RAMInBytes, "32.3")
+	assertError(t, RAMInBytes, " 32 ")
+	assertError(t, RAMInBytes, "32.3Kb")
+	assertError(t, RAMInBytes, "32 mb")
+	assertError(t, RAMInBytes, "32m b")
+	assertError(t, RAMInBytes, "32bm")
+}
+
+func assertEquals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		t.Errorf("Expected '%v' but got '%v'", expected, actual)
+	}
+}
+
+// func that maps to the parse function signatures as testing abstraction
+type parseFn func(string) (int64, error)
+
+// Define 'String()' for pretty-print
+func (fn parseFn) String() string {
+	fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	return fnName[strings.LastIndex(fnName, ".")+1:]
+}
+
+func assertSuccessEquals(t *testing.T, expected int64, fn parseFn, arg string) {
+	res, err := fn(arg)
+	if err != nil || res != expected {
+		t.Errorf("%s(\"%s\") -> expected '%d' but got '%d' with error '%v'", fn, arg, expected, res, err)
+	}
+}
+
+func assertError(t *testing.T, fn parseFn, arg string) {
+	res, err := fn(arg)
+	if err == nil && res != -1 {
+		t.Errorf("%s(\"%s\") -> expected error but got '%d'", fn, arg, res)
+	}
+}


### PR DESCRIPTION
Feel free to just cherry-pick some of this. 22fa9dd is the most important one since it makes it possible to build stuff without running `gb vendor restore` first. 3bd4380 sort of depends on aa1cc05 because the option the README update mentions isn't available in the old docker-compose versions as far as I can determine. Of course, the docker-compose yaml format update makes docker-compose 1.6 required, so your call.