### PR TITLE
templeton: support multiple bindings on one queue so periodic mode doesn't need two queues

### DIFF
--- a/golang/src/templeton/main.go
+++ b/golang/src/templeton/main.go
@@ -125,14 +125,15 @@ func doPeriodicMode(es *elasticsearch.Elasticer, d *database.Databaser, client *
 	go client.Listen()
 
 	// Accept and handle messages sent out with the index.all and index.templates routing keys
-	client.AddConsumer(messaging.ReindexExchange, "direct", "templeton.reindexAll", messaging.ReindexAllKey, func(del amqp.Delivery) {
-		es.Reindex(d)
-		del.Ack(false)
-	})
-	client.AddConsumer(messaging.ReindexExchange, "direct", "templeton.reindexTemplates", messaging.ReindexTemplatesKey, func(del amqp.Delivery) {
-		es.Reindex(d)
-		del.Ack(false)
-	})
+	client.AddConsumerMulti(
+		messaging.ReindexExchange,
+		"direct",
+		"templeton.periodic",
+		[]string{messaging.ReindexAllKey, messaging.ReindexTemplatesKey},
+		func(del amqp.Delivery) {
+			es.Reindex(d)
+			del.Ack(false)
+		})
 
 	spin()
 }


### PR DESCRIPTION
Just a small thing I hadn't bothered to do correctly the first time since this wasn't implemented in the AMQP client at that point and I wanted it to get done.