### PR TITLE
CORE-7566: also unshare input files when unsharing an analysis

### DIFF
--- a/services/apps/src/apps/service/apps/jobs/permissions.clj
+++ b/services/apps/src/apps/service/apps/jobs/permissions.clj
@@ -9,13 +9,6 @@
   [apps-client job-id]
   (every? #(.supportsJobSharing apps-client %) (jp/list-representative-job-steps job-id)))
 
-(defn- validate-job-permission-level
-  [short-username perms required-level job-ids]
-  (doseq [job-id job-ids]
-    (let [user-perms (filter (comp (partial = short-username) :id :subject) (perms job-id))]
-      (when (iplant-groups/lacks-permission-level {job-id user-perms} required-level job-id)
-        (cxu/forbidden (str "insufficient privileges for analysis " job-id))))))
-
 (defn- validate-job-sharing-support
   [apps-client job-ids]
   (doseq [job-id job-ids]
@@ -27,11 +20,15 @@
   (when-let [subjob-ids (seq (map :id (filter :parent-id jobs)))]
     (cxu/bad-request (str "analysis sharing not supported for members of a batch job") :jobs subjob-ids)))
 
-(defn- validate-jobs-for-permissions
-  [apps-client {short-username :shortUsername} perms required-level job-ids]
-  (ju/validate-job-existence job-ids)
-  (validate-job-permission-level short-username perms required-level job-ids)
-  (validate-job-sharing-support apps-client job-ids))
+(defn validate-job-permissions
+  ([{short-username :shortUsername :as user} required-level job-ids]
+   (let [perms (iplant-groups/load-analysis-permissions short-username job-ids)]
+     (validate-job-permissions user perms required-level job-ids)))
+  ([{short-username :shortUsername} perms required-level job-ids]
+   (doseq [job-id job-ids]
+     (let [user-perms (filter (comp (partial = short-username) :id :subject) (perms job-id))]
+       (when (iplant-groups/lacks-permission-level {job-id user-perms} required-level job-id)
+         (cxu/forbidden (str "insufficient privileges for analysis " job-id)))))))
 
 (defn- format-job-permission
   [short-username perms {:keys [id job-name]}]
@@ -46,11 +43,12 @@
   {:analyses (mapv (partial format-job-permission short-username perms) jobs)})
 
 (defn list-job-permissions
-  [apps-client {:keys [username] :as user} job-ids]
+  [apps-client user job-ids]
   (ju/validate-job-existence job-ids)
   (transaction
    (let [jobs (jp/list-jobs-by-id job-ids)]
      (verify-not-subjobs jobs)
      (let [perms (iplant-groups/list-analysis-permissions job-ids)]
-       (validate-jobs-for-permissions apps-client user perms "read" job-ids)
+       (validate-job-permissions user perms "read" job-ids)
+       (validate-job-sharing-support apps-client job-ids)
        (format-job-permission-listing user perms (jp/list-jobs-by-id job-ids))))))


### PR DESCRIPTION
This PR includes unsharing input files when an analysis is unshared and the problems with the parameter values and relaunch info endpoints.