### PR TITLE
Make the name of the "data" index configurable (in ansible, Infosquito, and terrain)

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -261,6 +261,7 @@ elasticsearch:
   base: "http://{{ groups['elasticsearch'][0] }}"
   scroll_size: 1000
   cluster_name: elasticsearch
+  data_index: data
   heap_size:
   network_http_port:
   network_transport_tcp_port:

--- a/ansible/roles/util-cfg-service/templates/infosquito.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/infosquito.properties.j2
@@ -2,6 +2,7 @@
 infosquito.es.host        = {{ elasticsearch.host }}
 infosquito.es.port        = {{ elasticsearch.port }}
 infosquito.es.scroll-size = {{ elasticsearch.scroll_size }}
+infosquito.es.index       = {{ elasticsearch.data_index }}
 
 # ICAT Database Connection Settings
 infosquito.icat.host     = {{ icat.host }}

--- a/ansible/roles/util-cfg-service/templates/terrain.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/terrain.properties.j2
@@ -58,8 +58,9 @@ terrain.jex.base-url = {{ jex.base }}/
 # Tree viewer settings
 terrain.tree-viewer.base-url = {{ tree_parser_base }}
 
-# Elastic Search settings
-terrain.infosquito.es-url = {{ elasticsearch.base }}
+# Elasticsearch settings
+terrain.infosquito.es-url   = {{ elasticsearch.base }}
+terrain.infosquito.es-index = {{ elasticsearch.data_index }}
 
 # App execution settings
 terrain.job-exec.default-output-folder = {{ apps.out_dir }}

--- a/services/Infosquito/src/infosquito/actions.clj
+++ b/services/Infosquito/src/infosquito/actions.clj
@@ -21,4 +21,4 @@
   (let [icat-cfg ((comp icat/init props->icat-cfg) props)]
     (icat/with-icat icat-cfg
       (esc/purge-index props)
-      (icat/reindex icat-cfg))))
+      (icat/reindex icat-cfg props))))

--- a/services/Infosquito/src/infosquito/props.clj
+++ b/services/Infosquito/src/infosquito/props.clj
@@ -12,6 +12,7 @@
   ["infosquito.es.host"
    "infosquito.es.port"
    "infosquito.es.scroll-size"
+   "infosquito.es.index"
    "infosquito.icat.host"
    "infosquito.icat.port"
    "infosquito.icat.user"
@@ -71,6 +72,9 @@
   [props]
   (get props "infosquito.es.scroll-size"))
 
+(defn get-es-index
+  [props]
+  (get props "infosquito.es.index"))
 
 (defn get-icat-host
   [props]

--- a/services/terrain/src/terrain/persistence/search.clj
+++ b/services/terrain/src/terrain/persistence/search.clj
@@ -35,7 +35,7 @@
      ::cx/invalid-cfg - This is thrown if there is a problem with elasticsearch"
   [^IPersistentMap tag]
   (try+
-    (doc/create (connect) "data" "tag" tag :id (:id tag))
+    (doc/create (connect) (cfg/es-index) "tag" tag :id (:id tag))
     (catch [:status 404] {:keys []}
       (throw+ es-uninitialized))))
 
@@ -54,7 +54,7 @@
     (let [script "ctx._source.value = value;
                   ctx._source.description = description;
                   ctx._source.dateModified = dateModified"]
-      (doc/update-with-script (connect) "data" "tag" (str tag-id) script updates))
+      (doc/update-with-script (connect) (cfg/es-index) "tag" (str tag-id) script updates))
     (catch [:status 404] {:keys []}
       (throw+ es-uninitialized))))
 
@@ -72,7 +72,7 @@
   (try+
     (let [script "ctx._source.targets = targets"
           update {:targets (map #(assoc % :type (str (:type %))) targets)}]
-      (doc/update-with-script (connect) "data" "tag" (str tag-id) script update))
+      (doc/update-with-script (connect) (cfg/es-index) "tag" (str tag-id) script update))
     (catch [:status 404] {:keys []}
       (throw+ es-uninitialized))))
 
@@ -87,7 +87,7 @@
      ::cx/invalid-cfg - This is thrown if there is a problem with elasticsearch"
   [^UUID tag-id]
   (try+
-    (doc/delete (connect) "data" "tag" (str tag-id))
+    (doc/delete (connect) (cfg/es-index) "tag" (str tag-id))
     (catch [:status 404] {:keys []}
       (throw+ es-uninitialized))))
 
@@ -104,7 +104,7 @@
   [^String user ^ISeq tag-ids]
   (try+
     (let [query (query/bool :must (query/term :id tag-ids) :filter (query/term :creator user))
-          hits  (resp/hits-from (doc/search (connect) "data" "tag" :query query :_source false))]
+          hits  (resp/hits-from (doc/search (connect) (cfg/es-index) "tag" :query query :_source false))]
       (map :_id hits))
     (catch [:status 404] {:keys []}
       (throw+ es-uninitialized))))
@@ -187,7 +187,7 @@
      :invalid-query - This is thrown if the query string is invalid."
   [^ISeq types ^IPersistentMap query ^IPersistentMap sort ^Integer from ^Integer size]
   (try+
-    (let [resp (doc/search (connect) "data" (map name types)
+    (let [resp (doc/search (connect) (cfg/es-index) (map name types)
                  :query        query
                  :from         from
                  :size         size

--- a/services/terrain/src/terrain/util/config.clj
+++ b/services/terrain/src/terrain/util/config.clj
@@ -373,9 +373,14 @@
   "terrain.tree-viewer.base-url")
 
 (cc/defprop-str es-url
-  "The URL for Elastic Search"
+  "The URL for Elasticsearch"
   [props config-valid configs data-routes-enabled]
   "terrain.infosquito.es-url")
+
+(cc/defprop-str es-index
+  "The index name for Elasticsearch."
+  [props config-valid configs data-routes-enabled]
+  "terrain.infosquito.es-index")
 
 (cc/defprop-str jwt-private-signing-key
   "The path to the private key used for signing JWT assertions."


### PR DESCRIPTION
In order to update the mappings for template metadata, I'm planning to migrate us to having the 'data' index be an index alias, pointing to an underlying index with some other name. The private ansible repo's `index-template-metadata` has changes to the role there which initializes our elasticsearch cluster with the new mappings, as well as using the newly-configurable index name. I've also made it so Infosquito and terrain use this configurable name, primarily because it was easy. dewey I've left alone, its config is more annoying to pass around.