### PR TITLE
time_limit_seconds and restricted fields are included in the job submission JSON

### DIFF
--- a/services/apps/src/apps/service/apps/de/jobs/common.clj
+++ b/services/apps/src/apps/service/apps/de/jobs/common.clj
@@ -65,7 +65,13 @@
   (-> (select* :tasks)
       (join :tools {:tasks.tool_id :tools.id})
       (join :tool_types {:tools.tool_type_id :tool_types.id})
-      (fields :tools.description :tools.location :tools.name [:tool_types.name :type] :tools.id)
+      (fields :tools.description
+              :tools.location
+              :tools.name
+              [:tool_types.name :type]
+              :tools.id
+              :tools.restricted
+              :tools.time_limit_seconds)
       (where {:tasks.id task-id})
       (select)
       (first)


### PR DESCRIPTION
The apps service has been modified to include the time_limit_seconds and restricted fields from the tools table in the JSON sent to the jex-adapter service.

I ran the apps tests against this and there weren't any errors.