### PR TITLE
Make dewey's queue declaration not auto-delete. 

### DIFF
--- a/services/dewey/src/dewey/amq.clj
+++ b/services/dewey/src/dewey/amq.clj
@@ -41,7 +41,7 @@
                                                           delivery-fn)))]
     (lb/qos channel qos)
     (le/topic channel exchange-name :durable exchange-durable :auto-delete exchange-auto-delete)
-    (lq/declare channel queue :durable true)
+    (lq/declare channel queue :durable true :auto-delete false :exclusive false)
     (doseq [topic topics] (lq/bind channel queue exchange-name :routing-key topic))
     (lb/consume channel queue consumer :auto-ack false)))
 


### PR DESCRIPTION
Durability means very little without this, since it would only be durable in the case of being created and the broker restarted before anything connected to it. This is because `durable` makes it stay on server restarts, but `auto-delete` makes it get deleted any time the number of consumers goes to 0 from a larger number. So, durable + auto-delete means it'd only stay around if for some reason it was created but not connected to before a server restart, which isn't exactly useful.