### PR TITLE
CORE-7356 Fix data window updates on folder moves.

### DIFF
--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -170,12 +170,10 @@
     (raw/move-single user path-uuid dest)))
 
 (defn move
-  "Uses the data-info single and bulk mover endpoints to move an item or many items into a new directory."
+  "Uses the data-info bulk mover endpoint to move items into a new directory."
   [{:keys [user]} {:keys [sources dest]}]
   (validators/not-superuser user)
-  (if (= 1 (count sources))
-    (move-single user (first sources) dest)
-    (raw/move-multi user sources dest)))
+  (raw/move-multi user sources dest))
 
 (defn move-contents
   "Uses the data-info set-children-directory-name endpoint to move the contents of one directory

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/events/diskResources/DiskResourcesMovedEvent.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/events/diskResources/DiskResourcesMovedEvent.java
@@ -1,8 +1,8 @@
-package org.iplantc.de.diskResource.client.events;
+package org.iplantc.de.client.events.diskResources;
 
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.Folder;
-import org.iplantc.de.diskResource.client.events.DiskResourcesMovedEvent.DiskResourcesMovedEventHandler;
+import org.iplantc.de.client.events.diskResources.DiskResourcesMovedEvent.DiskResourcesMovedEventHandler;
 
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/services/DiskResourceMove.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/services/DiskResourceMove.java
@@ -29,11 +29,11 @@ public interface DiskResourceMove {
     /**
      * In case when contents of the folder needs to moved (i.e select all)
      * 
-     * @param id id of the parent folder
+     * @param path path of the parent folder
      */
     @PropertyName("source")
-    void setSelectedFolderId(String id);
+    void setSourcePath(String path);
     
     @PropertyName("source")
-    String getSelectedFolderId();
+    String getSourcePath();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
@@ -97,21 +97,23 @@ public interface DiskResourceServiceFacade {
 
     /**
      * Calls the move folder and move file services for the list of given disk resource ids.
-     * 
-     * @param diskResources list of file and folder ids to move.
+     *
+     * @param sourceFolder the source folder of disk resources to move.
      * @param destFolder the destination folder where the disk resources will be moved.
+     * @param diskResources list of file and folder ids to move.
      */
-    void moveDiskResources(final List<DiskResource> diskResources,
+    void moveDiskResources(final Folder sourceFolder,
                            final Folder destFolder,
+                           final List<DiskResource> diskResources,
                            AsyncCallback<DiskResourceMove> callback);
 
     /**
      * Calls the move folder and move file services for moving contents of a given folder.
      * 
-     * @param sourceFolderId id of the source folder
+     * @param sourceFolder the source folder of disk resources to move.
      * @param destFolder the destination folder where the disk resources will be moved.
      */
-    void moveContents(final String sourceFolderId,
+    void moveContents(final Folder sourceFolder,
                       final Folder destFolder,
                       AsyncCallback<DiskResourceMove> callback);
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
@@ -205,6 +205,18 @@ public class DiskResourceUtil {
         return false;
     }
 
+    public <R extends DiskResource> boolean contains(Iterable<R> selection, R target) {
+        if (selection != null && target != null) {
+            for (DiskResource resource : selection) {
+                if (resource.getId().equals(target.getId())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     public <R extends DiskResource> boolean containsFolder(Iterable<R> selection) {
         for (DiskResource resource : selection) {
             if (resource instanceof Folder) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/NavigationView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/NavigationView.java
@@ -100,6 +100,8 @@ public interface NavigationView extends IsWidget,
 
         Folder getFolderByPath(String path);
 
+        Folder getParent(Folder child);
+
         Folder getSelectedFolder();
 
         Folder getSelectedUploadFolder();

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
@@ -582,24 +582,22 @@ public class DiskResourcePresenterImpl implements
 
     @Override
     public void doMoveDiskResources(Folder targetFolder, List<DiskResource> resources) {
-        Folder parent = navigationPresenter.getSelectedFolder();
         view.mask(appearance.moveDiskResourcesLoadingMask());
-        if (gridViewPresenter.isSelectAllChecked()) {
-            diskResourceService.moveContents(parent.getPath(),
-                                             targetFolder,
-                                             new DiskResourceMoveCallback(view,
-                                                                          true,
-                                                                          parent,
-                                                                          targetFolder,
-                                                                          resources));
+
+        Folder parent = navigationPresenter.getSelectedFolder();
+        if (diskResourceUtil.contains(resources, parent)) {
+            parent = navigationPresenter.getParent(parent);
+        }
+
+        boolean moveContents = gridViewPresenter.isSelectAllChecked();
+
+        DiskResourceMoveCallback callback =
+                new DiskResourceMoveCallback(view, moveContents, parent, targetFolder, resources);
+
+        if (moveContents) {
+            diskResourceService.moveContents(parent, targetFolder, callback);
         } else {
-            diskResourceService.moveDiskResources(resources,
-                                                  targetFolder,
-                                                  new DiskResourceMoveCallback(view,
-                                                                               false,
-                                                                               parent,
-                                                                               targetFolder,
-                                                                               resources));
+            diskResourceService.moveDiskResources(parent, targetFolder, resources, callback);
         }
     }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
@@ -589,12 +589,9 @@ public class DiskResourcePresenterImpl implements
             parent = navigationPresenter.getParent(parent);
         }
 
-        boolean moveContents = gridViewPresenter.isSelectAllChecked();
+        DiskResourceMoveCallback callback = new DiskResourceMoveCallback(view);
 
-        DiskResourceMoveCallback callback =
-                new DiskResourceMoveCallback(view, moveContents, parent, targetFolder, resources);
-
-        if (moveContents) {
+        if (gridViewPresenter.isSelectAllChecked()) {
             diskResourceService.moveContents(parent, targetFolder, callback);
         } else {
             diskResourceService.moveDiskResources(parent, targetFolder, resources, callback);

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceMoveCallback.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceMoveCallback.java
@@ -1,62 +1,34 @@
 package org.iplantc.de.diskResource.client.presenters.callbacks;
 
-import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.IsMaskable;
-import org.iplantc.de.client.models.diskResources.DiskResource;
-import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.models.errors.diskResources.DiskResourceErrorAutoBeanFactory;
 import org.iplantc.de.client.models.errors.diskResources.ErrorDiskResourceMove;
 import org.iplantc.de.client.models.services.DiskResourceMove;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
-import org.iplantc.de.diskResource.client.events.DiskResourcesMovedEvent;
 
 import com.google.gwt.core.client.GWT;
 import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
-
-import java.util.List;
 
 /**
  * @author jstroot
  */
 public class DiskResourceMoveCallback extends DiskResourceServiceCallback<DiskResourceMove> {
 
-    private final List<DiskResource> resourcesToMove;
-    private final Folder destFolder;
-    private final boolean moveContents;
-    private final Folder sourceFolder;
     private final DiskResourceCallbackAppearance appearance = GWT.create(DiskResourceCallbackAppearance.class);
 
-    public DiskResourceMoveCallback(final IsMaskable maskedCaller,
-                                    final boolean moveContents,
-                                    final Folder srcFolder,
-                                    final Folder destFolder,
-                                    final List<DiskResource> resourcesToMove) {
+    public DiskResourceMoveCallback(final IsMaskable maskedCaller) {
         super(maskedCaller);
-        this.destFolder = destFolder;
-        this.resourcesToMove = resourcesToMove;
-        this.moveContents = moveContents;
-        this.sourceFolder = srcFolder;
     }
 
     @Override
     public void onSuccess(DiskResourceMove result) {
         unmaskCaller();
-        // FIXME CORE-5300 Round-robin. Fix
-        // TODO psarando CORE-6952: May be refactored similar to refresh events if a fix is still necessary.
 
         String successMsg = appearance.diskResourceMoveSuccess(result.getDest(), result.getSources());
         IplantAnnouncer.getInstance().schedule(new SuccessAnnouncementConfig(successMsg));
-
-        /*
-         * JDS Result should have a "sources" key
-         * and a "dest" key.
-         *
-         * TODO JDS Verify returned keys to the objects we have already.
-         */
-        EventBus.getInstance().fireEvent(new DiskResourcesMovedEvent(sourceFolder, destFolder, resourcesToMove, moveContents));
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/NavigationPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/NavigationPresenterImpl.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.diskResource.client.presenters.navigation;
 
 import org.iplantc.de.client.events.EventBus;
+import org.iplantc.de.client.events.diskResources.DiskResourcesMovedEvent;
 import org.iplantc.de.client.events.diskResources.FolderRefreshedEvent;
 import org.iplantc.de.client.models.HasPath;
 import org.iplantc.de.client.models.IsMaskable;
@@ -16,7 +17,6 @@ import org.iplantc.de.diskResource.client.events.DiskResourceNameSelectedEvent;
 import org.iplantc.de.diskResource.client.events.DiskResourcePathSelectedEvent;
 import org.iplantc.de.diskResource.client.events.DiskResourceRenamedEvent;
 import org.iplantc.de.diskResource.client.events.DiskResourcesDeletedEvent;
-import org.iplantc.de.diskResource.client.events.DiskResourcesMovedEvent;
 import org.iplantc.de.diskResource.client.events.FolderCreatedEvent;
 import org.iplantc.de.diskResource.client.events.FolderSelectionEvent;
 import org.iplantc.de.diskResource.client.events.RequestImportFromUrlEvent;
@@ -202,19 +202,20 @@ public class NavigationPresenterImpl implements
 
     @Override
     public void onDiskResourcesMoved(DiskResourcesMovedEvent event) {
+        if (event.isMoveContents()) {
+            // If a folder's contents was moved, then the src and dest folders will already be refreshed.
+            return;
+        }
+
         List<DiskResource> resourcesToMove = event.getResourcesToMove();
         Folder destinationFolder = event.getDestinationFolder();
         Folder srcFolder = event.getSrcFolder();
         Folder selectedFolder = getSelectedFolder();
-        if (!event.isMoveContents()) {
-            if (diskResourceUtil.contains(resourcesToMove, selectedFolder)) {
-                selectedFolderMovedFromNavTree(destinationFolder);
-            } else {
-                diskResourcesMovedFromGrid(resourcesToMove,
-                                           selectedFolder,
-                                           srcFolder,
-                                           destinationFolder);
-            }
+
+        if (diskResourceUtil.contains(resourcesToMove, selectedFolder)) {
+            selectedFolderMovedFromNavTree(destinationFolder);
+        } else {
+            diskResourcesMovedFromGrid(resourcesToMove, selectedFolder, srcFolder, destinationFolder);
         }
     }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/NavigationPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/NavigationPresenterImpl.java
@@ -204,15 +204,17 @@ public class NavigationPresenterImpl implements
     public void onDiskResourcesMoved(DiskResourcesMovedEvent event) {
         List<DiskResource> resourcesToMove = event.getResourcesToMove();
         Folder destinationFolder = event.getDestinationFolder();
+        Folder srcFolder = event.getSrcFolder();
         Folder selectedFolder = getSelectedFolder();
-        // moved contents only not the folder itself
-        if (event.isMoveContents()) {
-            reloadTreeStoreFolderChildren(destinationFolder);
-            reloadTreeStoreFolderChildren(selectedFolder);
-        } else if (resourcesToMove.contains(selectedFolder)) {
-            selectedFolderMovedFromNavTree(selectedFolder, destinationFolder);
-        } else {
-            diskResourcesMovedFromGrid(resourcesToMove, selectedFolder, destinationFolder);
+        if (!event.isMoveContents()) {
+            if (diskResourceUtil.contains(resourcesToMove, selectedFolder)) {
+                selectedFolderMovedFromNavTree(destinationFolder);
+            } else {
+                diskResourcesMovedFromGrid(resourcesToMove,
+                                           selectedFolder,
+                                           srcFolder,
+                                           destinationFolder);
+            }
         }
     }
 
@@ -335,6 +337,11 @@ public class NavigationPresenterImpl implements
             }
         }
         return null;
+    }
+
+    @Override
+    public Folder getParent(Folder child) {
+        return treeStore.getParent(child);
     }
 
     @Override
@@ -494,53 +501,24 @@ public class NavigationPresenterImpl implements
 
     private void diskResourcesMovedFromGrid(List<DiskResource> resourcesToMove,
                                             Folder selectedFolder,
+                                            Folder srcFolder,
                                             Folder destinationFolder) {
-        if (diskResourceUtil.containsFolder(resourcesToMove)) {
-            // Refresh the destination folder, since it has gained a child.
-            if (diskResourceUtil.isDescendantOfFolder(destinationFolder, selectedFolder)) {
-                removeChildren(destinationFolder);
-            } else {
-                /*
-                 * Refresh the selected folder since it has lost a child. This will also reload the
-                 * selected folder's contents in the grid.
-                 */
-                reloadTreeStoreFolderChildren(selectedFolder);
-                // Refresh the destination folder since it has gained a child.
-                reloadTreeStoreFolderChildren(destinationFolder);
-                return;
+        // If a folder was moved, then the src and dest folders will already be refreshed.
+        if (!diskResourceUtil.containsFolder(resourcesToMove)) {
+            String selectedFolderId = selectedFolder.getId();
+            if (destinationFolder.getId().equals(selectedFolderId)
+                || srcFolder.getId().equals(selectedFolderId)) {
+                // Refresh the selected folder's contents.
+                setSelectedFolder((HasPath)selectedFolder);
             }
         }
-
-        // Refresh the selected folder's contents.
-        setSelectedFolder((HasPath)selectedFolder);
     }
 
-    private void selectedFolderMovedFromNavTree(Folder selectedFolder, Folder destinationFolder) {
-        /*
-         * If the selected folder happens to be one of the moved items, then view the destination by
-         * setting it as the selected folder.
-         */
-        Folder parentFolder = treeStore.getParent(selectedFolder);
-
-        if (diskResourceUtil.isDescendantOfFolder(parentFolder, destinationFolder)) {
-            /*
-             * The destination is under the parent, so if we prune the parent and set the destination as
-             * the selected folder, the parent will lazy-load down to the destination.
-             */
-            removeChildren(parentFolder);
-        } else if (diskResourceUtil.isDescendantOfFolder(destinationFolder, parentFolder)) {
-            /*
-             * The parent is under the destination, so we only need to view the destination folder's
-             * contents and refresh its children.
-             */
-            reloadTreeStoreFolderChildren(destinationFolder);
-        } else {
-            // Refresh the parent folder since it has lost a child.
-            reloadTreeStoreFolderChildren(parentFolder);
-            // Refresh the destination folder since it has gained a child.
-            reloadTreeStoreFolderChildren(destinationFolder);
-        }
-
+    /**
+     * If the selected folder happens to be one of the moved items, then view the destination by
+     * setting it as the selected folder.
+     */
+    private void selectedFolderMovedFromNavTree(Folder destinationFolder) {
         // View the destination folder's contents.
         setSelectedFolder((HasPath)destinationFolder);
     }


### PR DESCRIPTION
Reverted terrain's [POST /filesystem/move endpoint](http://cyverse.github.io/DE/api/endpoints/filesystem/move.html#moving-files-andor-directories) response.
Updated the DiskResourceServiceFacadeImpl logic that updates its folder cache when folders are moved, since we can no longer lookup folders in the cache by path.
Instead, the source and destination folders are refreshed when folders have been moved to and from them.
Refreshing instead of preserving folder caches allows some DiskResourcesMovedEvent handler logic to be cleaned up in the NavigationPresenterImpl.
