### PR TITLE
iRODS AMQP broker can now be on separate host

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -394,6 +394,10 @@ irods:
   admins: rodsadmin
   data_curators_group: data-curators
   bad_chars: \u0060\u0027\u000A\u0009
+  amqp_broker:
+    host: "{{ groups['amqp-brokers'][0] }}"
+    port:
+
 
 # Jex does not actually have a container. The container name is how most syslog entries
 # are identified. See rsyslog-config role.

--- a/ansible/roles/util-cfg-service/templates/dewey.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/dewey.properties.j2
@@ -1,7 +1,7 @@
 dewey.environment-name          = {{ environment_name }}
 
-dewey.amqp.host                 = {{ amqp_broker.host }}
-dewey.amqp.port                 = {{ amqp_broker.port }}
+dewey.amqp.host                 = {{ irods.amqp_broker.host }}
+dewey.amqp.port                 = {{ irods.amqp_broker.port }}
 dewey.amqp.user                 = {{ amqp_user }}
 dewey.amqp.password             = {{ amqp_password }}
 dewey.amqp.exchange.name        = {{ amqp_irods_exchange }}

--- a/ansible/roles/util-cfg-service/templates/info-typer.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/info-typer.properties.j2
@@ -16,8 +16,8 @@ info-typer.irods.retry-sleep = 1000
 info-typer.irods.use-trash   = true
 
 # AMQP settings
-info-typer.amqp.host                 = {{ amqp_broker.host }}
-info-typer.amqp.port                 = {{ amqp_broker.port }}
+info-typer.amqp.host                 = {{ irods.amqp_broker.host }}
+info-typer.amqp.port                 = {{ irods.amqp_broker.port }}
 info-typer.amqp.user                 = {{ amqp_user }}
 info-typer.amqp.pass                 = {{ amqp_password }}
 info-typer.amqp.retry-sleep          = 10000


### PR DESCRIPTION
This is a pull request against the master branch to bring the AMQP broker configuration specified in ansible scripts inline with what's currently in prod.  There are corresponding changes in the `irods_amqp_cfg` branch of the `de-ansible` private repo.