### PR TITLE
CORE-7676: added the restricted column to the tools table

### DIFF
--- a/databases/de-database-schema/src/main/conversions/c270_2016052601.clj
+++ b/databases/de-database-schema/src/main/conversions/c270_2016052601.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c270-2016052601
+  (:use [korma.core]
+         [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version."
+  "2.7.0:20160526.01")
+
+(defn- add-restricted-column
+  []
+  (println "\t* Adding restricted column to the tools table.")
+  (exec-sql-statement "ALTER TABLE tools ADD restricted BOOLEAN NOT NULL DEFAULT FALSE"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-restricted-column))

--- a/databases/de-database-schema/src/main/data/99_version.sql
+++ b/databases/de-database-schema/src/main/data/99_version.sql
@@ -75,3 +75,4 @@ INSERT INTO version (version) VALUES ('2.6.0:20160222.01');
 INSERT INTO version (version) VALUES ('2.6.0:20160309.01');
 INSERT INTO version (version) VALUES ('2.6.0:20160420.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160525.01');
+INSERT INTO version (version) VALUES ('2.7.0:20160526.01');

--- a/databases/de-database-schema/src/main/tables/03_tools.sql
+++ b/databases/de-database-schema/src/main/tables/03_tools.sql
@@ -13,5 +13,6 @@ CREATE TABLE tools (
     attribution text,
     integration_data_id uuid NOT NULL,
     container_images_id uuid,
-    time_limit_seconds integer NOT NULL DEFAULT 0
+    time_limit_seconds integer NOT NULL DEFAULT 0,
+    restricted boolean NOT NULL DEFAULT FALSE
 );

--- a/libs/kameleon/project.clj
+++ b/libs/kameleon/project.clj
@@ -14,4 +14,4 @@
                  [slingshot "0.12.2"]]
   :plugins [[lein-marginalia "0.7.1"]
             [test2junit "1.1.3"]]
-  :manifest {"db-version" "2.7.0:20160525.01"})
+  :manifest {"db-version" "2.7.0:20160526.01"})


### PR DESCRIPTION
This pull request adds a restricted column to the tools table in the DE. It should be a not null boolean column and defaults to false.

A conversion named c270_2016052601.clj was added to update existing databases with the new column.

Kameleon's db version was updated to 2.7.0:20160526.01.

These was tested locally by doing the following:

Mounting the new database.tar.gz and facepalm uberjar files into a running discoenv/unittest-dedb:dev container and docker exec'ing the update-dev-database.sh script.

Creating a new version of the discoenv/unittest-dedb:dev image with the changes loaded by default.

Creating a new version of the discoenv/unittest-dedb:dev image with the changes loaded by default, and then running the the update-dev-database.sh script.

The database ships with 3 tools integrated, so the above testing also showed that existing tools got updated with the new default value.