### PR TITLE
upgrade dewey/infosquito/monkey to langohr 3.5.1

### DIFF
--- a/services/Infosquito/project.clj
+++ b/services/Infosquito/project.clj
@@ -26,7 +26,7 @@
                                [com.fasterxml.jackson.core/jackson-databind]
                                [com.fasterxml.jackson.core/jackson-core]]]
                  [clojurewerkz/elastisch "2.0.0"]
-                 [com.novemberain/langohr "2.11.0"]
+                 [com.novemberain/langohr "3.5.1"]
                  [slingshot "0.10.3"]
                  [me.raynes/fs "1.4.6"]
                  [org.iplantc/clojure-commons "5.2.5.0"]

--- a/services/Infosquito/src/infosquito/messages.clj
+++ b/services/Infosquito/src/infosquito/messages.clj
@@ -48,11 +48,11 @@
 (defn- declare-queue
   [ch exchange queue-name]
   (lq/declare ch queue-name
-              :durable     true
-              :auto-delete false
-              :exclusive   false)
+              {:durable     true
+               :auto-delete false
+               :exclusive   false})
   (doseq [key ["index.all" "index.data"]]
-    (lq/bind ch queue-name exchange :routing-key key)))
+    (lq/bind ch queue-name exchange {:routing-key key})))
 
 (defn- reindex-handler
   [props ch {:keys [delivery-tag]} _]
@@ -70,8 +70,8 @@
  (let [exchange   (cfg/get-amqp-exchange-name props)
        queue-name (cfg/get-amqp-reindex-queue props)]
    (le/direct ch exchange
-     :durable     (cfg/amqp-exchange-durable? props)
-     :auto-delete (cfg/amqp-exchange-auto-delete? props))
+     {:durable     (cfg/amqp-exchange-durable? props)
+      :auto-delete (cfg/amqp-exchange-auto-delete? props)})
    (declare-queue ch exchange queue-name)
    (lc/blocking-subscribe ch queue-name (partial reindex-handler props))))
 

--- a/services/dewey/project.clj
+++ b/services/dewey/project.clj
@@ -25,7 +25,7 @@
                                 [com.fasterxml.jackson.core/jackson-databind]
                                 [com.fasterxml.jackson.core/jackson-core]]]
                  [clojurewerkz/elastisch "2.0.0"]
-                 [com.novemberain/langohr "2.11.0"]
+                 [com.novemberain/langohr "3.5.1"]
                  [liberator "0.11.1"]
                  [compojure "1.1.8"]
                  [ring "1.4.0"]

--- a/services/dewey/src/dewey/amq.clj
+++ b/services/dewey/src/dewey/amq.clj
@@ -28,22 +28,22 @@
   [connection queue exchange-name exchange-durable exchange-auto-delete qos topics delivery-fn]
   (let [channel  (lch/open connection)
         consumer (lc/create-default channel
-                   :handle-consume-ok-fn (fn [_] (log/info "Registered with AMQP broker"))
-                   :handle-delivery-fn   delivery-fn
-                   :handle-cancel-fn     (fn [_] (log/info "AMQP broker registration canceled")
-                                                 (Thread/sleep 1000)
-                                                 (consume connection
-                                                          queue
-                                                          exchange-name
-                                                          exchange-durable
-                                                          exchange-auto-delete
-                                                          topics
-                                                          delivery-fn)))]
+                   {:handle-consume-ok-fn (fn [_] (log/info "Registered with AMQP broker"))
+                    :handle-delivery-fn   delivery-fn
+                    :handle-cancel-fn     (fn [_] (log/info "AMQP broker registration canceled")
+                                                  (Thread/sleep 1000)
+                                                  (consume connection
+                                                           queue
+                                                           exchange-name
+                                                           exchange-durable
+                                                           exchange-auto-delete
+                                                           topics
+                                                           delivery-fn))})]
     (lb/qos channel qos)
-    (le/topic channel exchange-name :durable exchange-durable :auto-delete exchange-auto-delete)
-    (lq/declare channel queue :durable true :auto-delete false :exclusive false)
-    (doseq [topic topics] (lq/bind channel queue exchange-name :routing-key topic))
-    (lb/consume channel queue consumer :auto-ack false)))
+    (le/topic channel exchange-name {:durable exchange-durable :auto-delete exchange-auto-delete})
+    (lq/declare channel queue {:durable true :auto-delete false :exclusive false})
+    (doseq [topic topics] (lq/bind channel queue exchange-name {:routing-key topic}))
+    (lb/consume channel queue consumer {:auto-ack false})))
 
 
 (defn attach-to-exchange

--- a/services/monkey/project.clj
+++ b/services/monkey/project.clj
@@ -21,7 +21,7 @@
                  [postgresql "9.1-901-1.jdbc4"]
                  [org.clojure/java.jdbc "0.3.5"]
                  [clojurewerkz/elastisch "2.0.0"]
-                 [com.novemberain/langohr "2.11.0"]
+                 [com.novemberain/langohr "3.5.1"]
                  [me.raynes/fs "1.4.6"]
                  [slingshot "0.10.3"]
                  [org.iplantc/clojure-commons "5.2.5.0"]

--- a/services/monkey/src/monkey/messenger.clj
+++ b/services/monkey/src/monkey/messenger.clj
@@ -42,11 +42,11 @@
   (let [exchange (props/amqp-exchange-name props)
         queue    (props/amqp-queue props)]
     (exchange/direct ch exchange
-      :durable     (props/amqp-exchange-durable? props)
-      :auto-delete (props/amqp-exchange-auto-delete? props))
-    (queue/declare ch queue :durable true)
+      {:durable     (props/amqp-exchange-durable? props)
+       :auto-delete (props/amqp-exchange-auto-delete? props)})
+    (queue/declare ch queue {:durable true})
     (doseq [key ["index.all" "index.tags"]]
-      (queue/bind ch queue exchange :routing-key key))
+      (queue/bind ch queue exchange {:routing-key key}))
     queue))
 
 


### PR DESCRIPTION
I did the upgrade for info-typer separately since it wasn't changing major versions, but these ones are. This upgrade primarily serves to upgrade dependencies of langohr itself, including lots of bugfixes in the java rabbitmq client. I'm hoping that upgrading this will help dewey the most (as the thing handling the most messages) but it's mostly just intended as keeping on top of things.