### PR TITLE
CORE-7552: validate UUIDs refer to extant objects in stat-gatherer endpoint.

### DIFF
--- a/services/data-info/src/data_info/services/stat.clj
+++ b/services/data-info/src/data_info/services/stat.clj
@@ -98,6 +98,7 @@
   [{user :user validation :validation-behavior} {paths :paths uuids :ids}]
   (with-jargon (cfg/jargon-cfg) [cm]
     (validators/user-exists cm user)
+    (validators/all-uuids-exist cm uuids)
     (let [uuid-paths (map (juxt (comp keyword str) (partial uuid/get-path cm)) uuids)
           all-paths (into paths (map second uuid-paths))]
       (validators/all-paths-exist cm all-paths)

--- a/services/data-info/src/data_info/util/validators.clj
+++ b/services/data-info/src/data_info/util/validators.clj
@@ -8,6 +8,7 @@
             [clj-jargon.item-info :as item]
             [clj-jargon.permissions :as perm]
             [clj-jargon.users :as user]
+            [clj-jargon.by-uuid :as uuid]
             [clojure-commons.error-codes :as error]
             [data-info.util.config :as cfg])
   (:import [clojure.lang IPersistentCollection]))
@@ -215,3 +216,9 @@
       (throw+ {:error_code error/ERR_NOT_OWNER
                :user user
                :paths (filterv #(not (belongs-to? %)) paths)}))))
+
+(defn all-uuids-exist
+  [cm uuids]
+  (when-not (every? #(uuid/get-path cm %) uuids)
+    (throw+ {:error_code error/ERR_DOES_NOT_EXIST
+             :ids      (filterv #(not (uuid/get-path cm  %1)) uuids)})))


### PR DESCRIPTION
Just a small bugfix. Previously it was throwing an NPE after the `(partial uuid/get-path cm)` a line below returned nil, in the case of the UUID referring to a nonexistent object.