### PR TITLE
Analysis sharing

### DIFF
--- a/services/apps/src/apps/persistence/jobs.clj
+++ b/services/apps/src/apps/persistence/jobs.clj
@@ -9,6 +9,7 @@
   (:require [cheshire.core :as cheshire]
             [clojure.set :as set]
             [clojure.string :as string]
+            [clojure-commons.exception-util :as cxu]
             [kameleon.jobs :as kj]
             [korma.core :as sql]))
 
@@ -86,13 +87,34 @@
   [{:keys [field value]}]
   {(filter-field->where-field field) (filter-value->where-value field value)})
 
+(defn- apply-standard-filter
+  "Applies 'standard' filters to a query. Standard filters are filters that search for fields that are
+   included in the job listing response body."
+  [query standard-filter]
+  (if (seq standard-filter)
+    (where query (apply or (map filter-map->where-clause standard-filter)))
+    query))
+
+(defn- apply-ownership-filter
+  "Applies an 'ownership' filter to a query. An ownership filter is any filter for which the field is
+   'ownership'. Only one ownership filter is supported in a single job query. If multiple ownership
+   filters are included then the first one wins."
+  [query username [ownership-filter & _]]
+  (if ownership-filter
+    (condp = (:value ownership-filter)
+      "all"    query
+      "mine"   (where query {:j.username username})
+      "theirs" (where query {:j.username [not= username]})
+      (cxu/bad-request (str "invalid ownership filter value: " (:value ownership-filter))))
+    query))
+
 (defn- add-job-query-filter-clause
   "Filters results returned by the given job query by adding a (where (or ...)) clause based on the
    given filter map."
-  [query filter]
-  (if (empty? filter)
-    query
-    (where query (apply or (map filter-map->where-clause filter)))))
+  [query username query-filter]
+  (let [ownership-filter? (fn [{:keys [field]}] (= field "ownership"))]
+    (-> (apply-standard-filter query (remove ownership-filter? query-filter))
+        (apply-ownership-filter username (filter ownership-filter? query-filter)))))
 
 (defn save-job
   "Saves information about a job in the database."
@@ -167,26 +189,18 @@
 
 (defn- count-jobs-base
   "The base query for counting the number of jobs in the database for a user."
-  [username include-hidden]
-  (-> (select* [:jobs :j])
-      (join [:users :u] {:j.user_id :u.id})
+  [include-hidden]
+  (-> (select* [:job_listings :j])
       (aggregate (count :*) :count)
-      (where {:u.username username})
       (add-internal-app-clause include-hidden)))
-
-(defn count-jobs
-  "Counts the number of undeleted jobs in the database for a user."
-  [username filter include-hidden]
-  ((comp :count first)
-   (select (add-job-query-filter-clause (count-jobs-base username include-hidden) filter)
-           (where {:j.deleted false}))))
 
 (defn count-jobs-of-types
   "Counts the number of undeleted jobs of the given types in the database for a user."
-  [username filter include-hidden types]
+  [username filter include-hidden types accessible-ids]
   ((comp :count first)
-   (select (add-job-query-filter-clause (count-jobs-base username include-hidden) filter)
+   (select (add-job-query-filter-clause (count-jobs-base include-hidden) username filter)
            (where {:j.deleted false})
+           (where {:j.id [in accessible-ids]})
            (where (not (exists (job-type-subselect types)))))))
 
 (defn- translate-sort-field
@@ -256,29 +270,21 @@
            (aggregate (max :step_number) :max-step)
            (where {:job_id job-id}))))
 
-(defn list-jobs
-  "Gets a list of jobs satisfying a query."
-  [username row-limit row-offset sort-field sort-order filter include-hidden]
-  (-> (select* (add-job-query-filter-clause (job-base-query) filter))
-      (where {:j.deleted  false
-              :j.username username})
-      (add-internal-app-clause include-hidden)
-      (order (translate-sort-field sort-field) sort-order)
-      (offset (nil-if-zero row-offset))
-      (limit (nil-if-zero row-limit))
-      (select)))
+(defn- add-order
+  [query {:keys [sort-field sort-dir]}]
+  (order query (translate-sort-field sort-field) sort-dir))
 
 (defn list-jobs-of-types
   "Gets a list of jobs that contain only steps of the given types."
-  [username row-limit row-offset sort-field sort-order filter include-hidden types]
-  (-> (select* (add-job-query-filter-clause (job-base-query) filter))
-      (where {:j.deleted  false
-              :j.username username})
+  [username search-params types accessible-ids]
+  (-> (select* (add-job-query-filter-clause (job-base-query) username (:filter search-params)))
+      (where {:j.deleted false})
+      (where {:j.id [in accessible-ids]})
       (where (not (exists (job-type-subselect types))))
-      (add-internal-app-clause include-hidden)
-      (order (translate-sort-field sort-field) sort-order)
-      (offset (nil-if-zero row-offset))
-      (limit (nil-if-zero row-limit))
+      (add-internal-app-clause (:include-hidden search-params))
+      (add-order search-params)
+      (offset (nil-if-zero (:offset search-params)))
+      (limit (nil-if-zero (:limit search-params)))
       (select)))
 
 (defn list-jobs-by-id

--- a/services/apps/src/apps/routes/params.clj
+++ b/services/apps/src/apps/routes/params.clj
@@ -85,7 +85,15 @@
         To find jobs associated with a specific `parent_id`, the parameter value can be
         `[{\"field\":\"parent_id\",\"value\":\"b4c2f624-7cbd-496e-adad-5be8d0d3b941\"}]`.
         It's also possible to search for jobs without a parent using this parameter value:
-        `[{\"field\":\"parent_id\",\"value\":null}]`.")}))
+        `[{\"field\":\"parent_id\",\"value\":null}]`.
+        The 'ownership' field can be used to specify whether analyses that belong to the authenticated
+        user or analyses that are shared with the authenticated user should be listed. If the value is
+        `all` then all analyses that are visible to the user will be listed. If the value is `mine` then
+        only analyses that were submitted by the user will be listed. If the value is `theirs` then only
+        analyses that have been shared with the user will be listed. By default, all analyses are listed.
+        The `ownership` field is the only field for which only one filter value is supported. If multiple
+        `ownership` field values are specified then the first value specified is used. Here's an example:
+        `[{\"field\":\"ownership\",\"value\":\"mine\"}]`.")}))
 
 (s/defschema ToolSearchParams
   (merge SecuredPagingParams IncludeHiddenParams


### PR DESCRIPTION
This change adds a way to filter analyses by submitter. There are three options: list analyses submitted by the authenticated user, list analyses _not_ listed by the authenticated user, and list all analyses. The default is to list all analyses. There were also some problems with the way that HT batches were being shared; these problems have been fixed.
