### PR TITLE
CORE-7669: zero-downtime UI deployment

### DIFF
--- a/ansible/playbooks/de-deploy-service-nginx.yaml
+++ b/ansible/playbooks/de-deploy-service-nginx.yaml
@@ -236,7 +236,6 @@
   gather_facts: false
   tags:
     - ui
-    - uncolored
     - de-ui-nginx
   roles:
     - role: de-deploy-service

--- a/ansible/playbooks/de-deploy-service-nginx.yaml
+++ b/ansible/playbooks/de-deploy-service-nginx.yaml
@@ -229,3 +229,17 @@
       deploy_use_color: false
       force_recreate: false
       service_name: "{{user_sessions.compose_service}}_nginx"
+
+- name: Redeploy de-ui-nginx
+  hosts: ui:&systems
+  become: true
+  gather_facts: false
+  tags:
+    - ui
+    - uncolored
+    - de-ui-nginx
+  roles:
+    - role: de-deploy-service
+      has_iplant_data: true
+      deploy_use_color: false
+      service_name: "{{de.http_server.compose_service}}"

--- a/ansible/playbooks/de-deploy-services.yaml
+++ b/ansible/playbooks/de-deploy-services.yaml
@@ -257,6 +257,23 @@
     - role: util-notify-chat
       msg: ":heavy_check_mark: Done deploying user-sessions"
 
+- name: Redeploy de-ui
+  hosts: ui:&systems
+  become: true
+  gather_facts: false
+  tags:
+    - ui
+    - colored
+  roles:
+    - role: util-notify-chat
+      msg: "Deploying UI"
+    - role: de-deploy-service
+      has_iplant_data: true
+      deploy_use_color: true
+      service_name: "{{de.compose_service}}"
+    - role: util-notify-chat
+      msg: ":heavy_check_mark: Done deploying UI"
+
 
 ##############################################################
 # Services which do not use colors ever
@@ -298,41 +315,6 @@
     - role: util-notify-chat
       when: not parasitic
       msg: ":heavy_check_mark: Done deploying dewey"
-
-- name: Redeploy de-ui
-  hosts: ui:&systems
-  become: true
-  gather_facts: false
-  tags:
-    - ui
-    - uncolored
-  roles:
-    - role: util-notify-chat
-      msg: "Deploying UI"
-    - role: de-deploy-service
-      has_iplant_data: true
-      deploy_use_color: false
-      service_name: "{{de.compose_service}}"
-    - role: util-notify-chat
-      msg: ":heavy_check_mark: Done deploying UI"
-
-- name: Redeploy de-ui-nginx
-  hosts: ui:&systems
-  become: true
-  gather_facts: false
-  tags:
-    - ui
-    - uncolored
-    - de-ui-nginx
-  roles:
-    - role: util-notify-chat
-      msg: "Deploying UI nginx"
-    - role: de-deploy-service
-      has_iplant_data: true
-      deploy_use_color: false
-      service_name: "{{de.http_server.compose_service}}"
-    - role: util-notify-chat
-      msg: ":heavy_check_mark: Done deploying UI nginx"
 
 - name: Redeploy exim-sender
   hosts: exim-sender:&systems


### PR DESCRIPTION
* move de-ui deployment to color section
* move de-ui-nginx to service-nginx deployment

there is also a private ansible branch for this, which updates the docker-compose files (more than I already had to get the nginx working initially, which is already in the dev environment) and to the documentation (to mention the de-deploy-service-nginx.yaml playbook and when it should be run in deployments (i.e., when downtime is acceptable)