### PR TITLE
Core 7664

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -492,6 +492,7 @@ apps:
   user_subs: "[\"Apps under development\",\"Favorite Apps\"]"
   trash_category: Trash
   max_heap: "{{ max_heap.high }}"
+  grouper_user:
 
 metadata_db_driver: "{{ db_driver }}"
 metadata_db_vendor: "{{ db_vendor }}"

--- a/ansible/roles/util-cfg-service/templates/apps.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/apps.properties.j2
@@ -66,7 +66,8 @@ apps.notificationagent.base-url = {{ notificationagent.base }}
 apps.jobs.poll-interval = {{ job_status_poll_interval }}
 
 # The base URL for iplant-groups.
-apps.iplant-groups.base-url = {{ iplant_groups.base_url }}
+apps.iplant-groups.base-url     = {{ iplant_groups.base_url }}
+apps.iplant-groups.grouper-user = {{ apps.grouper_user }}
 
 # Metadata connection settings
 apps.metadata.base-url = http://{{ metadata.host }}:{{ metadata.port }}

--- a/services/apps/src/apps/clients/iplant_groups.clj
+++ b/services/apps/src/apps/clients/iplant_groups.clj
@@ -11,7 +11,6 @@
             [clojure-commons.exception :as cx]
             [kameleon.uuids :refer [uuidify]]))
 
-(def grouper-user "de_grouper")
 (def grouper-user-group-fmt "iplant:de:%s:users:de-users")
 (def grouper-app-permission-def-fmt "iplant:de:%s:apps:app-permission-def")
 (def grouper-app-resource-name-fmt "iplant:de:%s:apps:%s")
@@ -86,12 +85,12 @@
   "Adds a user to the de-users group."
   [subject-id]
   (http/put (grouper-url "groups" (grouper-user-group) "members" subject-id)
-            {:query-params {:user grouper-user}}))
+            {:query-params {:user (config/de-grouper-user)}}))
 
 (defn- retrieve-permissions*
   "Retrieves permission assignments from Grouper."
   [role subject attribute-def attribute-def-names]
-  (->> {:user                grouper-user
+  (->> {:user                (config/de-grouper-user)
         :role                role
         :attribute_def       attribute-def
         :attribute_def_names attribute-def-names
@@ -154,7 +153,7 @@
   "Creates a new permission name in grouper."
   [resource-name permission-def]
   (:body (http/post (grouper-url "attributes")
-                    {:query-params {:user grouper-user}
+                    {:query-params {:user (config/de-grouper-user)}
                      :form-params  {:name                 resource-name
                                     :attribute_definition {:name permission-def}}
                      :content-type :json
@@ -164,13 +163,13 @@
   "Removes an existing permission name from grouper."
   [resource-name]
   (http/delete (grouper-url "attributes" resource-name)
-               {:query-params {:user grouper-user}}))
+               {:query-params {:user (config/de-grouper-user)}}))
 
 (defn- grant-role-user-permission
   "Grants permission to access a resource to an individual user."
   [user role resource-name action]
   (:body (http/put (grouper-url "attributes" resource-name "permissions" "memberships" role user action)
-                   {:query-params {:user grouper-user}
+                   {:query-params {:user (config/de-grouper-user)}
                     :form-params  {:allowed true}
                     :content-type :json
                     :as           :json})))
@@ -216,7 +215,7 @@
   "Makes an app publicly accessible in Grouper."
   [app-id]
   (:body (http/put (grouper-url "attributes" (grouper-app-resource-name app-id) "permissions")
-                   {:query-params {:user grouper-user}
+                   {:query-params {:user (config/de-grouper-user)}
                     :form-params  (public-permission-update-body)
                     :content-type :json
                     :as           :json})))
@@ -225,7 +224,7 @@
   "Shares a resource with a user."
   [resource-name role-name subject-id level]
   (http/put (grouper-url "attributes" resource-name "permissions" "memberships" role-name subject-id level)
-            {:query-params {:user grouper-user}
+            {:query-params {:user (config/de-grouper-user)}
              :form-params  {:allowed true}
              :content-type :json
              :as           :json})
@@ -235,7 +234,7 @@
   "Unshares a resource with a user."
   [resource-name role-name subject-id]
   (http/delete (grouper-url "attributes" resource-name "permissions" "memberships" role-name subject-id)
-               {:query-params {:user grouper-user}
+               {:query-params {:user (config/de-grouper-user)}
                 :as           :json})
   nil)
 

--- a/services/apps/src/apps/util/config.clj
+++ b/services/apps/src/apps/util/config.clj
@@ -234,6 +234,11 @@
   [props config-valid configs]
   "apps.iplant-groups.base-url")
 
+(cc/defprop-str de-grouper-user
+  "The username that the DE users to authenticate to Grouper."
+  [props config-valid configs]
+  "apps.iplant-groups.grouper-user")
+
 (cc/defprop-str metadata-base
   "The base URL for the metadata service."
   [props config-valid configs]

--- a/services/apps/src/apps/util/config.clj
+++ b/services/apps/src/apps/util/config.clj
@@ -235,7 +235,7 @@
   "apps.iplant-groups.base-url")
 
 (cc/defprop-str de-grouper-user
-  "The username that the DE users to authenticate to Grouper."
+  "The username that the DE uses to authenticate to Grouper."
   [props config-valid configs]
   "apps.iplant-groups.grouper-user")
 

--- a/tools/sharkbait/src/sharkbait/consts.clj
+++ b/tools/sharkbait/src/sharkbait/consts.clj
@@ -1,8 +1,5 @@
 (ns sharkbait.consts)
 
-;; The username used by the DE.
-(def de-username "de_grouper")
-
 ;; Various folders used by the DE.
 (def folder-format-strings
   {:de          "iplant:de:%s"

--- a/tools/sharkbait/src/sharkbait/folders.clj
+++ b/tools/sharkbait/src/sharkbait/folders.clj
@@ -21,7 +21,7 @@
    to add. The set of valid keywords is stored in the variable, valid-privs."
   [folder subject privs & [{:keys [revoke-unselected?] :or {revoke-unselected? false}}]]
   (let [privs (set privs)]
-     (.grantPrivs folder subject
+    (.grantPrivs folder subject
                  (contains? privs :stem)
                  (contains? privs :create)
                  (contains? privs :attr-read)

--- a/tools/sharkbait/src/sharkbait/folders.clj
+++ b/tools/sharkbait/src/sharkbait/folders.clj
@@ -21,7 +21,7 @@
    to add. The set of valid keywords is stored in the variable, valid-privs."
   [folder subject privs & [{:keys [revoke-unselected?] :or {revoke-unselected? false}}]]
   (let [privs (set privs)]
-    (.grantPrivs folder subject
+     (.grantPrivs folder subject
                  (contains? privs :stem)
                  (contains? privs :create)
                  (contains? privs :attr-read)


### PR DESCRIPTION
This change was requested by the ODUM Institute, which doesn't have control over the LDAP instance that it uses and can't add the `de_grouper` user. The primary thing that I'd like to verify with this PR is that I've caught all of the cases where the `de_grouper` user was referenced directly in code.
