### PR TITLE
CORE-7499: Add has_child queries for file and folder (template) metadata

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/DataSearchQueryBuilder.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/DataSearchQueryBuilder.java
@@ -43,6 +43,7 @@ public class DataSearchQueryBuilder {
     public static final String PATH = "path";
     public static final String METADATA2 = "metadata";
     public static final String NESTED2 = "nested";
+    public static final String HAS_CHILD = "has_child";
     public static final String FILE_SIZE = "fileSize";
     public static final String LABEL = "label";
     public static final String DATE_CREATED = "dateCreated";
@@ -188,19 +189,44 @@ public class DataSearchQueryBuilder {
         return toString();
     }
 
+    private Splittable metadataNested(String content, String field) {
+        // {"nested":{"path":"metadata","query":{"query_string":{"query":"*ipc* OR *attrib*","fields":["metadata.attribute"]}}}}
+        Splittable metadata = StringQuoter.createSplittable();
+
+        Splittable nested = addChild(metadata, NESTED2);
+        StringQuoter.create(METADATA2).assign(nested, PATH);
+
+        getSimpleQuery(field, content).assign(nested, QUERY2);
+        return metadata;
+    }
+
+    private Splittable childQuery(String type, Splittable innerQuery) {
+        // {"has_child": {"type": "...", "score_mode": "max", "query": {...}}
+        Splittable query = StringQuoter.createSplittable();
+        Splittable hasChild = addChild(query, HAS_CHILD);
+        StringQuoter.create(type).assign(hasChild, "type");
+        StringQuoter.create("max").assign(hasChild, "score_mode");
+        innerQuery.assign(hasChild, QUERY2);
+        return query;
+    }
+
     public DataSearchQueryBuilder metadataAttribute() {
         String content = dsf.getMetadataAttributeQuery();
         if (!Strings.isNullOrEmpty(content)) {
+            Splittable attr = StringQuoter.createSplittable();
+            Splittable attrBool = addChild(attr, BOOL);
+            Splittable attrShouldList = addArray(attrBool, "should");
 
-            // {"nested":{"path":"metadata","query":{"query_string":{"query":"*ipc* OR *attrib*","fields":["metadata.attribute"]}}}}
-            Splittable metadata = StringQuoter.createSplittable();
+            Splittable metadata = metadataNested(content, METADATA_ATTRIBUTE);
+            appendArrayItem(attrShouldList, metadata);
 
-            Splittable nested = addChild(metadata, NESTED2);
-            StringQuoter.create(METADATA2).assign(nested, PATH);
+            Splittable childFileQuery = childQuery("file_metadata", metadata.deepCopy());
+            appendArrayItem(attrShouldList, childFileQuery);
 
-            getSimpleQuery(METADATA_ATTRIBUTE, content).assign(nested, QUERY2);
+            Splittable childFolderQuery = childQuery("folder_metadata", metadata.deepCopy());
+            appendArrayItem(attrShouldList, childFolderQuery);
 
-            appendArrayItem(mustList, metadata);
+            appendArrayItem(mustList, attr);
         }
         return this;
     }
@@ -208,14 +234,20 @@ public class DataSearchQueryBuilder {
     public DataSearchQueryBuilder metadataValue() {
         String content = dsf.getMetadataValueQuery();
         if (!Strings.isNullOrEmpty(content)) {
-            // {"nested":{"path":"metadata","query":{"query_string":{"query":"*ipc* OR *attrib*","fields":["metadata.value"]}}}}
-            Splittable metadata = StringQuoter.createSplittable();
+            Splittable value = StringQuoter.createSplittable();
+            Splittable valueBool = addChild(value, BOOL);
+            Splittable valueShouldList = addArray(valueBool, "should");
 
-            Splittable nested = addChild(metadata, NESTED2);
-            StringQuoter.create(METADATA2).assign(nested, PATH);
-            getSimpleQuery(METADATA_VALUE, content).assign(nested, QUERY2);
+            Splittable metadata = metadataNested(content, METADATA_VALUE);
+            appendArrayItem(valueShouldList, metadata);
 
-            appendArrayItem(mustList, metadata);
+            Splittable childFileQuery = childQuery("file_metadata", metadata.deepCopy());
+            appendArrayItem(valueShouldList, childFileQuery);
+
+            Splittable childFolderQuery = childQuery("folder_metadata", metadata.deepCopy());
+            appendArrayItem(valueShouldList, childFolderQuery);
+
+            appendArrayItem(mustList, value);
         }
         return this;
     }

--- a/ui/de-lib/src/test/java/org/iplantc/de/client/services/impl/DataSearchQueryBuilderTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/client/services/impl/DataSearchQueryBuilderTest.java
@@ -355,9 +355,12 @@ public class DataSearchQueryBuilderTest {
     private String setMetadataAttributeQuery(final String givenQuery) {
         when(dsf.getMetadataAttributeQuery()).thenReturn(givenQuery);
         DataSearchQueryBuilder uut = new DataSearchQueryBuilder(dsf, userInfoMock);
-        return "{\"nested\":{\"query\":"
+        String nestedQuery = "{\"nested\":{\"query\":"
                 + uut.getSimpleQuery(DataSearchQueryBuilder.METADATA_ATTRIBUTE, givenQuery).getPayload()
                 + ",\"path\":\"metadata\"}}";
+        String fileQuery = "{\"has_child\":{\"query\":"+nestedQuery+",\"score_mode\":\"max\",\"type\":\"file_metadata\"}}";
+        String folderQuery = "{\"has_child\":{\"query\":"+nestedQuery+",\"score_mode\":\"max\",\"type\":\"folder_metadata\"}}";
+        return "{\"bool\":{\"should\":[" + nestedQuery + "," + fileQuery + "," + folderQuery + "]}}";
     }
 
     /**
@@ -366,9 +369,12 @@ public class DataSearchQueryBuilderTest {
     private String setMetadataValueQuery(final String givenQuery) {
         when(dsf.getMetadataValueQuery()).thenReturn(givenQuery);
         DataSearchQueryBuilder uut = new DataSearchQueryBuilder(dsf, userInfoMock);
-        return "{\"nested\":{\"query\":"
+        String nestedQuery = "{\"nested\":{\"query\":"
                 + uut.getSimpleQuery(DataSearchQueryBuilder.METADATA_VALUE, givenQuery).getPayload()
                 + ",\"path\":\"metadata\"}}";
+        String fileQuery = "{\"has_child\":{\"query\":"+nestedQuery+",\"score_mode\":\"max\",\"type\":\"file_metadata\"}}";
+        String folderQuery = "{\"has_child\":{\"query\":"+nestedQuery+",\"score_mode\":\"max\",\"type\":\"folder_metadata\"}}";
+        return "{\"bool\":{\"should\":[" + nestedQuery + "," + fileQuery + "," + folderQuery + "]}}";
     }
 
     /**


### PR DESCRIPTION
This implements the UI changes necessary to take advantage of the new template metadata indexing (#91). Instead of a single `nested` query which queries the `metadata` field of the main `file` or `folder` document, this changes it so that it combines this with two other queries in a `bool` via `should`: two `has_child` queries which query the `file_metadata` and `folder_metadata` types, respectively, with their own `nested` queries against the identically-structured `metadata` field of those types. I've set these to use `score_mode` of `max`, which shouldn't really matter much because our structure only has one child document, meaning various averages, maximums, sums, etc. pretty much work the same, but I thought I may as well be explicit.

This requires the reindexing to have already been done; these queries will error when run against an index without the new mappings.