### PR TITLE
Bump compojure-api to 0.24.5.

### DIFF
--- a/libs/common-swagger-api/project.clj
+++ b/libs/common-swagger-api/project.clj
@@ -11,6 +11,6 @@
                                [com.fasterxml.jackson.core/jackson-databind]
                                [com.fasterxml.jackson.core/jackson-core]]]
                  [clj-time "0.9.0"] ; required due to bug in lein-ring
-                 [metosin/compojure-api "0.24.2"]]
+                 [metosin/compojure-api "0.24.5"]]
   :profiles {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]]
                    :plugins [[lein-ring "0.9.6"]]}})

--- a/libs/iplant-clojure-commons/project.clj
+++ b/libs/iplant-clojure-commons/project.clj
@@ -8,7 +8,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [buddy/buddy-sign "0.7.0"]
                  [metosin/ring-http-response "0.6.5"]
-                 [metosin/compojure-api "0.24.2"]
+                 [metosin/compojure-api "0.24.5"]
                  [cheshire "5.5.0"]
                  [clj-http "2.0.0"]
                  [clj-time "0.11.0"]

--- a/services/apps/project.clj
+++ b/services/apps/project.clj
@@ -20,7 +20,7 @@
                  [com.google.guava/guava "18.0"]
                  [de.ubercode.clostache/clostache "1.4.0"]
                  [medley "0.7.0"]
-                 [metosin/compojure-api "0.24.2"]
+                 [metosin/compojure-api "0.24.5"]
                  [org.iplantc/authy "5.2.7.0"]
                  [org.iplantc/clojure-commons "5.2.7.0"]
                  [org.iplantc/kameleon "5.2.7.0"]

--- a/services/data-info/project.clj
+++ b/services/data-info/project.clj
@@ -23,7 +23,7 @@
                  [com.cemerick/url "0.1.1"]
                  [dire "0.5.3"]
                  [me.raynes/fs "1.4.6"]
-                 [metosin/compojure-api "0.24.2"]
+                 [metosin/compojure-api "0.24.5"]
                  [org.apache.tika/tika-core "1.11"]
                  [net.sf.opencsv/opencsv "2.3"]
                  [slingshot "0.12.2"]

--- a/services/iplant-groups/project.clj
+++ b/services/iplant-groups/project.clj
@@ -20,7 +20,7 @@
                  [clj-time "0.10.0"]
                  [com.cemerick/url "0.1.1"]
                  [medley "0.7.0"]
-                 [metosin/compojure-api "0.24.2"]
+                 [metosin/compojure-api "0.24.5"]
                  [me.raynes/fs "1.4.6"]
                  [org.iplantc/clojure-commons "5.2.7.0"]
                  [org.iplantc/common-cfg "5.2.7.0"]

--- a/services/metadata/project.clj
+++ b/services/metadata/project.clj
@@ -14,7 +14,7 @@
             :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [metosin/compojure-api "0.24.2"]
+                 [metosin/compojure-api "0.24.5"]
                  [cheshire "5.5.0"]
                  [com.novemberain/langohr "3.5.1"]
                  [org.iplantc/clojure-commons "5.2.7.0"]

--- a/services/terrain/project.clj
+++ b/services/terrain/project.clj
@@ -23,7 +23,7 @@
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
                  [commons-net "3.4"]                               ; provides org.apache.commons.net
                  [compojure "1.4.0"]
-                 [metosin/compojure-api "0.24.2"]  ; should be held to the same version as the one 
+                 [metosin/compojure-api "0.24.5"]  ; should be held to the same version as the one
                                                    ; used by org.iplantc/clojure-commons
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [dire "0.5.3"]


### PR DESCRIPTION
 Moving to 1.0+ will require a bit of work (https://github.com/metosin/compojure-api/wiki/Migration-Guide-to-1.0.0), but this is just bugfixes. I haven't tested everything which uses this intensively but everything compiles and the changes are pretty minimal (starting at https://github.com/metosin/compojure-api/blob/master/CHANGELOG.md#0245-1712016 and below).