### PR TITLE
Split tree urls client out from terrain and into its own library

### DIFF
--- a/libs/tree-urls-client/.gitignore
+++ b/libs/tree-urls-client/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port

--- a/libs/tree-urls-client/project.clj
+++ b/libs/tree-urls-client/project.clj
@@ -1,0 +1,9 @@
+(defproject org.iplantc/tree-urls-client "5.2.7.0"
+  :description "Client for the tree-urls service"
+  :url "https://github.com/cyverse/DE"
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.iplantc/clojure-commons "5.2.7.0" :exclusions [buddy/buddy-sign metosin/compojure-api metosin/ring-http-response ring]]
+                 [slingshot "0.12.2"]
+                 [clj-http "2.0.0"]
+                 [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
+                 [cheshire "5.5.0"]])

--- a/project-defs.edn
+++ b/project-defs.edn
@@ -117,6 +117,18 @@
   :language :clojure
   :archive? false}
 
+ "tree-urls-client"
+ {:type     :library
+  :type-num 16
+  :path     "libs/tree-urls-client"
+  :build    :lein
+  :install  :lein
+  :tarball? false
+  :uberjar? false
+  :install? true
+  :language :clojure
+  :archive? false}
+
  "kameleon"
  {:type     :library
   :type-num 6

--- a/services/terrain/project.clj
+++ b/services/terrain/project.clj
@@ -37,6 +37,7 @@
                  [org.iplantc/clj-icat-direct "5.2.7.0"]
                  [org.iplantc/clj-jargon "5.2.7.0"]
                  [org.iplantc/clojure-commons "5.2.7.0"]
+                 [org.iplantc/tree-urls-client "5.2.7.0"]
                  [org.iplantc/common-cfg "5.2.7.0"]
                  [org.iplantc/common-cli "5.2.7.0"]
                  [org.iplantc/kameleon "5.2.7.0"]

--- a/services/terrain/src/terrain/core.clj
+++ b/services/terrain/src/terrain/core.clj
@@ -7,6 +7,7 @@
         [compojure.core]
         [compojure.api.middleware :only [wrap-exceptions]]
         [ring.middleware.keyword-params]
+        [tree-urls-client.core :only [with-tree-urls-base]]
         [terrain.routes.admin]
         [terrain.routes.callbacks]
         [terrain.routes.data]
@@ -58,6 +59,12 @@
         (handler request)
         (tc/with-logging-context {:user-info (cheshire/encode user-info)}
                                  (handler request))))))
+
+(defn- wrap-tree-urls-config
+  [handler]
+  (fn [request]
+    (with-tree-urls-base (config/tree-urls-base)
+      (handler request))))
 
 (defn- start-nrepl
   []
@@ -191,6 +198,7 @@
 
 (def secured-routes-handler
   (-> (delayed-handler secured-routes)
+      (wrap-routes wrap-tree-urls-config)
       (wrap-routes authenticate-current-user)
       (wrap-routes wrap-user-info)
       (wrap-routes wrap-exceptions  cx/exception-handlers)

--- a/services/terrain/src/terrain/services/buggalo.clj
+++ b/services/terrain/src/terrain/services/buggalo.clj
@@ -5,7 +5,7 @@
         [terrain.services.buggalo.nexml :only [is-nexml? extract-trees-from-nexml]]
         [terrain.util.service :only [success-response temp-dir-failure-response]]
         [terrain.auth.user-attributes :only [current-user]]
-        [terrain.clients.tree-urls]
+        [tree-urls-client.core]
         [slingshot.slingshot :only [throw+ try+]])
   (:require [cheshire.core :as cheshire]
             [clj-http.client :as client]

--- a/services/terrain/src/terrain/services/filesystem/manifest.clj
+++ b/services/terrain/src/terrain/services/filesystem/manifest.clj
@@ -11,7 +11,7 @@
             [terrain.services.filesystem.validators :as validators]
             [terrain.services.filesystem.stat :refer [detect-content-type]]
             [terrain.services.filesystem.garnish.irods :as filetypes]
-            [terrain.clients.tree-urls :as tree]
+            [tree-urls-client.core :as tree]
             [terrain.util.config :as cfg]
             [terrain.services.filesystem.icat :as icat])
   (:import [org.apache.tika Tika]))


### PR DESCRIPTION
This is somewhat in anticipation of using it in data-info (for the manifest endpoint), and somewhat as a way to solicit opinions on using this sort of a tactic more generally. I really dislike how many duplicated clients for our own services we maintain, and as we move further into microservice architecture this can only get worse without a bit of deliberate action.