### PR TITLE
Add an nginx+consul-template dockerfile/etc. intended for use with service nginx containers.

### DIFF
--- a/docker/images.txt
+++ b/docker/images.txt
@@ -17,6 +17,7 @@ kifshare
 apps
 metadata
 monkey
+nginx-consul-template
 notification-agent
 porklock
 saved-searches

--- a/docker/nginx-consul-template/Dockerfile
+++ b/docker/nginx-consul-template/Dockerfile
@@ -1,0 +1,18 @@
+FROM nginx:alpine
+MAINTAINER Ian McEwen <mian@cyverse.org>
+
+ENV CONSUL_TEMPLATE_VERSION=0.14.0
+ENV CONSUL_CONNECT=localhost:8500
+ENV NGINX_TEMPLATE=/templates/nginx.conf.tmpl
+ENV NGINX_CONF=/etc/nginx/nginx.conf
+
+ADD https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip /
+
+RUN unzip consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip \
+    && mkdir -p /usr/local/bin \
+    && mv consul-template /usr/local/bin/consul-template
+
+COPY run.sh /usr/local/bin/run.sh
+COPY nginx.conf.tmpl /templates/nginx.conf.tmpl
+
+CMD ["/usr/local/bin/run.sh"]

--- a/docker/nginx-consul-template/Dockerfile
+++ b/docker/nginx-consul-template/Dockerfile
@@ -1,5 +1,7 @@
 FROM nginx:alpine
 MAINTAINER Ian McEwen <mian@cyverse.org>
+ARG git_commit
+LABEL org.iplantc.de.nginx-consul-template.git-ref="$git_commit"
 
 ENV CONSUL_TEMPLATE_VERSION=0.14.0
 ENV CONSUL_CONNECT=localhost:8500

--- a/docker/nginx-consul-template/nginx.conf.tmpl
+++ b/docker/nginx-consul-template/nginx.conf.tmpl
@@ -5,7 +5,7 @@ events {
 http {
     upstream service {
       {{- range service (printf "%s.%s" (env "DE_ENV") (env "NGINX_PROXY_SERVICE_NAME")) }}
-      server {{.Address}}:{{.Port}} max_fails=3 fail_timeout=60 weight=1 {{- if not (.Tags.Contains (key (printf "%s/%s/color" (env "DE_ENV") (env "NGINX_PROXY_SERVICE_NAME"))))}} backup{{end}}; # {{.ID}} {{.Tags}}
+      server {{.Address}}:{{.Port}} max_fails=3 fail_timeout=60 weight=1 {{- if not (.Tags.Contains (key_or_default (printf "%s/%s/color" (env "DE_ENV") (env "NGINX_PROXY_SERVICE_NAME")) "green"))}} backup{{end}}; # {{.ID}} {{.Tags}}
       {{- else}}
       server 127.0.0.1:65535; # Force a 502. No {{env "DE_ENV"}}.{{env "NGINX_PROXY_SERVICE_NAME"}} services were found.
       {{- end}}

--- a/docker/nginx-consul-template/nginx.conf.tmpl
+++ b/docker/nginx-consul-template/nginx.conf.tmpl
@@ -1,0 +1,24 @@
+events {
+    worker_connections 4096;
+}
+
+http {
+    upstream service {
+      {{- range service (printf "%s.%s" (env "DE_ENV") (env "NGINX_PROXY_SERVICE_NAME")) }}
+      server {{.Address}}:{{.Port}} max_fails=3 fail_timeout=60 weight=1 {{- if not (.Tags.Contains (key (printf "%s/%s/color" (env "DE_ENV") (env "NGINX_PROXY_SERVICE_NAME"))))}} backup{{end}}; # {{.ID}} {{.Tags}}
+      {{- else}}
+      server 127.0.0.1:65535; # Force a 502. No {{env "DE_ENV"}}.{{env "NGINX_PROXY_SERVICE_NAME"}} services were found.
+      {{- end}}
+    }
+
+    server {
+      listen {{env "NGINX_PROXY_PORT"}};
+
+      location / {
+        proxy_pass http://service;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+      }
+    }
+}

--- a/docker/nginx-consul-template/nginx.conf.tmpl
+++ b/docker/nginx-consul-template/nginx.conf.tmpl
@@ -3,12 +3,12 @@ events {
 }
 
 http {
+{{- with $service_query := (printf "%s.%s" (env "DE_ENV") (env "NGINX_PROXY_SERVICE_NAME")) }}
+  {{- if service $service_query }}
     upstream service {
-      {{- range service (printf "%s.%s" (env "DE_ENV") (env "NGINX_PROXY_SERVICE_NAME")) }}
+    {{- range service $service_query }}
       server {{.Address}}:{{.Port}} max_fails=3 fail_timeout=60 weight=1 {{- if not (.Tags.Contains (key_or_default (printf "%s/%s/color" (env "DE_ENV") (env "NGINX_PROXY_SERVICE_NAME")) "green"))}} backup{{end}}; # {{.ID}} {{.Tags}}
-      {{- else}}
-      server 127.0.0.1:65535; # Force a 502. No {{env "DE_ENV"}}.{{env "NGINX_PROXY_SERVICE_NAME"}} services were found.
-      {{- end}}
+    {{- end }}
     }
 
     server {
@@ -21,4 +21,12 @@ http {
         proxy_set_header X-Real-IP $remote_addr;
       }
     }
+  {{- else }}
+    server {
+      listen {{env "NGINX_PROXY_PORT"}};
+
+      return 502;
+    }
+  {{- end }}
+{{- end }}
 }

--- a/docker/nginx-consul-template/run.sh
+++ b/docker/nginx-consul-template/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+nginx -g "daemon off;" &
+
+exec consul-template -consul $CONSUL_CONNECT -template "$NGINX_TEMPLATE:$NGINX_CONF:nginx -s reload || true"


### PR DESCRIPTION
This is the first step toward the zero-downtime deployment setup. There's still lots to do in terms of ansible changes, docker-compose file modifications, etc. (not least of all including this image in our docker-compose files) but I think this can be independently reviewed.

Most of the configuration for this comes in through environment variables. As an example:

`docker run -p 5555:5555 -e CONSUL_CONNECT=some-consul-server:8500 -e NGINX_PROXY_PORT=5555 -e NGINX_PROXY_SERVICE_NAME=anon-files -e DE_ENV=de-2 nginx-consul-template`

This invocation would run an nginx on port 5555 (in-container and outside of the container) which proxies for anon-files instances marked as being in de-2. The color (blue/green -- really just an arbitrary tag) which it should use is stored in a consul k/v; in this case, it'd be `/de-2/anon-files/color`.

consul-template operates as a "proper" PID 1 -- cleans up zombies, etc., which is why I have it be that. However, we wanted the nginx logs to stdout too, so I run everything such that those messages won't be hidden.

nginx is smart about how it does things, so if a change in consul produces an invalid nginx config (for example, if the color changes but the new color doesn't have any servers, all of the previous servers will be marked backup, which is an invalid state) the reload won't actually reload the config. This way things stay up, as much as possible. The `|| true` in the consul-template invocation ensures that consul-template itself doesn't exit if the `nginx -s reload` exits non-zero, such that correcting the mistake in consul can then regenerate the config and try again. Basically, other than explicitly killing it or some unforeseen bug in consul-template, it's pretty much not possible for this container to die off entirely.

Since we'll be running this on a server with registrator, we'll probably also end up wanting to add `SERVICE_NAME`, `SERVICE_CHECK_*`, etc. environment variables as well, but that's unrelated to this.