### PR TITLE
Reorganize code so clj-jargon.tickets/ticket-admin-service can be private.

### DIFF
--- a/libs/clj-jargon/src/clj_jargon/tickets.clj
+++ b/libs/clj-jargon/src/clj_jargon/tickets.clj
@@ -14,7 +14,7 @@
                                     TicketClientSupport
                                     Ticket]))
 
-(defn ^TicketAdminService ticket-admin-service
+(defn- ^TicketAdminService ticket-admin-service
   "Creates an instance of TicketAdminService, which provides
    access to utility methods for performing operations on tickets.
    Probably doesn't need to be called directly."
@@ -68,6 +68,16 @@
    identifier."
   [cm user ticket-id]
   (.isTicketInUse (ticket-admin-service cm user) ticket-id))
+
+(defn ^Boolean public-ticket?
+  "Checks to see if the provided ticket ID is publicly accessible."
+  [cm user ticket-id]
+
+  (let [tas    (ticket-admin-service cm user)
+        groups (.listAllGroupRestrictionsForSpecifiedTicket tas ticket-id 0)]
+    (if (contains? (set groups) "public")
+      true
+      false)))
 
 (defn ^Ticket ticket-by-id
   "Looks up the ticket by the provided ticket-id string and

--- a/services/kifshare/src/kifshare/tickets.clj
+++ b/services/kifshare/src/kifshare/tickets.clj
@@ -11,16 +11,6 @@
         [ring.util.response :only [status]]
         [clojure-commons.error-codes]))
 
-(defn public-ticket?
-  [cm user ticket-id]
-  (log/debug "entered kifshare.tickets/public-ticket?")
-
-  (let [tas    (jtickets/ticket-admin-service cm user)
-        groups (.listAllGroupRestrictionsForSpecifiedTicket tas ticket-id 0)]
-    (if (contains? (set groups) "public")
-      true
-      false)))
-
 (defn check-ticket
   "Makes sure that the ticket actually exists, is not expired,
    and is not used up. Returns nil on success, throws an error
@@ -44,7 +34,7 @@
                  :ticket-id ticket-id
                  :num-uses (str (.getUsesLimit ticket-obj))})
 
-        (not (public-ticket? cm (username) ticket-id))
+        (not (jtickets/public-ticket? cm (username) ticket-id))
         (throw+ {:error_code ERR_TICKET_NOT_PUBLIC
                  :ticket-id ticket-id})))))
 


### PR DESCRIPTION
Minor thing, but it seemed weird that we had one utility function for tickets in a kifshare namespace, used only once, and that was the only reason `ticket-admin-service`, which seemed intended to be private by its docstring, wasn't private.

So I moved it. ¯\\_(ツ)_/¯