### PR TITLE
Dewey's irods port as passed to irods/init needs to be a string

### DIFF
--- a/services/dewey/src/dewey/core.clj
+++ b/services/dewey/src/dewey/core.clj
@@ -39,7 +39,7 @@
 (defn- init-irods
   []
   (irods/init (cfg/irods-host)
-              (cfg/irods-port)
+              (str (cfg/irods-port))
               (cfg/irods-user)
               (cfg/irods-pass)
               (cfg/irods-home)


### PR DESCRIPTION
Otherwise it throws a bunch of errors about how it can't cast a string to an integer when it tries to call `Integer/parseInt` on the value it's passed.