### PR TITLE
Cleanup duplicated 'docker' group_vars.

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -17,8 +17,6 @@ docker:
   version: 1.11.0
   compose_path: /etc/docker-compose.yml
   registry:
-    host: "{{ groups['docker-registry'][0] }}"
-    port: 5000
     base: "{{ groups['docker-registry'][0] }}:5000"
 
 java:


### PR DESCRIPTION
Replaced `docker.registry.host` and `docker.registry.port` with `docker.registry.base`.
Please also review the `ansible-docker-vars-cleanup` branch in the private de-ansible repo, which is the only place where these `docker.registry.host|port` vars were used. The duplicated `docker.compose_path` was also removed from the private de-ansible repo's `group_vars/all`.