### PR TITLE
Cleaned up/generalized iRODS AMQP config changes

### DIFF
--- a/ansible/inventories/example.cfg
+++ b/ansible/inventories/example.cfg
@@ -184,3 +184,6 @@ icat.example.com
 [irods]
 irods.example.com
 
+[irods-amqp-brokers]
+irods-amqp.example.com
+

--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -58,7 +58,7 @@ amqp_irods_connection_health_check_interval: 5000
 
 amqp_broker:
   host: "{{ groups['amqp-brokers'][0] }}"
-  port:
+  port: 5672
   condor_events:
     exchange: condor_events
     exchange_type: fanout
@@ -391,7 +391,7 @@ irods:
   bad_chars: \u0060\u0027\u000A\u0009
   amqp_broker:
     host: "{{ groups['amqp-brokers'][0] }}"
-    port:
+    port: 5672
 
 
 # Jex does not actually have a container. The container name is how most syslog entries

--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -45,8 +45,6 @@ agave:
   client_key:
   client_secret:
 
-amqp_password:
-amqp_user:
 amqp_de_exchange:
 amqp_de_exchange_durable: true
 amqp_de_exchange_auto_delete: false
@@ -58,6 +56,8 @@ amqp_irods_exchange_auto_delete: false
 amqp_broker:
   host: "{{ groups['amqp-brokers'][0] }}"
   port: 5672
+  user: guest
+  password: guest
   condor_events:
     exchange: condor_events
     exchange_type: fanout
@@ -391,6 +391,8 @@ irods:
   amqp_broker:
     host: "{{ groups['irods-amqp-brokers'][0] }}"
     port: 5672
+    user: guest
+    password:
 
 
 # Jex does not actually have a container. The container name is how most syslog entries

--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -54,7 +54,6 @@ amqp_irods_exchange: irods
 amqp_irods_exchange_type: topic
 amqp_irods_exchange_durable: true
 amqp_irods_exchange_auto_delete: false
-amqp_irods_connection_health_check_interval: 5000
 
 amqp_broker:
   host: "{{ groups['amqp-brokers'][0] }}"

--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -389,7 +389,7 @@ irods:
   data_curators_group: data-curators
   bad_chars: \u0060\u0027\u000A\u0009
   amqp_broker:
-    host: "{{ groups['amqp-brokers'][0] }}"
+    host: "{{ groups['irods-amqp-brokers'][0] }}"
     port: 5672
 
 

--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -392,7 +392,7 @@ irods:
     host: "{{ groups['irods-amqp-brokers'][0] }}"
     port: 5672
     user: guest
-    password:
+    password: guest
 
 
 # Jex does not actually have a container. The container name is how most syslog entries

--- a/ansible/roles/de-rabbitmq-cfg/tasks/main.yml
+++ b/ansible/roles/de-rabbitmq-cfg/tasks/main.yml
@@ -4,7 +4,6 @@
 
 - name: set up the user
   rabbitmq_user:
-  vars:
     user: "{{ amqp_broker.user }}"
     password: "{{ amqp_broker.password }}" 
     vhost: de 

--- a/ansible/roles/de-rabbitmq-cfg/tasks/main.yml
+++ b/ansible/roles/de-rabbitmq-cfg/tasks/main.yml
@@ -3,4 +3,13 @@
   rabbitmq_vhost: name=de state=present
 
 - name: set up the user
-  rabbitmq_user: user={{amqp_user}} password={{amqp_password}} vhost=de state=present configure_priv=.* read_priv=.* write_priv=.* tags="administrator"
+  rabbitmq_user:
+  vars:
+    user: "{{ amqp_broker.user }}"
+    password: "{{ amqp_broker.password }}" 
+    vhost: de 
+    state: present 
+    configure_priv: .* 
+    read_priv: .* 
+    write_priv: .* 
+    tags: administrator

--- a/ansible/roles/util-cfg-service/templates/condor-log-monitor.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/condor-log-monitor.properties.j2
@@ -1,6 +1,6 @@
 {
   "AMQPHost" : "{{ amqp_broker.host }}:{{ amqp_broker.port }}",
-  "AMQPUserPass" : "{{ amqp_user }}:{{ amqp_password }}",
+  "AMQPUserPass" : "{{ amqp_broker.user }}:{{ amqp_broker.password }}",
   "ExchangeName" : "{{ amqp_broker.condor_events.exchange }}",
   "ExchangeType" : "{{ amqp_broker.condor_events.exchange_type }}",
   "RoutingKey" : "{{ amqp_broker.condor_events.exchange_routing_key }}",

--- a/ansible/roles/util-cfg-service/templates/dewey.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/dewey.properties.j2
@@ -2,8 +2,8 @@ dewey.environment-name          = {{ environment_name }}
 
 dewey.amqp.host                 = {{ irods.amqp_broker.host }}
 dewey.amqp.port                 = {{ irods.amqp_broker.port }}
-dewey.amqp.user                 = {{ amqp_user }}
-dewey.amqp.password             = {{ amqp_password }}
+dewey.amqp.user                 = {{ irods.amqp_broker.user }}
+dewey.amqp.password             = {{ irods.amqp_broker.password }}
 dewey.amqp.exchange.name        = {{ amqp_irods_exchange }}
 dewey.amqp.exchange.durable     = {{ amqp_irods_exchange_durable }}
 dewey.amqp.exchange.auto-delete = {{ amqp_irods_exchange_auto_delete }}

--- a/ansible/roles/util-cfg-service/templates/info-typer.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/info-typer.properties.j2
@@ -18,8 +18,8 @@ info-typer.irods.use-trash   = true
 # AMQP settings
 info-typer.amqp.host                 = {{ irods.amqp_broker.host }}
 info-typer.amqp.port                 = {{ irods.amqp_broker.port }}
-info-typer.amqp.user                 = {{ amqp_user }}
-info-typer.amqp.pass                 = {{ amqp_password }}
+info-typer.amqp.user                 = {{ irods.amqp_broker.user }}
+info-typer.amqp.pass                 = {{ irods.amqp_broker.password }}
 info-typer.amqp.retry-sleep          = 10000
 info-typer.amqp.exchange             = {{ amqp_irods_exchange }}
 info-typer.amqp.exchange.type        = {{ amqp_irods_exchange_type }}

--- a/ansible/roles/util-cfg-service/templates/infosquito.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/infosquito.properties.j2
@@ -17,8 +17,8 @@ infosquito.index-batch-size = 1000
 # AMQP Settings
 infosquito.amqp.host                 = {{ amqp_broker.host }}
 infosquito.amqp.port                 = {{ amqp_broker.port }}
-infosquito.amqp.user                 = {{ amqp_user }}
-infosquito.amqp.password             = {{ amqp_password }}
+infosquito.amqp.user                 = {{ amqp_broker.user }}
+infosquito.amqp.password             = {{ amqp_broker.password }}
 infosquito.amqp.reindex-queue        = infosquito.reindex
 infosquito.amqp.exchange.name        = {{ amqp_de_exchange }}
 infosquito.amqp.exchange.durable     = {{ amqp_de_exchange_durable }}

--- a/ansible/roles/util-cfg-service/templates/jexevents.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/jexevents.properties.j2
@@ -1,5 +1,5 @@
 {
-  "AMQPURI" : "amqp://{{ amqp_user }}:{{ amqp_password }}@{{ amqp_broker.host }}:{{ amqp_broker.port }}/",
+  "AMQPURI" : "amqp://{{ amqp_broker.user }}:{{ amqp_broker.password }}@{{ amqp_broker.host }}:{{ amqp_broker.port }}/",
   "EventLog" : "{{ condor_log_monitor_event_log }}",
   "ExchangeName" : "{{ amqp_broker.condor_events.exchange }}",
   "ExchangeType" : "{{ amqp_broker.condor_events.exchange_type }}",

--- a/ansible/roles/util-cfg-service/templates/jobservices.yml.j2
+++ b/ansible/roles/util-cfg-service/templates/jobservices.yml.j2
@@ -1,5 +1,5 @@
 amqp:
-  uri: amqp://{{amqp_user}}:{{amqp_password}}@{{amqp_broker.host}}:{{amqp_broker.port}}/de
+  uri: amqp://{{amqp_broker.user}}:{{amqp_broker.password}}@{{amqp_broker.host}}:{{amqp_broker.port}}/de
 
 apps:
   callbacks_uri: "{{apps.base}}/callbacks/de-job"

--- a/ansible/roles/util-cfg-service/templates/metadata.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/metadata.properties.j2
@@ -16,6 +16,6 @@ metadata.db.password    = {{ metadata_db_password }}
 # AMQP settings
 metadata.amqp.host                 = {{ amqp_broker.host }}
 metadata.amqp.port                 = {{ amqp_broker.port }}
-metadata.amqp.user                 = {{ amqp_user }}
-metadata.amqp.password             = {{ amqp_password }}
+metadata.amqp.user                 = {{ amqp_broker.user }}
+metadata.amqp.password             = {{ amqp_broker.password }}
 metadata.amqp.exchange.name        = {{ amqp_de_exchange }}

--- a/ansible/roles/util-cfg-service/templates/monkey.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/monkey.properties.j2
@@ -4,8 +4,8 @@ monkey.retry-period-ms       = 1000
 
 monkey.amqp.host     = {{ amqp_broker.host }}
 monkey.amqp.port     = {{ amqp_broker.port }}
-monkey.amqp.user     = {{ amqp_user }}
-monkey.amqp.password = {{ amqp_password }}
+monkey.amqp.user     = {{ amqp_broker.user }}
+monkey.amqp.password = {{ amqp_broker.password }}
 monkey.amqp.queue    = monkey
 
 monkey.amqp.exchange.name        = {{ amqp_de_exchange }}

--- a/ansible/roles/util-cfg-service/templates/templeton-incremental.yaml.j2
+++ b/ansible/roles/util-cfg-service/templates/templeton-incremental.yaml.j2
@@ -1,5 +1,5 @@
 amqp:
-  uri: amqp://{{ amqp_user }}:{{ amqp_password }}@{{ amqp_broker.host }}:{{ amqp_broker.port }}/
+  uri: amqp://{{ amqp_broker.user }}:{{ amqp_broker.password }}@{{ amqp_broker.host }}:{{ amqp_broker.port }}/
 
 elasticsearch:
   base: http://{{ elasticsearch.host }}:{{ elasticsearch.port }}

--- a/ansible/roles/util-cfg-service/templates/templeton-periodic.yaml.j2
+++ b/ansible/roles/util-cfg-service/templates/templeton-periodic.yaml.j2
@@ -1,5 +1,5 @@
 amqp:
-  uri: amqp://{{ amqp_user }}:{{ amqp_password }}@{{ amqp_broker.host }}:{{ amqp_broker.port }}/
+  uri: amqp://{{ amqp_broker.user }}:{{ amqp_broker.password }}@{{ amqp_broker.host }}:{{ amqp_broker.port }}/
 
 elasticsearch:
   base: http://{{ elasticsearch.host }}:{{ elasticsearch.port }}


### PR DESCRIPTION
This PR expands the configuration changes that allow iRODS and the DE to use separate AMQP brokers.  A few cleanups were made as well.