### PR TITLE
CORE-7573 Fix Texta Font 404 errors

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/BaseDesktopAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/BaseDesktopAppearance.java
@@ -7,6 +7,7 @@ import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.DataResource;
 import com.google.gwt.resources.client.ImageResource;
 
 import com.sencha.gxt.widget.core.client.button.IconButton.IconConfig;
@@ -63,6 +64,10 @@ public class BaseDesktopAppearance implements DesktopView.DesktopAppearance {
 
         @Source("org/iplantc/de/theme/base/client/desktop/user.png")
         ImageResource userPrefImg();
+
+        @DataResource.MimeType("font/opentype")
+        @Source("org/iplantc/de/theme/base/client/desktop/Texta_Font/Texta-Bold.otf")
+        DataResource textaBold();
     }
 
     private final DesktopResources resources;

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/Desktop.css
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/Desktop.css
@@ -2,22 +2,25 @@
 @def footerHeight 30px;
 @def footerHeight10 40px;
 
+@def TEXTA_BOLD textaBold;
+@def TEXTA_REGULAR textaRegular;
+ 
+@font-face {
+    font-family: TextaBold;
+    src: TEXTA_BOLD format("opentype");
+}
+ 
+@font-face {
+    font-family: TextaRegular;
+    src: TEXTA_REGULAR format("opentype");
+}
+
 .deBody {
     position: fixed;
     top: 0;
     bottom: 0;
     right: 0;
     left: 0;
-}
-
-@font-face {
-    font-family: TextaRegular;
-    src: url(Texta_Font/Texta-Regular.otf);
-}
-
-@font-face {
-    font-family: TextaBold;
-    src: url(Texta_Font/Texta-Bold.otf);
 }
 
 @sprite .iplantHeader {

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/IplantBaseWindowAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/IplantBaseWindowAppearance.java
@@ -5,6 +5,7 @@ import org.iplantc.de.desktop.client.views.windows.IplantWindowBase;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.resources.client.DataResource;
 import com.google.gwt.resources.client.ImageResource;
 
 import com.sencha.gxt.widget.core.client.Header;
@@ -63,6 +64,14 @@ public class IplantBaseWindowAppearance implements IplantWindowBase.IplantWindow
 
         @Source("org/iplantc/de/theme/base/client/desktop/window/button_restore_hover.png")
         ImageResource restoreBtnHoverImage();
+
+        @DataResource.MimeType("font/opentype")
+        @Source("org/iplantc/de/theme/base/client/desktop/Texta_Font/Texta-Bold.otf")
+        DataResource textaBold();
+
+        @DataResource.MimeType("font/opentype")
+        @Source("org/iplantc/de/theme/base/client/desktop/Texta_Font/Texta-Regular.otf")
+        DataResource textaRegular();
     }
 
     private final IplantWindowResources resources;

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/IplantWindowStyles.css
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/IplantWindowStyles.css
@@ -1,6 +1,8 @@
+@def TEXTA_BOLD textaBold;
+
 @font-face {
     font-family: TextaBold;
-    src: url(../Texta_Font/Texta-Bold.otf);
+    src: TEXTA_BOLD format("opentype");
 }
 
 @sprite .restoreBtn {


### PR DESCRIPTION
Relative paths in the CSS url field were causing 404 errors.  Switched to using full path location in the .java files which the CSS files then use.