### PR TITLE
Don't create temporary passwords for a fake user to create tickets

### DIFF
--- a/libs/clj-jargon/src/clj_jargon/tickets.clj
+++ b/libs/clj-jargon/src/clj_jargon/tickets.clj
@@ -18,9 +18,12 @@
   "Creates an instance of TicketAdminService, which provides
    access to utility methods for performing operations on tickets.
    Probably doesn't need to be called directly."
-  [cm user]
-  (let [tsf (TicketServiceFactoryImpl. (:accessObjectFactory cm))]
-    (.instanceTicketAdminService tsf (override-user-account cm user (temp-password cm user)))))
+  [cm username]
+  (let [tsf (TicketServiceFactoryImpl. (:accessObjectFactory cm))
+        user (if (= username (:user cm))
+                 (:irodsAccount cm)
+                 (override-user-account cm username (temp-password cm username)))]
+    (.instanceTicketAdminService tsf user)))
 
 (defn set-ticket-options
   "Sets the optional settings for a ticket, such as the expiration date


### PR DESCRIPTION
(at least, not when we already have an IRODSAccount to be used)

Assuming this doesn't break everything, it fixes the one place we make temporary passwords. I think this could be done better, probably? There seems to be a lot of vestigial code in this area of the codebase.

I'll work on testing that this actually works tomorrow morning, anyway.