### PR TITLE
Analysis sharing

### DIFF
--- a/services/apps/src/apps/clients/notifications/job_sharing.clj
+++ b/services/apps/src/apps/clients/notifications/job_sharing.clj
@@ -3,7 +3,7 @@
         [medley.core :only [remove-vals]])
   (:require [clojure.string :as string]))
 
-(def notification-type "analyses")
+(def notification-type "analysis")
 (def singular "analysis")
 (def plural "analyses")
 

--- a/services/apps/src/apps/persistence/jobs.clj
+++ b/services/apps/src/apps/persistence/jobs.clj
@@ -493,6 +493,22 @@
           (where {:job_id job-id})
           (order :step_number)))
 
+(defn- child-job-subselect
+  [job-id]
+  (subselect :jobs
+             (fields :id)
+             (where {:parent_id job-id})
+             (limit 1)))
+
+(defn list-representative-job-steps
+  "Lists all of the job steps in a standalone job or all of the steps of one of the jobs in an HT batch. The purpose
+   of this function is to ensure that steps of every job type that are used in a job are listed. The analysis listing
+   code uses this function to determine whether or not a job can be shared."
+  [job-id]
+  (select (job-step-base-query)
+          (where (or {:job_id job-id}
+                     {:job_id [in (child-job-subselect job-id)]}))))
+
 (defn list-jobs-to-delete
   [ids]
   (select [:jobs :j]

--- a/services/apps/src/apps/routes/domain/analysis/listing.clj
+++ b/services/apps/src/apps/routes/domain/analysis/listing.clj
@@ -62,7 +62,10 @@
    (describe UUID "The identifier of the parent analysis.")
 
    (optional-key :batch_status)
-   (describe BatchStatus "A summary of the status of the batch.")})
+   (describe BatchStatus "A summary of the status of the batch.")
+
+   :can_share
+   (describe Boolean "Indicates whether or not the analysis can be shared.")})
 
 (defschema AnalysisList
   {:analyses  (describe [Analysis] "The list of analyses.")

--- a/services/apps/src/apps/service/apps/job_listings.clj
+++ b/services/apps/src/apps/service/apps/job_listings.clj
@@ -43,7 +43,11 @@
            (assoc (->> (group-by batch-child-status children)
                        (map (fn [[k v]] [k (count v)]))
                        (into {}))
-             :total (count children)))))
+                  :total (count children)))))
+
+(defn- job-supports-sharing?
+  [apps-client {parent-id :parent_id :keys [id]}]
+  (and (nil? parent-id) (every? #(.supportsJobSharing apps-client %) (jp/list-representative-job-steps id))))
 
 (defn format-job
   [apps-client app-tables job]
@@ -66,8 +70,7 @@
     :parent_id       (:parent-id job)
     :batch           (:is-batch job)
     :batch_status    (when (:is-batch job) (format-batch-status (:id job)))
-    :can_share       (and (not (:is-batch job))
-                          (every? #(.supportsJobSharing apps-client %) (jp/list-job-steps (:id job))))}))
+    :can_share       (job-supports-sharing? apps-client job)}))
 
 (defn- list-jobs*
   [{:keys [username]} {:keys [limit offset sort-field sort-dir filter include-hidden]} types]

--- a/services/apps/src/apps/service/apps/jobs/sharing.clj
+++ b/services/apps/src/apps/service/apps/jobs/sharing.clj
@@ -7,6 +7,7 @@
             [apps.persistence.jobs :as jp]
             [apps.service.apps.jobs.permissions :as job-permissions]
             [apps.util.service :as service]
+            [clojure.tools.logging :as log]
             [clojure-commons.error-codes :as ce]))
 
 (defn- get-job-name
@@ -16,7 +17,8 @@
 (def job-sharing-formats
   {:not-found    "analysis ID {{analysis-id}} does not exist"
    :load-failure "unable to load permissions for {{analysis-id}}: {{detail}}"
-   :not-allowed  "insufficient privileges for analysis ID {{analysis-id}}"})
+   :not-allowed  "insufficient privileges for analysis ID {{analysis-id}}"
+   :is-subjob    "analysis sharing not supported for individual jobs within an HT batch"})
 
 (defn- job-sharing-success
   [job-id job level]
@@ -69,6 +71,16 @@
   (-> (iplant-groups/load-analysis-permissions user [job-id])
       (iplant-groups/has-permission-level required-level job-id)))
 
+(defn- verify-accessible
+  [sharer job-id]
+  (when-not (has-analysis-permission (:shortUsername sharer) job-id "own")
+    (job-sharing-msg :not-allowed job-id)))
+
+(defn- verify-not-subjob
+  [{:keys [id parent-id]}]
+  (when parent-id
+    (job-sharing-msg :is-subjob id)))
+
 (defn- share-app-for-job
   [apps-client sharer sharee job-id {:keys [app-id]}]
   (when-not (.hasAppPermission apps-client sharee app-id "read")
@@ -84,29 +96,21 @@
    (catch ce/clj-http-error? {:keys [body]}
      (str "unable to share result folder: " (:error_code (service/parse-json body))))))
 
-(defn- do-job-sharing-steps
+(defn- share-job*
   [apps-client sharer sharee job-id job level]
-  (or (share-app-for-job apps-client sharer sharee job-id job)
+  (or (verify-not-subjob job)
+      (verify-accessible sharer job-id)
+      (share-app-for-job apps-client sharer sharee job-id job)
       (share-output-folder sharer sharee job)
       (iplant-groups/share-analysis job-id sharee level)))
-
-(defn- share-accessible-job
-  [apps-client sharer sharee job-id job level]
-  (if-let [failure-reason (do-job-sharing-steps apps-client sharer sharee job-id job level)]
-    (job-sharing-failure job-id job level failure-reason)
-    (job-sharing-success job-id job level)))
-
-(defn- share-extant-job
-  [apps-client sharer sharee job-id job level]
-  (if (has-analysis-permission (:shortUsername sharer) job-id "own")
-    (share-accessible-job apps-client sharer sharee job-id job level)
-    (job-sharing-failure job-id job level (job-sharing-msg :not-allowed job-id))))
 
 (defn- share-job
   [apps-client sharer sharee {job-id :analysis_id level :permission}]
   (if-let [job (jp/get-job-by-id job-id)]
     (try+
-     (share-extant-job apps-client sharer sharee job-id job level)
+     (if-let [failure-reason (share-job* apps-client sharer sharee job-id job level)]
+       (job-sharing-failure job-id job level failure-reason)
+       (job-sharing-success job-id job level))
      (catch [:type ::permission-load-failure] {:keys [reason]}
        (job-sharing-failure job-id job level (job-sharing-msg :load-failure job-id reason))))
     (job-sharing-failure job-id nil level (job-sharing-msg :not-found job-id))))
@@ -132,28 +136,20 @@
 
 ;; The apps client isn't used at this time, but it will be once we extend analysis sharing
 ;; to HPC apps.
-(defn- do-job-unsharing-steps
+(defn- unshare-job*
   [apps-client sharer sharee job-id job]
-  (or (unshare-output-folder sharer sharee job)
+  (or (verify-not-subjob job)
+      (verify-accessible sharer job-id)
+      (unshare-output-folder sharer sharee job)
       (iplant-groups/unshare-analysis job-id sharee)))
-
-(defn- unshare-accessible-job
-  [apps-client sharer sharee job-id job]
-  (if-let [failure-reason (do-job-unsharing-steps apps-client sharer sharee job-id job)]
-    (job-unsharing-failure job-id job failure-reason)
-    (job-unsharing-success job-id job)))
-
-(defn- unshare-extant-job
-  [apps-client sharer sharee job-id job]
-  (if (has-analysis-permission (:shortUsername sharer) job-id "own")
-    (unshare-accessible-job apps-client sharer sharee job-id job)
-    (job-unsharing-failure job-id job (job-sharing-msg :not-allowed job-id))))
 
 (defn- unshare-job
   [apps-client sharer sharee job-id]
   (if-let [job (jp/get-job-by-id job-id)]
     (try+
-     (unshare-extant-job apps-client sharer sharee job-id job)
+     (if-let [failure-reason (unshare-job* apps-client sharer sharee job-id job)]
+       (job-unsharing-failure job-id job failure-reason)
+       (job-unsharing-success job-id job))
      (catch [:type ::permission-load-failure] {:keys [reason]}
        (job-unsharing-failure job-id job (job-sharing-msg :load-failure job-id reason))))
     (job-unsharing-failure job-id nil (job-sharing-msg :not-found job-id))))


### PR DESCRIPTION
This PR consists of a few different changes. The primary change was to add a Boolean flag to the analysis listing service indicating whether or not the analysis could be shared. An analysis can be shared if it does not have a parent analysis (that is, if it's not a member of an HT batch) and if all of its execution systems support analysis sharing. The rest of the changes were mostly related to validation. The only exception was the notification type used for analysis sharing notifications, which was changed from `analyses` to `analysis`.
