### PR TITLE
Add basic simple status check endpoints to anon-files and kifshare for consul to use.

### DIFF
--- a/services/anon-files/src/anon_files/core.clj
+++ b/services/anon-files/src/anon_files/core.clj
@@ -27,6 +27,7 @@
    ["-h" "--help"]])
 
 (defroutes app
+  (GET "/" [] "Hello from anon-files.")
   (HEAD "/*" [:as req] (log/spy (handle-head-request req)))
   (GET "/*" [:as req] (log/spy (handle-request req)))
   (OPTIONS "/*" [:as req] (log/spy (handle-options-request req))))

--- a/services/kifshare/src/kifshare/core.clj
+++ b/services/kifshare/src/kifshare/core.clj
@@ -34,6 +34,8 @@
       keep-alive))
 
 (defroutes kifshare-routes
+  (GET "/" [] "Hello from kifshare.")
+
   (GET "/favicon.ico" []
        (static-resp (cfg/favicon-path)))
 


### PR DESCRIPTION
This way (with the appropriate environment variables and stuff in place, anyway) consul-template won't consider these services to be up until they can actually respond to an HTTP ping (i.e., when they're actually up). These just match our other services (specifically the simple ones). If we switch to using swagger for these at some point then these can become proper status endpoints like the data-info/metadata/apps ones but it doesn't matter much for consul.