### PR TITLE
CORE-6259: migrate data-info/stat-by-uuid and data-info/owns? usages

### DIFF
--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -353,19 +353,6 @@
     (throw+ {:error_code error/ERR_NOT_FOUND :uuid data-id})))
 
 
-(defn ^Boolean owns?
-  "Indicates if a file or folder is owned by a given user.
-
-   Parameters:
-     user       - the username of the user
-     data-path - The absolute path to the file or folder
-
-   Returns:
-     It returns true if the user own the data item, otherwise false."
-  [^String user ^String data-path]
-  (users/owns? user data-path))
-
-
 (defn ^String resolve-data-type
   "Given filesystem id, it returns the type of data item it is, file or folder.
 

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -3,6 +3,7 @@
         [slingshot.slingshot :only [throw+ try+]])
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [cemerick.url :as url]
             [cheshire.core :as json]
             [me.raynes.fs :as fs]
@@ -286,8 +287,11 @@
    Returns:
      It returns a path-stat map containing an additional UUID field."
   [^String user ^UUID uuid]
-  (uuids/path-for-uuid user uuid))
-
+  (-> (raw/collect-stats user :ids [uuid])
+      :body
+      json/decode
+      (get-in ["ids" uuid])
+      walk/keywordize-keys))
 
 (defn ^ISeq stats-by-uuids-paged
   "Resolves the stat info for the entities with the given UUIDs. The results are paged.

--- a/services/terrain/src/terrain/services/metadata/comments.clj
+++ b/services/terrain/src/terrain/services/metadata/comments.clj
@@ -92,8 +92,7 @@
   (let [user        (:shortUsername user/current-user)
         comment-id  (valid/extract-uri-uuid comment-id)
         entry-id    (extract-accessible-entry-id user entry-id)
-        entry-path  (:path (data/stat-by-uuid user entry-id))
-        owns-entry? (and entry-path (data/owns? user entry-path))]
+        owns-entry? (= (keyword (:permission (data/stat-by-uuid user entry-id))) :own)]
     (if owns-entry?
       (metadata/admin-update-data-retract-status entry-id comment-id retracted)
       (metadata/update-data-retract-status entry-id comment-id retracted))))

--- a/services/terrain/src/terrain/services/permanent_id_requests.clj
+++ b/services/terrain/src/terrain/services/permanent_id_requests.clj
@@ -73,8 +73,8 @@
     target-type))
 
 (defn- validate-owner
-  [user {:keys [id path] :as data-item}]
-  (when-not (data-info/owns? user path)
+  [user {:keys [id permission] :as data-item}]
+  (when-not (= (keyword permission) :own)
     (throw+ {:type :clojure-commons.exception/not-owner
              :error "User does not own given folder."
              :user user


### PR DESCRIPTION
This changes the data-info client's `stat-by-uuid` to use data-info rather than jargon directly. It also removes both uses of its `owns?` function (used, incidentally, the same two places) to use the `permission` value retrieved from data-info instead of calling out with jargon to check the ownership permission.

This doesn't close the ticket, which is quite large, but moves a few more things to properly use data-info instead of jargon calls in terrain.