### PR TITLE
Add a debug-utils class with a helpful log-time macro

### DIFF
--- a/libs/debug-utils/.gitignore
+++ b/libs/debug-utils/.gitignore
@@ -1,0 +1,15 @@
+pom.xml
+*jar
+/lib/
+/classes/
+/target/
+.lein-deps-sum
+.lein-failures
+.lein-repl-history
+*~
+*.swp
+.dir-locals.el
+.nrepl-hist.eld
+/.classpath
+/.project
+/bin

--- a/libs/debug-utils/project.clj
+++ b/libs/debug-utils/project.clj
@@ -1,0 +1,7 @@
+(defproject org.iplantc/debug-utils "5.2.7.0"
+  :description "Common Debugging Utilities for Clojure Projects"
+  :url "https://github.com/cyverse/DE"
+  :license {:name "BSD"
+            :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/tools.logging "0.3.1"]])

--- a/libs/debug-utils/src/debug_utils/log_time.clj
+++ b/libs/debug-utils/src/debug_utils/log_time.clj
@@ -1,0 +1,14 @@
+(ns debug-utils.log-time
+  (:require [clojure.tools.logging :as log]))
+
+(def ^:dynamic *depth*
+  "Dynamic context to be used in calculating indentation."
+  0)
+
+(defmacro log-time [label & body]
+  `(binding [*depth* (+ *depth* 1)]
+     (let [start# (System/nanoTime)
+           ret# (do ~@body)
+           end# (System/nanoTime)]
+       (log/info (str (apply str (take (- *depth* 1) (repeat "    "))) ~label " took: " (/ (- end# start#) 1e6) "ms"))
+       ret#)))

--- a/project-defs.edn
+++ b/project-defs.edn
@@ -33,6 +33,18 @@
   :language :clojure
   :archive? false}
 
+ "debug-utils"
+ {:type     :library
+  :type-num 1
+  :path     "libs/debug-utils"
+  :build    :lein
+  :install  :lein
+  :tarball? false
+  :uberjar? false
+  :install? true
+  :language :clojure
+  :archive? false}
+
  "heuristomancer"
  {:type     :library
   :type-num 12


### PR DESCRIPTION
I've used versions of this macro a few times now and I don't want to write it again. Doing it this way means that for temporary debugging, `debug-utils` can be added to project.clj and then `log-time` can be imported and used (potentially across several projects/libraries/etc). I figured that putting this in a dedicated library was the most comfortable way to do this, rather than needing to put it into something we actually use outside of debugging, but I'm open to suggestions.

log-time runs its body, timing it, and then logs the provided label and the amount of time, indenting it by the depth of nested calls to log-time. Thus, for something like:

```clojure
(log-time "blah" 
  (log-time "foo" (+ 1 1))
  (log-time "bar" (dotimes [_ 77777] (+ 1 1))))
```

You'll get something like:
```
{"@timestamp":"2016-05-10T16:15:31.743-07:00","@version":1,"message":"    foo took: 0.001646ms","loggerName":"info-typer.core","thread":"nREPL-worker-1","level":"INFO","HOSTNAME":"IPC-MCEWEN","service":"info-typer"}
{"@timestamp":"2016-05-10T16:15:31.746-07:00","@version":1,"message":"    bar took: 2.165731ms","loggerName":"info-typer.core","thread":"nREPL-worker-1","level":"INFO","HOSTNAME":"IPC-MCEWEN","service":"info-typer"}
{"@timestamp":"2016-05-10T16:15:31.746-07:00","@version":1,"message":"blah took: 3.302839ms","loggerName":"info-typer.core","thread":"nREPL-worker-1","level":"INFO","HOSTNAME":"IPC-MCEWEN","service":"info-typer"}
```

(my testing happened to be with info-typer)