### PR TITLE
Add lb/qos calls to dewey/info-typer; standardize logging some.

### DIFF
--- a/ansible/roles/util-cfg-service/templates/dewey.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/dewey.properties.j2
@@ -7,6 +7,7 @@ dewey.amqp.password             = {{ amqp_password }}
 dewey.amqp.exchange.name        = {{ amqp_irods_exchange }}
 dewey.amqp.exchange.durable     = {{ amqp_irods_exchange_durable }}
 dewey.amqp.exchange.auto-delete = {{ amqp_irods_exchange_auto_delete }}
+dewey.amqp.qos                  = 100
 
 dewey.es.host                   = {{ elasticsearch.host }}
 dewey.es.port                   = {{ elasticsearch.port }}

--- a/ansible/roles/util-cfg-service/templates/info-typer.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/info-typer.properties.j2
@@ -25,3 +25,4 @@ info-typer.amqp.exchange             = {{ amqp_irods_exchange }}
 info-typer.amqp.exchange.type        = {{ amqp_irods_exchange_type }}
 info-typer.amqp.exchange.durable     = {{ amqp_irods_exchange_durable }}
 info-typer.amqp.exchange.auto-delete = {{ amqp_irods_exchange_auto_delete }}
+info-typer.amqp.qos                  = 100

--- a/services/dewey/dev-resources/local.properties
+++ b/services/dewey/dev-resources/local.properties
@@ -16,5 +16,6 @@ dewey.irods.user                = rods
 dewey.irods.password            = rods
 dewey.irods.default-resource    = ""
 dewey.irods.home                = /iplant/home/rods
+dewey.amqp.qos                  = 100
 
 dewey.status.listen-port        = 8080

--- a/services/dewey/src/dewey/amq.clj
+++ b/services/dewey/src/dewey/amq.clj
@@ -39,6 +39,7 @@
                                                           exchange-auto-delete
                                                           topics
                                                           delivery-fn)))]
+    (lb/qos channel 100)
     (le/topic channel exchange-name :durable exchange-durable :auto-delete exchange-auto-delete)
     (lq/declare channel queue :durable true)
     (doseq [topic topics] (lq/bind channel queue exchange-name :routing-key topic))

--- a/services/dewey/src/dewey/core.clj
+++ b/services/dewey/src/dewey/core.clj
@@ -57,6 +57,7 @@
                                             (get props "dewey.amqp.exchange.name")
                                             (Boolean. (get props "dewey.amqp.exchange.durable"))
                                             (Boolean. (get props "dewey.amqp.exchange.auto-delete"))
+                                            (Integer. (get props "dewey.amqp.qos"))
                                             (partial curation/consume-msg irods-cfg es)
                                             "data-object.#"
                                             "collection.#")

--- a/services/dewey/src/dewey/curation.clj
+++ b/services/dewey/src/dewey/curation.clj
@@ -309,7 +309,7 @@
    Throws:
      It throws any exception perculating up from below."
   [irods-cfg es routing-key msg]
-  (log/debug "received message:  routing key =" routing-key ", message =" msg)
+  (log/info (format "[curation/consume-msg] [%s] [%s]" routing-key (String. msg "UTF-8")))
   (if-let [consume (resolve-consumer routing-key)]
     (try+
       (irods/with-jargon irods-cfg [irods]

--- a/services/info-typer/src/info_typer/amqp.clj
+++ b/services/info-typer/src/info_typer/amqp.clj
@@ -86,7 +86,7 @@
   (log/info "configuring AMQP connection")
   (let [chan (lch/open (get-connection (connection-map)))
         q    (declare-queue chan (str "info-typer." (cfg/environment-name)))]
-    (lb/qos chan 100)
+    (lb/qos chan (cfg/amqp-qos))
     (declare-exchange chan (cfg/amqp-exchange) (cfg/amqp-exchange-type)
       :durable (cfg/amqp-exchange-durable?) :auto-delete (cfg/amqp-exchange-auto-delete?))
     (doseq [topic topics] (bind chan q (cfg/amqp-exchange) topic))

--- a/services/info-typer/src/info_typer/amqp.clj
+++ b/services/info-typer/src/info_typer/amqp.clj
@@ -1,6 +1,7 @@
 (ns info-typer.amqp
   (:require [clojure.tools.logging       :as log]
             [langohr.core                :as rmq]
+            [langohr.basic               :as lb]
             [langohr.channel             :as lch]
             [langohr.exchange            :as le]
             [langohr.queue               :as lq]
@@ -85,6 +86,7 @@
   (log/info "configuring AMQP connection")
   (let [chan (lch/open (get-connection (connection-map)))
         q    (declare-queue chan (str "info-typer." (cfg/environment-name)))]
+    (lb/qos chan 100)
     (declare-exchange chan (cfg/amqp-exchange) (cfg/amqp-exchange-type)
       :durable (cfg/amqp-exchange-durable?) :auto-delete (cfg/amqp-exchange-auto-delete?))
     (doseq [topic topics] (bind chan q (cfg/amqp-exchange) topic))

--- a/services/info-typer/src/info_typer/config.clj
+++ b/services/info-typer/src/info_typer/config.clj
@@ -150,6 +150,10 @@
   [props config-valid configs]
   "info-typer.amqp.exchange.auto-delete")
 
+(cc/defprop-int amqp-qos
+  "The number of messages to allow to be delivered to this client at once without acknowledgement."
+  [props config-valid configs]
+  "info-typer.amqp.qos")
 
 (defn- exception-filters
   []


### PR DESCRIPTION
http://reference.clojurerabbitmq.info/langohr.basic.html#var-qos

basic.qos configures how many unacknowledged messages may be sent on the channel unacknowledged; by default, everything's pretty much allocated immediately, is my understanding from documentation; I'd really prefer if it was a little more divided-out. For some reason, info-typer is not getting everything at once; I'm not sure if there's some difference in the implementations such that dewey is getting them all and info-typer isn't. But in any case, this makes it explicitly configured.

I've also added a line to dewey to make it log messages in basically the same format info-typer does, i.e. `[call function] [routing-key] [message]` at the INFO level. dewey basically only logs errors without this, which makes it hard to determine how much or what it's actually doing at any given time.