### PR TITLE
Reimplement several functions in clj-jargon to use more specific queries

### DIFF
--- a/libs/clj-jargon/src/clj_jargon/metadata.clj
+++ b/libs/clj-jargon/src/clj_jargon/metadata.clj
@@ -46,6 +46,7 @@
   [{^DataObjectAO data-ao :dataObjectAO
     ^CollectionAO collection-ao :collectionAO
     :as cm} path query]
+  (validate-path-lengths dir-path)
   (mapv avu2map
     (if (is-dir? cm path)
       (.findMetadataValuesByMetadataQueryForCollection collection-ao query path)
@@ -56,7 +57,6 @@
   [{^DataObjectAO data-ao :dataObjectAO
     ^CollectionAO collection-ao :collectionAO
     :as cm} dir-path attr]
-  (validate-path-lengths dir-path)
   (let [query [(AVUQueryElement/instanceForValueQuery
                 AVUQueryElement$AVUQueryPart/ATTRIBUTE
                 AVUQueryOperatorEnum/EQUAL
@@ -67,7 +67,6 @@
   [{^DataObjectAO data-ao :dataObjectAO
     ^CollectionAO collection-ao :collectionAO
     :as cm} apath attr val]
-  (validate-path-lengths apath)
   (let [query [(AVUQueryElement/instanceForValueQuery
                 AVUQueryElement$AVUQueryPart/ATTRIBUTE
                 AVUQueryOperatorEnum/EQUAL


### PR DESCRIPTION
The primary goal of this is speeding up info-typer some. I was investigating why it's so slow and found that a call to `clj-jargon/attribute?` (to check if there's already an `ipc-filetype` AVU) was taking about 90ms most times it ran, which is longer than the actual file identification process. Looking deeper, what we were doing was getting all metadata for the object and then filtering it in clj-jargon down to just the one attribute, by way of a chain of functions.

This changes the chain so it requests only the AVUs it actually wants, from the start. I've also done the same for lookups by attribute + value, which were implemented in a similar fashion.

It seems to have worked, since a brief test afterwards showed the same call taking less than a quarter of the time.