### PR TITLE
CORE-7550 Update terrain's Perm-ID Request endpoints to return null folders instead of errors when folder does not exist.

### DIFF
--- a/services/metadata/src/metadata/persistence/permanent_id_requests.clj
+++ b/services/metadata/src/metadata/persistence/permanent_id_requests.clj
@@ -26,6 +26,7 @@
             :target_id
             :target_type
             :requested_by
+            :original_path
             [:status_codes.name :status]
             [:statuses.date_assigned :status_date]
             [:statuses.updated_by])
@@ -44,12 +45,12 @@
     sort-field :sort-field
     sort-dir   :sort-dir}]
   (subselect [(list-permanent-id-requests-subselect user) :reqs]
-      (fields :id :type :target_id :target_type :requested_by
+      (fields :id :type :target_id :target_type :requested_by :original_path
               [(sqlfn :first :status_date) :date_submitted]
               [(sqlfn :last :status) :status]
               [(sqlfn :last :status_date) :date_updated]
               [(sqlfn :last :updated_by) :updated_by])
-      (group :id :type :target_id :target_type :requested_by)
+      (group :id :type :target_id :target_type :requested_by :original_path)
       (order (or sort-field :date_submitted) (or sort-dir :ASC))
       (limit row-limit)
       (offset row-offset)))

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/model/PermanentIdRequestPathProvider.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/model/PermanentIdRequestPathProvider.java
@@ -1,5 +1,6 @@
-package org.iplantc.de.admin.desktop.client.permIdRequest.views;
+package org.iplantc.de.admin.desktop.client.permIdRequest.model;
 
+import org.iplantc.de.admin.desktop.client.permIdRequest.views.PermanentIdRequestView.PermanentIdRequestViewAppearance;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequest;
 
 import com.sencha.gxt.core.client.ValueProvider;
@@ -7,11 +8,11 @@ import com.sencha.gxt.core.client.ValueProvider;
 /**
  * @author psarando
  */
-public class FolderPathProvider implements ValueProvider<PermanentIdRequest, String> {
+public class PermanentIdRequestPathProvider implements ValueProvider<PermanentIdRequest, String> {
 
-    private final PermanentIdRequestView.PermanentIdRequestViewAppearance appearance;
+    private final PermanentIdRequestViewAppearance appearance;
 
-    public FolderPathProvider(PermanentIdRequestView.PermanentIdRequestViewAppearance appearance) {
+    public PermanentIdRequestPathProvider(PermanentIdRequestViewAppearance appearance) {
         this.appearance = appearance;
     }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/presenter/PermanentIdRequestPresenter.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/presenter/PermanentIdRequestPresenter.java
@@ -5,6 +5,7 @@ import org.iplantc.de.admin.desktop.client.permIdRequest.views.PermanentIdReques
 import org.iplantc.de.admin.desktop.client.permIdRequest.views.PermanentIdRequestView.PermanentIdRequestPresenterAppearance;
 import org.iplantc.de.admin.desktop.client.permIdRequest.views.PermanentIdRequestView.Presenter;
 import org.iplantc.de.admin.desktop.client.permIdRequest.views.UpdatePermanentIdRequestDialog;
+import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequest;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestAutoBeanFactory;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestDetails;
@@ -60,7 +61,13 @@ public class PermanentIdRequestPresenter implements Presenter {
 
     @Override
     public void fetchMetadata() {
-        view.fetchMetadata(selectedRequest.getFolder(), appearance, drsvc);
+        final Folder selectedFolder = selectedRequest.getFolder();
+        if (selectedFolder != null) {
+            view.fetchMetadata(selectedFolder, appearance, drsvc);
+        } else {
+            final String errMessage = appearance.folderNotFound(selectedRequest.getOriginalPath());
+            IplantAnnouncer.getInstance().schedule(new ErrorAnnouncementConfig(errMessage));
+        }
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/FolderPathProvider.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/FolderPathProvider.java
@@ -1,0 +1,38 @@
+package org.iplantc.de.admin.desktop.client.permIdRequest.views;
+
+import org.iplantc.de.client.models.identifiers.PermanentIdRequest;
+
+import com.sencha.gxt.core.client.ValueProvider;
+
+/**
+ * @author psarando
+ */
+public class FolderPathProvider implements ValueProvider<PermanentIdRequest, String> {
+
+    private final PermanentIdRequestView.PermanentIdRequestViewAppearance appearance;
+
+    public FolderPathProvider(PermanentIdRequestView.PermanentIdRequestViewAppearance appearance) {
+        this.appearance = appearance;
+    }
+
+    @Override
+    public String getValue(PermanentIdRequest request) {
+        if (request == null || request.getFolder() == null) {
+            return appearance.folderNotFound();
+        }
+
+        return request.getFolder().getPath();
+    }
+
+    @Override
+    public void setValue(PermanentIdRequest request, String value) {
+        if (request != null && request.getFolder() != null) {
+            request.getFolder().setPath(value);
+        }
+    }
+
+    @Override
+    public String getPath() {
+        return "Folder.path";
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestProperties.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestProperties.java
@@ -3,8 +3,6 @@ package org.iplantc.de.admin.desktop.client.permIdRequest.views;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequest;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestType;
 
-import com.google.gwt.editor.client.Editor.Path;
-
 import com.sencha.gxt.core.client.ValueProvider;
 import com.sencha.gxt.data.shared.ModelKeyProvider;
 import com.sencha.gxt.data.shared.PropertyAccess;
@@ -27,9 +25,6 @@ public interface PermanentIdRequestProperties extends PropertyAccess<PermanentId
     ValueProvider<PermanentIdRequest, Date> dateSubmitted();
 
     ValueProvider<PermanentIdRequest, Date> dateUpdated();
-
-    @Path("Folder.path")
-    ValueProvider<PermanentIdRequest, String> path();
 
     ValueProvider<PermanentIdRequest, PermanentIdRequestType> type();
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestView.java
@@ -75,6 +75,8 @@ public interface PermanentIdRequestView extends IsWidget, IsMaskable {
         String request();
 
         String userEmail();
+
+        String folderNotFound();
     }
 
     public interface Presenter {
@@ -102,6 +104,8 @@ public interface PermanentIdRequestView extends IsWidget, IsMaskable {
         String createPermIdSucess();
 
         String createPermIdFailure();
+
+        String folderNotFound(String path);
 
         String metadataSaveError();
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestViewImpl.java
@@ -154,7 +154,7 @@ public class PermanentIdRequestViewImpl extends Composite implements PermanentId
         ColumnConfig<PermanentIdRequest, String> nameCol = new ColumnConfig<>(pr_props.requestedBy(),
                                                                               appearance.nameColumnWidth(),
                                                                               appearance.nameColumnLabel());
-        ColumnConfig<PermanentIdRequest, String> pathCol = new ColumnConfig<>(pr_props.path(),
+        ColumnConfig<PermanentIdRequest, String> pathCol = new ColumnConfig<>(new FolderPathProvider(appearance),
                                                                               appearance.pathColumnWidth(),
                                                                               appearance.pathColumnLabel());
         ColumnConfig<PermanentIdRequest, Date> dateSubCol = new ColumnConfig<>(pr_props.dateSubmitted(),

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestViewImpl.java
@@ -1,10 +1,10 @@
 package org.iplantc.de.admin.desktop.client.permIdRequest.views;
 
+import org.iplantc.de.admin.desktop.client.permIdRequest.model.PermanentIdRequestPathProvider;
 import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequest;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestAutoBeanFactory;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestType;
-import org.iplantc.de.client.models.identifiers.PermanentIdRequestUpdate;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 
 import com.google.gwt.core.client.GWT;
@@ -23,7 +23,6 @@ import com.sencha.gxt.widget.core.client.box.MessageBox;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent.DialogHideHandler;
-import com.sencha.gxt.widget.core.client.event.SelectEvent.SelectHandler;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
@@ -154,7 +153,7 @@ public class PermanentIdRequestViewImpl extends Composite implements PermanentId
         ColumnConfig<PermanentIdRequest, String> nameCol = new ColumnConfig<>(pr_props.requestedBy(),
                                                                               appearance.nameColumnWidth(),
                                                                               appearance.nameColumnLabel());
-        ColumnConfig<PermanentIdRequest, String> pathCol = new ColumnConfig<>(new FolderPathProvider(appearance),
+        ColumnConfig<PermanentIdRequest, String> pathCol = new ColumnConfig<>(new PermanentIdRequestPathProvider(appearance),
                                                                               appearance.pathColumnWidth(),
                                                                               appearance.pathColumnLabel());
         ColumnConfig<PermanentIdRequest, Date> dateSubCol = new ColumnConfig<>(pr_props.dateSubmitted(),

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/identifiers/PermanentIdRequest.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/identifiers/PermanentIdRequest.java
@@ -17,6 +17,9 @@ public interface PermanentIdRequest extends HasId {
 
     Folder getFolder();
 
+    @PropertyName("original_path")
+    String getOriginalPath();
+
     @PropertyName("requested_by")
     String getRequestedBy();
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/permIdRequest/PermIdRequestDisplayStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/permIdRequest/PermIdRequestDisplayStrings.java
@@ -54,4 +54,6 @@ public interface PermIdRequestDisplayStrings extends Messages {
     String statusUpdateSuccess();
 
     String userEmail();
+
+    String folderNotFound();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/permIdRequest/PermIdRequestDisplayStrings.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/permIdRequest/PermIdRequestDisplayStrings.properties
@@ -24,3 +24,4 @@ requestLoadFailure = Unable to load permanentId requests!
 statusUpdateFailure = Unable to update the status of this request!
 statusUpdateSuccess = Request updated!
 userEmail = Email
+folderNotFound = Folder Not Found

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/permIdRequest/PermanentIdRequestPresenterDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/permIdRequest/PermanentIdRequestPresenterDefaultAppearance.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.theme.base.client.admin.permIdRequest;
 
 import org.iplantc.de.admin.desktop.client.permIdRequest.views.PermanentIdRequestView.PermanentIdRequestPresenterAppearance;
+import org.iplantc.de.resources.client.messages.IplantErrorStrings;
 
 import com.google.gwt.core.client.GWT;
 
@@ -8,13 +9,16 @@ public class PermanentIdRequestPresenterDefaultAppearance implements
                                                          PermanentIdRequestPresenterAppearance {
 
     private final PermIdRequestDisplayStrings displayStrings;
+    private final IplantErrorStrings errorStrings;
 
     public PermanentIdRequestPresenterDefaultAppearance() {
-        this(GWT.<PermIdRequestDisplayStrings> create(PermIdRequestDisplayStrings.class));
+        this(GWT.<PermIdRequestDisplayStrings>create(PermIdRequestDisplayStrings.class),
+             GWT.<IplantErrorStrings>create(IplantErrorStrings.class));
     }
 
-    public PermanentIdRequestPresenterDefaultAppearance(PermIdRequestDisplayStrings displayStrings) {
+    public PermanentIdRequestPresenterDefaultAppearance(PermIdRequestDisplayStrings displayStrings, IplantErrorStrings errorStrings) {
         this.displayStrings = displayStrings;
+        this.errorStrings = errorStrings;
     }
 
     @Override
@@ -25,6 +29,11 @@ public class PermanentIdRequestPresenterDefaultAppearance implements
     @Override
     public String createPermIdFailure() {
         return displayStrings.createPermIdFailure();
+    }
+
+    @Override
+    public String folderNotFound(String path) {
+        return errorStrings.folderNotFound(path);
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/permIdRequest/PermanentIdRequestViewDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/permIdRequest/PermanentIdRequestViewDefaultAppearance.java
@@ -133,4 +133,8 @@ public class PermanentIdRequestViewDefaultAppearance implements PermanentIdReque
         return displayStrings.userEmail();
     }
 
+    @Override
+    public String folderNotFound() {
+        return displayStrings.folderNotFound();
+    }
 }


### PR DESCRIPTION
Also updated Belphegor to display "Not Found" messages for null folders in the listing grid and when the "View Metadata" action is selected.
The Perm-ID Request "View Metadata" error message also includes the request's original path.