### PR TITLE
Jex go logging

### DIFF
--- a/services/jobservices/src/condor-launcher/condor_test.go
+++ b/services/jobservices/src/condor-launcher/condor_test.go
@@ -43,12 +43,10 @@ func _inittests(t *testing.T, memoize bool) *model.Job {
 		data, err := JSONData()
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		s, err = model.NewFromData(data)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		PATH := fmt.Sprintf("../test/:%s", os.Getenv("PATH"))
 		err = os.Setenv("PATH", PATH)
@@ -234,12 +232,10 @@ func TestLaunch(t *testing.T) {
 	j, err := model.NewFromData(data)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	actual, err := launch(j)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	expected := "10000"
 	if actual != expected {
@@ -267,7 +263,6 @@ func TestStop(t *testing.T) {
 	actual, err := stop(jr)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if actual == "" {
 		t.Errorf("stop returned an empty string")

--- a/services/jobservices/src/condor-launcher/condor_test.go
+++ b/services/jobservices/src/condor-launcher/condor_test.go
@@ -4,7 +4,6 @@ import (
 	"configurate"
 	"fmt"
 	"io/ioutil"
-	"logcabin"
 	"model"
 	"os"
 	"path"
@@ -25,7 +24,6 @@ func JSONData() ([]byte, error) {
 
 var (
 	s *model.Job
-	l = logcabin.New("test_condor", "test_condor")
 )
 
 func _inittests(t *testing.T, memoize bool) *model.Job {

--- a/services/jobservices/src/configurate/configurate_test.go
+++ b/services/jobservices/src/configurate/configurate_test.go
@@ -11,7 +11,6 @@ func TestNew(t *testing.T) {
 	err := configurator()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if C == nil {
 		t.Errorf("configurate.New() returned nil")
@@ -22,12 +21,10 @@ func TestAMQPConfig(t *testing.T) {
 	err := configurator()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	actual, err := C.String("amqp.uri")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	expected := "amqp://guest:guest@rabbit:5672/"
 	if actual != expected {

--- a/services/jobservices/src/jex-adapter/main_test.go
+++ b/services/jobservices/src/jex-adapter/main_test.go
@@ -63,12 +63,10 @@ func _inittests(t *testing.T, memoize bool) *model.Job {
 		data, err := JSONData()
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		s, err = model.NewFromData(data)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 	}
 	return s
@@ -82,7 +80,6 @@ func TestGetHome(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://for-a-test.org", nil)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	recorder := httptest.NewRecorder()
 	home(recorder, req)
@@ -103,7 +100,6 @@ func TestStop(t *testing.T) {
 	client, err := messaging.NewClient(uri(), false)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	defer client.Close()
 	client.AddConsumer(messaging.JobsExchange, "test_stop", stopKey, func(d amqp.Delivery) {
@@ -137,7 +133,6 @@ func TestStop(t *testing.T) {
 	request, err := http.NewRequest("DELETE", requestURL, nil)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	recorder := httptest.NewRecorder()
 	NewRouter().ServeHTTP(recorder, request)
@@ -156,7 +151,6 @@ func TestLaunch(t *testing.T) {
 	client, err := messaging.NewClient(uri(), false)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	defer client.Close()
 	client.AddConsumer(messaging.JobsExchange, "test_launch", messaging.LaunchesKey, func(d amqp.Delivery) {
@@ -184,12 +178,10 @@ func TestLaunch(t *testing.T) {
 	marshalledJob, err := json.Marshal(job)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	request, err := http.NewRequest("POST", "http://for-a-test.org/", bytes.NewReader(marshalledJob))
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	recorder := httptest.NewRecorder()
 	NewRouter().ServeHTTP(recorder, request)
@@ -208,12 +200,10 @@ func TestPreview(t *testing.T) {
 	marshalledPreviewer, err := json.Marshal(previewer)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	request, err := http.NewRequest("POST", "http://for-a-test.org/arg-preview", bytes.NewReader(marshalledPreviewer))
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	recorder := httptest.NewRecorder()
 	NewRouter().ServeHTTP(recorder, request)
@@ -224,12 +214,10 @@ func TestPreview(t *testing.T) {
 	body, err := ioutil.ReadAll(recorder.Body)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = json.Unmarshal(body, returnedPreview)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	actual := returnedPreview.Params
 	expected := model.PreviewableStepParam(params).String()

--- a/services/jobservices/src/jex-adapter/main_test.go
+++ b/services/jobservices/src/jex-adapter/main_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"logcabin"
 	"messaging"
 	"model"
 	"net/http"
@@ -20,7 +19,6 @@ import (
 
 var (
 	s *model.Job
-	l = logcabin.New("test_jex_adapter", "test_jex_adapter")
 )
 
 func shouldrun() bool {

--- a/services/jobservices/src/job-status-recorder/main_test.go
+++ b/services/jobservices/src/job-status-recorder/main_test.go
@@ -33,12 +33,10 @@ func initdb(t *testing.T) *sql.DB {
 	db, err := sql.Open("postgres", dburi())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = db.Ping()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	return db
 }
@@ -53,17 +51,14 @@ func TestInsert(t *testing.T) {
 	actual, err := insert("RUNNING", "test-invocation-id", "test", "localhost", "127.0.0.1", n)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	rowCount, err := actual.RowsAffected()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	rows, err := db.Query("select status, message, sent_from, sent_from_hostname, sent_on from job_status_updates where external_id = 'test-invocation-id'")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	defer rows.Close()
 	var (
@@ -75,7 +70,6 @@ func TestInsert(t *testing.T) {
 		err := rows.Scan(&status, &message, &sentFrom, &sentFromHostname, &sentOn)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		if status != "RUNNING" {
 			t.Errorf("status was %s instead of RUNNING", status)
@@ -96,7 +90,6 @@ func TestInsert(t *testing.T) {
 	err = rows.Err()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if rowCount != 1 {
 		t.Errorf("RowsAffected() should have returned 1: %d", rowCount)
@@ -116,7 +109,6 @@ func TestMsg(t *testing.T) {
 	me, err := os.Hostname()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	j := &model.Job{InvocationID: "test-invocation-id"}
 	expected := &messaging.UpdateMessage{
@@ -129,7 +121,6 @@ func TestMsg(t *testing.T) {
 	m, err := json.Marshal(expected)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	d := amqp.Delivery{
 		Body:      m,
@@ -139,7 +130,6 @@ func TestMsg(t *testing.T) {
 	rows, err := db.Query("select status, message, sent_from, sent_from_hostname, sent_on from job_status_updates where external_id = 'test-invocation-id'")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	defer rows.Close()
 	var (
@@ -151,7 +141,6 @@ func TestMsg(t *testing.T) {
 		err := rows.Scan(&status, &message, &sentFrom, &sentFromHostname, &sentOn)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		if status != string(expected.State) {
 			t.Errorf("status was %s instead of %s", status, expected.State)
@@ -162,14 +151,12 @@ func TestMsg(t *testing.T) {
 		ips, err := net.LookupIP(expected.Sender)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		var expectedSentFrom string
 		if len(ips) > 0 {
 			expectedSentFrom = ips[0].String()
 		} else {
 			t.Error("Couldn't get ip address")
-			t.Fail()
 		}
 		if sentFrom != expectedSentFrom {
 			t.Errorf("sentFrom was %s instead of %s", sentFrom, expectedSentFrom)
@@ -185,7 +172,6 @@ func TestMsg(t *testing.T) {
 	err = rows.Err()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	_, err = db.Exec("DELETE FROM job_status_updates")
 	if err != nil {

--- a/services/jobservices/src/logcabin/logcabin.go
+++ b/services/jobservices/src/logcabin/logcabin.go
@@ -14,6 +14,14 @@ var (
 	Info	*log.Logger
 	Warning	*log.Logger
 	Error	*log.Logger
+
+	Trace_Lincoln *Lincoln
+	Info_Lincoln *Lincoln
+	Warning_Lincoln *Lincoln
+	Error_Lincoln *Lincoln
+
+	Service string
+	Artifact string
 )
 
 // Log Level Constants
@@ -24,11 +32,23 @@ const (
 	err_lvl = "ERR"
 )
 
+func init() {
+	Init("jobservices", "default")
+}
+
 func Init(service, artifact string) {
-	Trace = log.New(&lincoln{service, artifact, trace_lvl}, "", log.Lshortfile)
-	Info = log.New(&lincoln{service, artifact, info_lvl}, "", log.Lshortfile)
-	Warning = log.New(&lincoln{service, artifact, warn_lvl}, "", log.Lshortfile)
-	Error = log.New(&lincoln{service, artifact, err_lvl}, "", log.Lshortfile)
+	Service = service
+	Artifact = artifact
+
+	Trace_Lincoln = &Lincoln{service, artifact, trace_lvl}
+	Info_Lincoln = &Lincoln{service, artifact, info_lvl}
+	Warning_Lincoln = &Lincoln{service, artifact, warn_lvl}
+	Error_Lincoln = &Lincoln{service, artifact, err_lvl}
+
+	Trace = log.New(Trace_Lincoln, "", log.Lshortfile)
+	Info = log.New(Info_Lincoln, "", log.Lshortfile)
+	Warning = log.New(Warning_Lincoln, "", log.Lshortfile)
+	Error = log.New(Error_Lincoln, "", log.Lshortfile)
 }
 
 // LogMessage represents a message that will be logged in JSON format.
@@ -42,14 +62,14 @@ type logMessage struct {
 }
 
 // Lincoln is a logger for jex-events.
-type lincoln struct {
+type Lincoln struct {
 	service string
 	artifact string
 	level string
 }
 
 // NewLogMessage returns a pointer to a new instance of LogMessage.
-func (l *lincoln) newLogMessage(message string) *logMessage {
+func (l *Lincoln) newLogMessage(message string) *logMessage {
 	lm := &logMessage{
 		Service:  l.service,
 		Artifact: l.artifact,
@@ -61,7 +81,7 @@ func (l *lincoln) newLogMessage(message string) *logMessage {
 	return lm
 }
 
-func (l *lincoln) Write(buf []byte) (n int, err error) {
+func (l *Lincoln) Write(buf []byte) (n int, err error) {
 	m := l.newLogMessage(string(buf[:]))
 	j, err := json.Marshal(m)
 	if err != nil {

--- a/services/jobservices/src/messaging/amqp_test.go
+++ b/services/jobservices/src/messaging/amqp_test.go
@@ -21,7 +21,6 @@ func GetClient(t *testing.T) *Client {
 	client, err = NewClient(uri(), false)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	client.SetupPublishing(JobsExchange)
 	go client.Listen()
@@ -85,7 +84,6 @@ func TestNewClient(t *testing.T) {
 	actual, err := NewClient(uri(), false)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	defer actual.Close()
 	expected := uri()
@@ -141,7 +139,6 @@ func TestSendTimeLimitRequest(t *testing.T) {
 	err := json.Unmarshal(actual, req)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if req.InvocationID != "test" {
 		t.Errorf("TimeLimitRequest's InvocationID was %s instead of test", req.InvocationID)
@@ -168,7 +165,6 @@ func TestSendTimeLimitResponse(t *testing.T) {
 	err := json.Unmarshal(actual, resp)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if resp.InvocationID != "test" {
 		t.Errorf("TimeLimitRequest's InvocationID was %s instead of test", resp.InvocationID)
@@ -195,7 +191,6 @@ func TestSendTimeLimitDelta(t *testing.T) {
 	err := json.Unmarshal(actual, delta)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if delta.InvocationID != "test" {
 		t.Errorf("TimeLimitDelta's InvocationID was %s instead of test", delta.InvocationID)
@@ -226,7 +221,6 @@ func TestSendStopRequest(t *testing.T) {
 	req := &StopRequest{}
 	if err = json.Unmarshal(actual, req); err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if req.Reason != "this is a test" {
 		t.Errorf("Reason was '%s' instead of '%s'", req.Reason, "this is a test")

--- a/services/jobservices/src/messaging/amqp_test.go
+++ b/services/jobservices/src/messaging/amqp_test.go
@@ -3,7 +3,6 @@ package messaging
 import (
 	"encoding/json"
 	"fmt"
-	"logcabin"
 	"model"
 	"os"
 	"reflect"
@@ -12,7 +11,6 @@ import (
 	"github.com/streadway/amqp"
 )
 
-var l = logcabin.New("test_amqp", "test_amqp")
 var client *Client
 
 func GetClient(t *testing.T) *Client {

--- a/services/jobservices/src/model/jobs_test.go
+++ b/services/jobservices/src/model/jobs_test.go
@@ -47,12 +47,10 @@ func _inittests(t *testing.T, memoize bool) *Job {
 		data, err := JSONData()
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		s, err = NewFromData(data)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 	}
 	return s
@@ -259,7 +257,6 @@ func TestCondorLogDir(t *testing.T) {
 	logPath, err := configurate.C.String("condor.log_path")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	expected := fmt.Sprintf("%s/", path.Join(logPath, s.Submitter, s.DirectoryName()))
 	actual := s.CondorLogDirectory()

--- a/services/jobservices/src/model/jobs_test.go
+++ b/services/jobservices/src/model/jobs_test.go
@@ -5,7 +5,6 @@ import (
 	"configurate"
 	"fmt"
 	"io/ioutil"
-	"logcabin"
 	"os"
 	"path"
 	"reflect"
@@ -28,7 +27,6 @@ func JSONData() ([]byte, error) {
 
 var (
 	s *Job
-	l = logcabin.New("test_jobs", "test_jobs")
 )
 
 func _inittests(t *testing.T, memoize bool) *Job {

--- a/services/jobservices/src/road-runner/containers.go
+++ b/services/jobservices/src/road-runner/containers.go
@@ -4,11 +4,11 @@ import (
 	"configurate"
 	"fmt"
 	"io"
-	"log"
 	"model"
 	"os"
 	"strconv"
 	"strings"
+	"logcabin"
 
 	"github.com/fsouza/go-dockerclient"
 )
@@ -185,7 +185,7 @@ func (d *Docker) Pull(name, tag string) error {
 		Repository:   name,
 		Registry:     reg,
 		Tag:          tag,
-		OutputStream: logger,
+		OutputStream: logcabin.Info_Lincoln,
 	}
 	return d.Client.PullImage(opts, auth)
 }
@@ -220,7 +220,7 @@ func (d *Docker) CreateContainerFromStep(step *model.Step, invID string) (*docke
 		if parsedMem, err := strconv.ParseInt(step.Component.Container.MemoryLimit, 10, 64); err == nil {
 			createConfig.Memory = parsedMem
 		} else {
-			log.Print(err)
+			logcabin.Error.Print(err)
 		}
 	}
 
@@ -228,7 +228,7 @@ func (d *Docker) CreateContainerFromStep(step *model.Step, invID string) (*docke
 		if parsedCPU, err := strconv.ParseInt(step.Component.Container.CPUShares, 10, 64); err == nil {
 			createConfig.CPUShares = parsedCPU
 		} else {
-			log.Print(err)
+			logcabin.Error.Print(err)
 		}
 	}
 
@@ -314,8 +314,8 @@ func (d *Docker) CreateContainerFromStep(step *model.Step, invID string) (*docke
 			fmt.Sprintf("%s:%s", lm.Source, lm.Destination),
 		)
 	}
-	log.Printf("Mounts: %#v\n", createConfig.Mounts)
-	log.Printf("Binds: %#v\n", createHostConfig.Binds)
+	logcabin.Info.Printf("Mounts: %#v\n", createConfig.Mounts)
+	logcabin.Info.Printf("Binds: %#v\n", createHostConfig.Binds)
 
 	for _, dev := range step.Component.Container.Devices {
 		device := docker.Device{
@@ -377,7 +377,7 @@ func (d *Docker) runContainer(container *docker.Container, opts *docker.CreateCo
 	go func() {
 		err = d.Attach(container, stdoutFile, stderrFile, successChan)
 		if err != nil {
-			log.Print(err)
+			logcabin.Error.Print(err)
 		}
 	}()
 	successChan <- <-successChan

--- a/services/jobservices/src/road-runner/containers_test.go
+++ b/services/jobservices/src/road-runner/containers_test.go
@@ -5,8 +5,6 @@ import (
 	"configurate"
 	"fmt"
 	"io/ioutil"
-	"log"
-	"logcabin"
 	"model"
 	"os"
 	"reflect"
@@ -19,7 +17,6 @@ import (
 
 var (
 	s *model.Job
-	l = logcabin.New("test_containers", "test_containers")
 )
 
 func shouldrun() bool {

--- a/services/jobservices/src/road-runner/containers_test.go
+++ b/services/jobservices/src/road-runner/containers_test.go
@@ -59,16 +59,14 @@ func _inittests(t *testing.T, memoize bool) *model.Job {
 		data, err := JSONData()
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		s, err = model.NewFromData(data)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		err = configurate.Init("../test/test_config.yaml")
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 	}
 	return s
@@ -85,7 +83,6 @@ func TestNewDocker(t *testing.T) {
 	_, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 }
 
@@ -96,7 +93,6 @@ func TestIsContainer(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	actual, err := dc.IsContainer("test_not_there")
 	if err != nil {
@@ -114,7 +110,6 @@ func TestPull(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = dc.Pull("alpine", "latest")
 	if err != nil {
@@ -130,7 +125,6 @@ func TestCreateIsContainerAndNukeByName(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = dc.Pull("alpine", "latest")
 	if err != nil {
@@ -146,7 +140,6 @@ func TestCreateIsContainerAndNukeByName(t *testing.T) {
 	container, opts, err := dc.CreateContainerFromStep(&job.Steps[0], job.InvocationID)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if container.ID == "" {
 		t.Error("CreateContainerFromStep created a container with a blank ID")
@@ -244,17 +237,14 @@ func TestCreateDownloadContainer(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	image, err := configurate.C.String("porklock.image")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	tag, err := configurate.C.String("porklock.tag")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = dc.Pull(image, tag)
 	if err != nil {
@@ -271,7 +261,6 @@ func TestCreateDownloadContainer(t *testing.T) {
 	container, opts, err := dc.CreateDownloadContainer(job, &job.Steps[0].Config.Inputs[0], "0")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 
 	if container.Name != cName {
@@ -298,7 +287,6 @@ func TestCreateDownloadContainer(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	expectedMount := docker.Mount{
 		Source:      wd,
@@ -338,17 +326,14 @@ func TestCreateUploadContainer(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	image, err := configurate.C.String("porklock.image")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	tag, err := configurate.C.String("porklock.tag")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	containerName := fmt.Sprintf("output-%s", job.InvocationID)
 	exists, err := dc.IsContainer(containerName)
@@ -361,7 +346,6 @@ func TestCreateUploadContainer(t *testing.T) {
 	container, opts, err := dc.CreateUploadContainer(job)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if container.Name != containerName {
 		t.Errorf("container name was %s instead of %s", container.Name, containerName)
@@ -387,7 +371,6 @@ func TestCreateUploadContainer(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	expectedMount := docker.Mount{
 		Source:      wd,
@@ -427,7 +410,6 @@ func TestAttach(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = dc.Pull("alpine", "latest")
 	if err != nil {
@@ -443,7 +425,6 @@ func TestAttach(t *testing.T) {
 	container, _, err := dc.CreateContainerFromStep(&job.Steps[0], job.InvocationID)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	stdout := bytes.NewBufferString("")
 	stderr := bytes.NewBufferString("")
@@ -452,7 +433,6 @@ func TestAttach(t *testing.T) {
 		err = dc.Attach(container, stdout, stderr, success)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 	}()
 	<-success
@@ -474,7 +454,6 @@ func TestRunStep(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = dc.Pull("alpine", "latest")
 	if err != nil {
@@ -491,13 +470,11 @@ func TestRunStep(t *testing.T) {
 		err = os.MkdirAll("logs", 0755)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 	}
 	exitCode, err := dc.RunStep(&job.Steps[0], job.InvocationID, 0)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if exitCode != 0 {
 		t.Errorf("RunStep's exit code was %d instead of 0\n", exitCode)
@@ -512,7 +489,6 @@ func TestRunStep(t *testing.T) {
 	actualBytes, err := ioutil.ReadFile(job.Steps[0].Stdout("0"))
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	actual := strings.TrimSpace(string(actualBytes))
 	if !reflect.DeepEqual(actual, expected) {
@@ -539,17 +515,14 @@ func TestDownloadInputs(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	image, err := configurate.C.String("porklock.image")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	tag, err := configurate.C.String("porklock.tag")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = dc.Pull(image, tag)
 	if err != nil {
@@ -567,13 +540,11 @@ func TestDownloadInputs(t *testing.T) {
 		err = os.MkdirAll("logs", 0755)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 	}
 	exitCode, err := dc.DownloadInputs(job, &job.Steps[0].Config.Inputs[0], 0)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if exitCode != 0 {
 		t.Errorf("DownloadInputs's exit code was %d instead of 0\n", exitCode)
@@ -591,7 +562,6 @@ func TestDownloadInputs(t *testing.T) {
 	actualBytes, err := ioutil.ReadFile(job.Steps[0].Config.Inputs[0].Stdout("0"))
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	actual := strings.TrimSpace(string(actualBytes))
 	if !reflect.DeepEqual(actual, expected) {
@@ -618,17 +588,14 @@ func TestUploadOutputs(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	image, err := configurate.C.String("porklock.image")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	tag, err := configurate.C.String("porklock.tag")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = dc.Pull(image, tag)
 	if err != nil {
@@ -646,13 +613,11 @@ func TestUploadOutputs(t *testing.T) {
 		err = os.MkdirAll("logs", 0755)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 	}
 	exitCode, err := dc.UploadOutputs(job)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if exitCode != 0 {
 		t.Errorf("UploadOutputs exit code was %d instead of 0\n", exitCode)
@@ -670,7 +635,6 @@ func TestUploadOutputs(t *testing.T) {
 	actualBytes, err := ioutil.ReadFile("logs/logs-stdout-output")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	actual := strings.TrimSpace(string(actualBytes))
 	if !reflect.DeepEqual(actual, expected) {
@@ -697,17 +661,14 @@ func TestCreateDataContainer(t *testing.T) {
 	dc, err := NewDocker(uri())
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	image, err := configurate.C.String("porklock.image")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	tag, err := configurate.C.String("porklock.tag")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	err = dc.Pull(image, tag)
 	if err != nil {

--- a/services/jobservices/src/road-runner/main_test.go
+++ b/services/jobservices/src/road-runner/main_test.go
@@ -20,7 +20,6 @@ func GetClient(t *testing.T) *messaging.Client {
 	client, err = messaging.NewClient(messagingURI(), false)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	client.SetupPublishing(messaging.JobsExchange)
 	go client.Listen()
@@ -39,7 +38,6 @@ func TestRegisterTimeLimitDeltaListener(t *testing.T) {
 	defaultDuration, err := time.ParseDuration("48h")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	exitFunc := func() {
 		fmt.Println("exitFunc called")
@@ -63,7 +61,6 @@ func TestRegisterTimeLimitRequestListener(t *testing.T) {
 	defaultDuration, err := time.ParseDuration("48h")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	exitFunc := func() {
 		fmt.Println("exitFunc called")
@@ -89,14 +86,12 @@ func TestRegisterTimeLimitRequestListener(t *testing.T) {
 	err = client.SendTimeLimitRequest(invID)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	time.Sleep(1000 * time.Millisecond)
 	<-coord
 	parsedResponse := &messaging.TimeLimitResponse{}
 	if err = json.Unmarshal(actual, parsedResponse); err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if parsedResponse.InvocationID != invID {
 		t.Errorf("InvocationID was %s instead of %s", parsedResponse.InvocationID, invID)
@@ -117,7 +112,6 @@ func TestRegisterStopRequestListener(t *testing.T) {
 	err := client.SendStopRequest(invID, "test", "this is a test")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	actual := <-exit
 	if actual != messaging.StatusKilled {
@@ -131,7 +125,6 @@ func TestNewTimeTracker(t *testing.T) {
 	duration, err := time.ParseDuration("1s")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	coord := make(chan int)
 	handler := func() {
@@ -152,19 +145,16 @@ func TestApplyDelta(t *testing.T) {
 	defaultDuration, err := time.ParseDuration("10s")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	resetDuration, err := time.ParseDuration("20s")
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	handler := func() {}
 	tt := NewTimeTracker(defaultDuration, handler)
 	firstDate := tt.EndDate
 	if err = tt.ApplyDelta(resetDuration); err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	secondDate := tt.EndDate
 	if !secondDate.After(firstDate) {


### PR DESCRIPTION
These are changes intended for PR #101.
`logcabin`, from the `jobservices` go service, has been updated to provide the ability to specify log-levels. All logging in the `jobservices` project has been updated to use the new `logcabin` loggers.

One other, minor, enhancements was also made. Specifically, removing the extraneous `t.Fail()` statements from the unit/integration tests.