### PR TITLE
Use more up-to-date group accounting in submit file

### DIFF
--- a/golang/src/condor-launcher/condor.go
+++ b/golang/src/condor-launcher/condor.go
@@ -77,12 +77,13 @@ rank = mips
 arguments = --config config --job job
 output = script-output.log
 error = script-error.log
-log = condor.log
+log = condor.log{{if .Group}}
+accounting_group = {{.Group}}
+accounting_group_user = {{.Submitter}}{{end}}
 request_disk = {{.RequestDisk}}
 +IpcUuid = "{{.InvocationID}}"
 +IpcJobId = "generated_script"
-+IpcUsername = "{{.Submitter}}"{{if .Group}}
-+AccountingGroup = "{{.Group}}.{{.Submitter}}"{{end}}
++IpcUsername = "{{.Submitter}}"
 concurrency_limits = {{.UserIDForSubmission}}
 {{with $x := index .Steps 0}}+IpcExe = "{{$x.Component.Name}}"{{end}}
 {{with $x := index .Steps 0}}+IpcExePath = "{{$x.Component.Location}}"{{end}}


### PR DESCRIPTION
http://research.cs.wisc.edu/htcondor/manual/v8.4/3_4User_Priorities.html#SECTION00447000000000000000
suggests that using accounting_group and accounting_group_user is the
modern way to do this, rather than using +AccountingGroup

I also moved it up in the file since we seem to roughly organize it with the submit-language stuff first and the + lines for custom attributes after.