### PR TITLE
CORE-7648: add DISTINCTs to some clj-icat-direct queries

### DIFF
--- a/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
+++ b/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
@@ -208,7 +208,7 @@
 
 (defn- mk-count-colls-in-coll
   [parent-path group-ids-query & {:keys [cond] :or {cond "TRUE"}}]
-  (str "SELECT COUNT(*) AS total
+  (str "SELECT COUNT(DISTINCT c.coll_id) AS total
           FROM r_coll_main c JOIN r_objt_access AS a ON c.coll_id = a.object_id
           WHERE c.parent_coll_name = '" parent-path "'
             AND c.coll_type != 'linkPoint'
@@ -218,7 +218,7 @@
 
 (defn- mk-count-objs-of-type
   [objs-cte avus-cte group-query info-type-cond & {:keys [cond] :or {cond "TRUE"}}]
-  (str "SELECT COUNT(*) AS total
+  (str "SELECT COUNT(DISTINCT d.data_id) AS total
           FROM " objs-cte " AS d
             JOIN r_objt_access AS a ON a.object_id = d.data_id
             LEFT JOIN (" (mk-file-types avus-cte) ") AS f ON f.object_id = d.data_id


### PR DESCRIPTION
These queries count incorrectly when a user has access to a file by way of multiple groups, which the original ticket (DE-1115) was triggering in the data_commons folder. Interestingly it seems to be resolved in the production data_commons folder but I could still reproduce this in a QA environment.

These added `DISTINCT` match the ones in the better-functioning queries lower in the file in the `queries` var.

I have no doubt that clj-icat-direct could use some substantial refactoring but I wanted to get this fixed first, and then maybe look at the technical debt.