### PR TITLE
CORE-7638: validate path readability in get-root so a nil permission can't seep through

### DIFF
--- a/services/data-info/src/data_info/services/root.clj
+++ b/services/data-info/src/data_info/services/root.clj
@@ -15,6 +15,7 @@
 
 (defn- get-root
   [cm user root-path]
+  (validators/path-readable cm user root-path) ;; CORE-7638; otherwise a 'nil' permission can pop up and cause issues
   (-> (stat/path-stat cm user root-path)
       (select-keys [:id :label :path :date-created :date-modified :permission])))
 


### PR DESCRIPTION
I also refactored the file generally a bit to be more consistent/clear about what it's doing.