### PR TITLE
Perms refactor

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -585,6 +585,8 @@ permissions:
   compose_service: permissions
   service_name_short: permissions
 
+permissions_base: "http://{{ permissions.host }}:{{ permissions.port }}"
+
 permissions_db_driver: "{{ db_driver }}"
 permissions_db_vendor: "{{ db_vendor }}"
 permissions_db_port: "{{ db_port }}"

--- a/ansible/roles/util-cfg-service/templates/apps.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/apps.properties.j2
@@ -71,3 +71,6 @@ apps.iplant-groups.grouper-user = {{ apps.grouper_user }}
 
 # Metadata connection settings
 apps.metadata.base-url = http://{{ metadata.host }}:{{ metadata.port }}
+
+# Permissions service connection settings.
+apps.permissions.base-url = {{ permissions_base }}

--- a/libs/permissions-client/.gitignore
+++ b/libs/permissions-client/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/libs/permissions-client/README.md
+++ b/libs/permissions-client/README.md
@@ -1,14 +1,65 @@
 # permissions-client
 
-A Clojure library designed to ... well, that part is up to you.
+A client library for the CyVerse Discovery Environment permissions service.
 
 ## Usage
 
-FIXME
+``` clojure
+(require '[permissions-client.core :as pc])
+
+(def client (pc/new-permissions-client base-uri))
+
+;; Get service status information.
+(pc/get-status client)
+
+;; Subject operations.
+(def subjects (pc/list-subjects client))
+(def subject (pc/add-subject client subject-id subject-type))
+(def updated-subject (pc/update-subject client (:id subject) new-subject-id new-subject-type))
+(pc/delete-subject client (:id updated-subject))
+
+;; Resource operations.
+(def resources (pc/list-resources client))
+(def resource (pc/add-resource client resource-name resource-type-name))
+(def updated-resource (pc/update-resource client (:id resource) new-resource-name))
+(pc/delete-resource client (:id updated-resource))
+
+;; Resource type operations.
+(def resource-types (pc/list-resource-types client))
+(def resource-type (pc/add-resource-type client name description))
+(def updated-resource-type (pc/update-resource-type client (:id resource-type) new-name new-description)
+(pc/delete-resource-type client (:id updated-resource-type))
+
+;; Permissions operations.
+(def permissions (pc/list-permissions client))
+(def permission (pc/grant-permission client resource-type resource-name subject-type subject-id permission-level))
+(pc/revoke-permission client resource-type resource-name subject-type subject-id)
+(def permissions (pc/list-resource-permissions client resource-type resource-name))
+
+;; List permissions by subject.
+(def permissions (pc/get-subject-permissions client subject-type subject-id false))
+
+;; Lookup the highest permission levels available to a subject. If the subject is a user then the listing may
+;; also include permissions that are assigned to groups that the user belongs to.
+(def permissions (pc/get-subject-permissions client subject-type subject-id true))
+
+;; List permissions by subject and resource type.
+(def permissions (pc/get-subject-permissions-for-resource-type client subject-type subject-id resource-type false))
+
+;; Lookup the highest permission levels available to a subject for a resource type. If the subject is a user then the
+;; listing may also include permissions that are assigned to groups that the user belongs to.
+(def permissions (pc/get-subject-permissions-for-resource-type client subject-type subject-id resource-type true)
+
+;; List permissions by subject and resource.
+(def permissions (pc/get-subject-permissions-for-resource client subject-type subject-id resource-type resource-name
+                                                          false))
+
+;; Lookup the highest permission levels available to a subject for a resource. If the subject is a user then the
+;; listing may also include permissions that are assigned to groups that the user belongs to.
+(def permissions (pc/get-subject-permissions-for-resource client subject-type subject-id resource-type resource-name
+                                                          true))
+```
 
 ## License
 
-Copyright © 2016 FIXME
-
-Distributed under the Eclipse Public License either version 1.0 or (at
-your option) any later version.
+http://www.cyverse.org/sites/default/files/iPLANT-LICENSE.txt

--- a/libs/permissions-client/README.md
+++ b/libs/permissions-client/README.md
@@ -1,0 +1,14 @@
+# permissions-client
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2016 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/libs/permissions-client/project.clj
+++ b/libs/permissions-client/project.clj
@@ -1,0 +1,10 @@
+(defproject permissions-client "5.2.7.0"
+  :description "A Clojure client library for the CyVerse permissions service."
+  :url "https://github.com/cyverse/DE"
+  :license {:name "BSD"
+            :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
+  :dependencies [[cheshire "5.6.1"]
+                 [clj-http "2.2.0"]
+                 [clj-http-fake "1.0.2"]
+                 [com.cemerick/url "0.1.1"]
+                 [org.clojure/clojure "1.7.0"]])

--- a/libs/permissions-client/project.clj
+++ b/libs/permissions-client/project.clj
@@ -5,6 +5,6 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :dependencies [[cheshire "5.6.1"]
                  [clj-http "2.2.0"]
-                 [clj-http-fake "1.0.2"]
                  [com.cemerick/url "0.1.1"]
-                 [org.clojure/clojure "1.7.0"]])
+                 [org.clojure/clojure "1.7.0"]]
+  :profiles {:test {:dependencies [[clj-http-fake "1.0.2"]]}})

--- a/libs/permissions-client/src/permissions_client/core.clj
+++ b/libs/permissions-client/src/permissions_client/core.clj
@@ -1,0 +1,200 @@
+(ns permissions-client.core
+  (:require [cemerick.url :as curl]
+            [clj-http.client :as http]))
+
+(defprotocol Client
+  "A client library for the Permissions API."
+  (get-status [_]
+    "Retrieves information about the status of the permissions service.")
+
+  (list-subjects [_]
+    "Lists all subjects defined in the permissions service.")
+
+  (add-subject [_ external-id subject-type]
+    "Registers a subject in the permissions service. The external-id field is the subject ID known to the
+     client. For clients that use Grouper, this subject ID should the same as the one used by Grouper. The
+     subject ID must be unique within the permissions database. The subject-type field can be either 'user'
+     or 'group'.")
+
+  (delete-subject [_ id]
+    "Removes the subject with the given internal ID from the permissions database.")
+
+  (update-subject [_ id external-id subject-type]
+    "Updates a subject in the permissions service. The external-id field is the subject ID known to the client.
+     For clients that use Grouper, this subject ID should be the same as the one used by Grouper. The subject
+     ID must be unique within the permissions database. The subject-type field can be either 'user' or 'group'.")
+
+  (list-resources [_]
+    "Lists all resources defined in the permissions service.")
+
+  (add-resource [_ resource-name resource-type]
+     "Adds a resource to the permissions service. The resource-name field is the name or identifier that is used
+      by the client to refer to the resource. This field must be unique among resources of the same type. The
+      resource-type field is the name of the resource type, which must have been registered in the permission
+      database already.")
+
+  (delete-resource [_ id]
+    "Removes the resource with the given ID from the permissions service.")
+
+  (update-resource [_ id resource-name]
+    "Updates a resource in the permissions service. The resource-name field is the name or identifier that is
+     used by the client to refer to the resource. This field must be unique among resources of the same type.
+     The type of an existing resource may not be modified.")
+
+  (list-resource-types [_]
+    "Lists all resource types registered in the permissions service.")
+
+  (add-resource-type [_ resource-type-name description]
+    "Adds a resource type to the permissions service. A resource type is a class of entities to which
+     permissions may be assigned. For example, the Discovery Environment uses two resource types, 'app'
+     and 'analysis', with individual apps or analyses being registered as resources of their respective
+     types. Each resource type must have a unique name.")
+
+  (delete-resource-type [_ id]
+    "Removes the resource type with the given ID from the permissions service. A resource type with associated
+     resources may not be deleted.")
+
+  (update-resource-type [_ id resource-type-name description]
+    "Updates a resource type in the permissions service. Each resource type must have a unique name.")
+
+  (list-permissions [_]
+    "Lists all permissions known to the permissions service.")
+
+  (grant-permission [_ resource-type resource-name subject-type subject-id level]
+    "Grants permission to access a resource to a user. The resource-type, resource-name, subject-type, and
+     subject-id fields have the same meanings as in the resources and subjects methods. Neither the resource
+     nor the subject need to be registered before calling this ednpoint; they will be added to the database
+     if necessary. The permission level must correspond to one of the available levels in the permissions
+     service. The currently available levels are 'read', 'admin', 'write', and 'own'.")
+
+  (revoke-permission [_ resource-type resource-name subject-type subject-id]
+    "Revokes a permission that has previously been granted.")
+
+  (list-resource-permissions [_ resource-type resource-name]
+    "Lists all permissions associated with a resource.")
+
+  (get-subject-permissions [_ subject-type subject-id lookup?]
+    "Looks up permissions that have been granted to a subject. If the 'lookup?' flag is set to 'true' and the
+     subject happens to be a user then the most privileged permissions available to the user or any group that
+     the user belongs to (as determined by Grouper) will be listed. If the 'lookup?' flag is set to 'false' or
+     the subject is a group then only permissions that were granted directly to the subject will be listed.")
+
+  (get-subject-permissions-for-resource-type [_ subject-type subject-id resource-type lookup?]
+    "Looks up permissions that have been granted to a subject for a single resource type. If the 'lookup?' flag
+     is set to 'true' and the subject happens to be a user then the most privileged permissions available to the
+     user or any group that the user belongs to (as determined by Grouper) will be listed. If the 'lookup?'
+     flag is set to 'false' or the subject is a group then only permissions that were granted directly to the
+     subject will be listed.")
+
+  (get-subject-permissions-for-resource [_ subject-type subject-id resource-type resource-name lookup?]
+    "Looks up permissions that have been granted to a subject for a single resource. If the 'lookup?' flag is
+     set to 'true' and the subject happens to be a user then the most privileged permissions available to the
+     user or any group that the user belongs to (as determined by Grouper) will be listed. If the 'lookup?'
+     flag is set to 'false' or the subject is a group then only permissions that were granted directly to the
+     subject will be listed."))
+
+(defn- build-url [base-url & path-elements]
+  (str (apply curl/url base-url path-elements)))
+
+(deftype PermissionsClient [base-url]
+  Client
+
+  (get-status [_]
+    (:body (http/get base-url {:as :json})))
+
+  (list-subjects [_]
+    (:body (http/get (build-url base-url "subjects")
+                     {:as :json})))
+
+  (add-subject [_ external-id subject-type]
+    (:body (http/post (build-url base-url "subjects")
+                      {:form-params  {:subject_id   external-id
+                                      :subject_type subject-type}
+                       :content-type :json
+                       :as           :json})))
+
+  (delete-subject [_ id]
+    (http/delete (build-url base-url "subjects" id))
+    nil)
+
+  (update-subject [_ id external-id subject-type]
+    (:body (http/put (build-url base-url "subjects" id)
+                     {:form-params  {:subject_id   external-id
+                                     :subject_type subject-type}
+                      :content-type :json
+                      :as           :json})))
+
+  (list-resources [_]
+    (:body (http/get (build-url base-url "resources") {:as :json})))
+
+  (add-resource [_ resource-name resource-type]
+    (:body (http/post (build-url base-url "resources")
+                      {:form-params  {:name          resource-name
+                                      :resource_type resource-type}
+                       :content-type :json
+                       :as           :json})))
+
+  (delete-resource [_ id]
+    (http/delete (build-url base-url "resources" id))
+    nil)
+
+  (update-resource [_ id resource-name]
+    (:body (http/put (build-url base-url "resources" id)
+                     {:form-params  {:name resource-name}
+                      :content-type :json
+                      :as           :json})))
+
+  (list-resource-types [_]
+    (:body (http/get (build-url base-url "resource_types") {:as :json})))
+
+  (add-resource-type [_ resource-type-name description]
+    (:body (http/post (build-url base-url "resource_types")
+                      {:form-params  {:name        resource-type-name
+                                      :description description}
+                       :content-type :json
+                       :as           :json})))
+
+  (delete-resource-type [_ id]
+    (http/delete (build-url base-url "resource_types" id))
+    nil)
+
+  (update-resource-type [_ id resource-type-name description]
+    (:body (http/put (build-url base-url "resource_types" id)
+                     {:form-params  {:name        resource-type-name
+                                     :description description}
+                      :content-type :json
+                      :as           :json})))
+
+  (list-permissions [_]
+    (:body (http/get (build-url base-url "permissions") {:as :json})))
+
+  (grant-permission [_ resource-type resource-name subject-type subject-id level]
+    (:body (http/put (build-url base-url "permissions" resource-type resource-name subject-type subject-id)
+                     {:form-params  {:permission_level level}
+                      :content-type :json
+                      :as           :json})))
+
+  (revoke-permission [_ resource-type resource-name subject-type subject-id]
+    (http/delete (build-url base-url "permissions" resource-type resource-name subject-type subject-id))
+    nil)
+
+  (list-resource-permissions [_ resource-type resource-name]
+    (:body (http/get (build-url base-url "permissions" resource-type resource-name) {:as :json})))
+
+  (get-subject-permissions [_ subject-type subject-id lookup?]
+    (:body (http/get (build-url base-url "permissions" subject-type subject-id)
+                     {:query-params {:lookup lookup?}
+                      :as           :json})))
+
+  (get-subject-permissions-for-resource-type [_ subject-type subject-id resource-type lookup?]
+    (:body (http/get (build-url base-url "permissions" subject-type subject-id resource-type)
+                     {:query-params {:lookup lookup?}
+                      :as           :json})))
+
+  (get-subject-permissions-for-resource [_ subject-type subject-id resource-type resource-name lookup?]
+    (:body (http/get (build-url base-url "permissions" subject-type subject-id resource-type resource-name)
+                     {:query-params {:lookup lookup?}
+                      :as           :json}))))
+
+(defn new-permissions-client [base-url]
+  (PermissionsClient. base-url))

--- a/libs/permissions-client/src/permissions_client/core.clj
+++ b/libs/permissions-client/src/permissions_client/core.clj
@@ -176,24 +176,25 @@
                       :as           :json})))
 
   (revoke-permission [_ resource-type resource-name subject-type subject-id]
-    (http/delete (build-url base-url "permissions" resource-type resource-name subject-type subject-id))
+    (http/delete (build-url base-url "permissions" "resources" resource-type resource-name "subjects" subject-type
+                            subject-id))
     nil)
 
   (list-resource-permissions [_ resource-type resource-name]
-    (:body (http/get (build-url base-url "permissions" resource-type resource-name) {:as :json})))
+    (:body (http/get (build-url base-url "permissions" "resources" resource-type resource-name) {:as :json})))
 
   (get-subject-permissions [_ subject-type subject-id lookup?]
-    (:body (http/get (build-url base-url "permissions" subject-type subject-id)
+    (:body (http/get (build-url base-url "permissions" "subjects" subject-type subject-id)
                      {:query-params {:lookup lookup?}
                       :as           :json})))
 
   (get-subject-permissions-for-resource-type [_ subject-type subject-id resource-type lookup?]
-    (:body (http/get (build-url base-url "permissions" subject-type subject-id resource-type)
+    (:body (http/get (build-url base-url "permissions" "subjects" subject-type subject-id resource-type)
                      {:query-params {:lookup lookup?}
                       :as           :json})))
 
   (get-subject-permissions-for-resource [_ subject-type subject-id resource-type resource-name lookup?]
-    (:body (http/get (build-url base-url "permissions" subject-type subject-id resource-type resource-name)
+    (:body (http/get (build-url base-url "permissions" "subjects" subject-type subject-id resource-type resource-name)
                      {:query-params {:lookup lookup?}
                       :as           :json}))))
 

--- a/libs/permissions-client/src/permissions_client/core.clj
+++ b/libs/permissions-client/src/permissions_client/core.clj
@@ -169,7 +169,8 @@
     (:body (http/get (build-url base-url "permissions") {:as :json})))
 
   (grant-permission [_ resource-type resource-name subject-type subject-id level]
-    (:body (http/put (build-url base-url "permissions" resource-type resource-name subject-type subject-id)
+    (:body (http/put (build-url base-url "permissions" "resources" resource-type resource-name "subjects"
+                                subject-type subject-id)
                      {:form-params  {:permission_level level}
                       :content-type :json
                       :as           :json})))

--- a/libs/permissions-client/test/permissions_client/core_test.clj
+++ b/libs/permissions-client/test/permissions_client/core_test.clj
@@ -33,7 +33,7 @@
    :headers {"Content-Type" "application/json"}
    :body    (json/encode fake-status)})
 
-(deftest test-status []
+(deftest test-status
   (with-fake-routes {fake-base-url {:get fake-status-response}}
     (is (= (pc/get-status (create-fake-client)) fake-status))))
 
@@ -54,7 +54,7 @@
    :headers {"Content-Type" "application/json"}
    :body    (json/encode fake-subjects)})
 
-(deftest test-subjects []
+(deftest test-subjects
   (with-fake-routes {(fake-url "subjects") {:get fake-subjects-response}}
     (is (= (pc/list-subjects (create-fake-client)) fake-subjects))))
 
@@ -68,7 +68,7 @@
    :headers {"Content-Type" "application/json"}
    :body    (json/encode (fake-subject (json/decode (slurp (:body request)) true)))})
 
-(deftest test-add-subject []
+(deftest test-add-subject
   (with-fake-routes {(fake-url "subjects") {:post add-subject-response}}
     (is (= (pc/add-subject (create-fake-client) "ipctest" "user")
            (fake-subject {:subject_id "ipctest" :subject_type "user"})))))
@@ -79,7 +79,7 @@
       {:status 200 :body ""}
       {:status 400 :body ""})))
 
-(deftest test-delete-subject []
+(deftest test-delete-subject
   (let [subject-id "54430509-794e-497e-8ccd-ba01c713ef9f"]
     (with-fake-routes {(fake-url "subjects" subject-id) {:delete (delete-subject-response-fn subject-id)}}
       (pc/delete-subject (create-fake-client) subject-id)
@@ -91,7 +91,7 @@
       {:status 200 :body (json/encode (assoc (json/decode (slurp body) true) :id id))}
       {:status 400 :body ""})))
 
-(deftest test-update-subject []
+(deftest test-update-subject
   (let [subject (fake-subject {:subject_id "ipcdev" :subject_type "user"})]
     (with-fake-routes {(fake-url "subjects" (:id subject)) {:put (update-subject-response-fn (:id subject))}}
       (is (= (pc/update-subject (create-fake-client) (:id subject) (:subject_id subject) (:subject_type subject))
@@ -113,7 +113,7 @@
    :headers {"Content-Type" "application/json"}
    :body    (json/encode fake-resources)})
 
-(deftest test-list-resources []
+(deftest test-list-resources
   (with-fake-routes {(fake-url "resources") {:get list-resources-response}}
     (is (= (pc/list-resources (create-fake-client)) fake-resources))))
 
@@ -127,7 +127,7 @@
    :headers {"Content-Type" "application/json"}
    :body    (json/encode (fake-resource (json/decode (slurp body) true)))})
 
-(deftest test-add-resource []
+(deftest test-add-resource
   (let [resource (fake-resource {:name "d" :resource_type "analysis"})]
     (with-fake-routes {(fake-url "resources") {:post add-resource-response}}
       (is (= (pc/add-resource (create-fake-client) (:name resource) (:resource_type resource)) resource)))))
@@ -138,7 +138,7 @@
       {:status 200 :body ""}
       {:status 400 :body ""})))
 
-(deftest test-delete-resource []
+(deftest test-delete-resource
   (let [resource-id "20dbf604-a080-4706-acbc-8e65779cf638"]
     (with-fake-routes {(fake-url "resources" resource-id) {:delete (delete-resource-response-fn resource-id)}}
       (pc/delete-resource (create-fake-client) resource-id)
@@ -150,7 +150,7 @@
       {:status 200 :body (json/encode (assoc (json/decode (slurp body) true) :id id :resource_type resource-type))}
       {:status 400 :body ""})))
 
-(deftest test-update-resource []
+(deftest test-update-resource
   (let [{:keys [id name] resource-type :resource_type :as resource} (fake-resource {:name "e" :resource_type "app"})]
     (with-fake-routes {(fake-url "resources" id) (update-resource-response-fn id resource-type)}
       (is (= (pc/update-resource (create-fake-client) id name) resource)))))
@@ -197,7 +197,7 @@
       {:status 200 :body ""}
       {:status 400 :body ""})))
 
-(deftest test-delete-resource-type []
+(deftest test-delete-resource-type
   (let [id "f41c182b-721a-4e6d-94a5-d9db7144ddc7"]
     (with-fake-routes {(fake-url "resource_types" id) (delete-resource-type-response-fn id)}
       (pc/delete-resource-type (create-fake-client) id)
@@ -209,7 +209,7 @@
       {:status 200 :body (json/encode (assoc (json/decode (slurp body) true) :id id))}
       {:status 400 :body ""})))
 
-(deftest test-update-resource-type []
+(deftest test-update-resource-type
   (let [{:keys [id name description] :as resource-type} (fake-resource-type {:name "a" :description "b"})]
     (with-fake-routes {(fake-url "resource_types" id) {:put (update-resource-type-response-fn id)}}
       (is (= (pc/update-resource-type (create-fake-client) id name description) resource-type)))))
@@ -238,7 +238,7 @@
    :headers {"Content-Type" "application/json"}
    :body    (json/encode fake-perms)})
 
-(deftest test-list-perms []
+(deftest test-list-perms
   (with-fake-routes {(fake-url "permissions") {:get list-perms-response}}
     (is (= (pc/list-permissions (create-fake-client)) fake-perms))))
 
@@ -257,38 +257,38 @@
        :body    (json/encode (fake-perm resource-type resource-name subject-type subject-id level))})
     {:status 400 :body ""}))
 
-(deftest test-grant-perm []
+(deftest test-grant-perm
   (let [[rt rn st sn l] ["app" "a" "user" "ipcdev" "own"]]
     (with-fake-routes {(fake-url "permissions" "resources" rt rn "subjects" st sn) {:put grant-perm-response}}
       (is (= (pc/grant-permission (create-fake-client) rt rn st sn l)
              (fake-perm rt rn st sn l))))))
 
-(deftest test-revoke-perm []
+(deftest test-revoke-perm
   (let [[rt rn st sn] ["app" "a" "user" "ipcdev"]]
     (with-fake-routes {(fake-url "permissions" "resources" rt rn "subjects" st sn) {:delete (success-fn)}}
       (pc/revoke-permission (create-fake-client) rt rn st sn)
       (is true "Permission revoked successfully."))))
 
-(deftest test-list-resource-permissions []
+(deftest test-list-resource-permissions
   (let [[rt rn] ["app" "a"]]
     (with-fake-routes {(fake-url "permissions" "resources" rt rn) {:get list-perms-response}}
       (is (= (pc/list-resource-permissions (create-fake-client) rt rn) fake-perms)))))
 
-(deftest test-get-subject-permissions []
+(deftest test-get-subject-permissions
   (let [[st sn] ["user" "ipcdev"]]
     (with-fake-routes {(fake-lookup-url false "permissions" "subjects" st sn) {:get list-perms-response}}
       (is (= (pc/get-subject-permissions (create-fake-client) st sn false) fake-perms)))
     (with-fake-routes {(fake-lookup-url true "permissions" "subjects" st sn) {:get list-perms-response}}
       (is (= (pc/get-subject-permissions (create-fake-client) st sn true) fake-perms)))))
 
-(deftest test-get-subject-permissions-for-resource-type []
+(deftest test-get-subject-permissions-for-resource-type
   (let [[st sn rt] ["user" "ipcdev" "app"]]
     (with-fake-routes {(fake-lookup-url false "permissions" "subjects" st sn rt) {:get list-perms-response}}
       (is (= (pc/get-subject-permissions-for-resource-type (create-fake-client) st sn rt false) fake-perms)))
     (with-fake-routes {(fake-lookup-url true "permissions" "subjects" st sn rt) {:get list-perms-response}}
       (is (= (pc/get-subject-permissions-for-resource-type (create-fake-client) st sn rt true) fake-perms)))))
 
-(deftest test-get-subject-permissions-for-resource []
+(deftest test-get-subject-permissions-for-resource
   (let [[st sn rt rn] ["user" "ipcdev" "app" "a"]]
     (with-fake-routes {(fake-lookup-url false "permissions" "subjects" st sn rt rn) {:get list-perms-response}}
       (is (= (pc/get-subject-permissions-for-resource (create-fake-client) st sn rt rn false) fake-perms)))

--- a/libs/permissions-client/test/permissions_client/core_test.clj
+++ b/libs/permissions-client/test/permissions_client/core_test.clj
@@ -1,0 +1,255 @@
+(ns permissions-client.core-test
+  (:require [permissions-client.core :as pc]
+            [cemerick.url :as curl]
+            [cheshire.core :as json]
+            [clojure.string :as string])
+  (:use [clj-http.fake]
+        [clojure.test]))
+
+(def fake-base-url "http://perms.example.org/")
+
+(defn fake-url [& components]
+  (str (apply curl/url fake-base-url components)))
+
+(defn create-fake-client []
+  (pc/new-permissions-client fake-base-url))
+
+(def fake-status
+  {:description "Manages Permissions for the CyVerse Discovery Environment and related applications."
+   :service     "Permissions Service"
+   :version     "1.2.3.4"})
+
+(defn fake-status-response [_]
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    (json/encode fake-status)})
+
+(deftest test-status []
+  (with-fake-routes {fake-base-url {:get fake-status-response}}
+    (is (= (pc/get-status (create-fake-client)) fake-status))))
+
+(def fake-subjects
+  {:subjects
+   [{:id           "e82a84e7-a5ef-4f2a-9b04-91e3d4888c8e"
+     :subject_id   "ipctest"
+     :subject_type "user"}
+    {:id           "ccb1791d-5681-4df8-8f2d-3d80ff84a338"
+     :subject_id   "1cf8509b-842d-49c9-a455-ca5dac6c2b92"
+     :subject_type "group"}
+    {:id           "bee5df29-a772-4d17-a32a-9957f234a375"
+     :subject_id   "ipcdev"
+     :subject_type "user"}]})
+
+(defn fake-subjects-response [_]
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    (json/encode fake-subjects)})
+
+(deftest test-subjects []
+  (with-fake-routes {(fake-url "subjects") {:get fake-subjects-response}}
+    (is (= (pc/list-subjects (create-fake-client)) fake-subjects))))
+
+(defn fake-subject [{subject-id :subject_id subject-type :subject_type}]
+  {:id           "acefbb43-00fe-4b16-a834-68f24207aba7"
+   :subject_id   subject-id
+   :subject_type subject-type})
+
+(defn add-subject-response [request]
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    (json/encode (fake-subject (json/decode (slurp (:body request)) true)))})
+
+(deftest test-add-subject []
+  (with-fake-routes {(fake-url "subjects") {:post add-subject-response}}
+    (is (= (pc/add-subject (create-fake-client) "ipctest" "user")
+           (fake-subject {:subject_id "ipctest" :subject_type "user"})))))
+
+(defn delete-subject-response-fn [id]
+  (fn [{:keys [uri]}]
+    (if (= id (last (string/split uri #"/")))
+      {:status 200 :body ""}
+      {:status 400 :body ""})))
+
+(deftest test-delete-subject []
+  (let [subject-id "54430509-794e-497e-8ccd-ba01c713ef9f"]
+    (with-fake-routes {(fake-url "subjects" subject-id) {:delete (delete-subject-response-fn subject-id)}}
+      (pc/delete-subject (create-fake-client) subject-id)
+      (is true "Subject deleted successfully."))))
+
+(defn update-subject-response-fn [id]
+  (fn [{:keys [uri body]}]
+    (if (= id (last (string/split uri #"/")))
+      {:status 200 :body (json/encode (assoc (json/decode (slurp body) true) :id id))}
+      {:status 400 :body ""})))
+
+(deftest test-update-subject []
+  (let [subject (fake-subject {:subject_id "ipcdev" :subject_type "user"})]
+    (with-fake-routes {(fake-url "subjects" (:id subject)) {:put (update-subject-response-fn (:id subject))}}
+      (is (= (pc/update-subject (create-fake-client) (:id subject) (:subject_id subject) (:subject_type subject))
+             subject)))))
+
+(def fake-resources
+  [{:id            "b3ae58c3-0d79-416b-a232-0938e7a9b699"
+    :name          "a"
+    :resource_type "app"}
+   {:id            "9a366ab6-0d67-4bba-b1cc-ded2a30929b4"
+    :name          "b"
+    :resource_type "app"}
+   {:id            "2350b289-ab0d-468f-b849-66c0ece7060b"
+    :name          "c"
+    :resource_type "analysis"}])
+
+(defn list-resources-response [_]
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    (json/encode fake-resources)})
+
+(deftest test-list-resources []
+  (with-fake-routes {(fake-url "resources") {:get list-resources-response}}
+    (is (= (pc/list-resources (create-fake-client)) fake-resources))))
+
+(defn fake-resource [{name :name resource-type :resource_type}]
+  {:id            "1aab7522-426a-411b-bef3-1c702ad9e89b"
+   :name          name
+   :resource_type resource-type})
+
+(defn add-resource-response [{:keys [body]}]
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    (json/encode (fake-resource (json/decode (slurp body) true)))})
+
+(deftest test-add-resource []
+  (let [resource (fake-resource {:name "d" :resource_type "analysis"})]
+    (with-fake-routes {(fake-url "resources") {:post add-resource-response}}
+      (is (= (pc/add-resource (create-fake-client) (:name resource) (:resource_type resource)) resource)))))
+
+(defn delete-resource-response-fn [id]
+  (fn [{:keys [uri]}]
+    (if (= id (last (string/split uri #"/")))
+      {:status 200 :body ""}
+      {:status 400 :body ""})))
+
+(deftest test-delete-resource []
+  (let [resource-id "20dbf604-a080-4706-acbc-8e65779cf638"]
+    (with-fake-routes {(fake-url "resources" resource-id) {:delete (delete-resource-response-fn resource-id)}}
+      (pc/delete-resource (create-fake-client) resource-id)
+      (is true "Resource deleted successfully."))))
+
+(defn update-resource-response-fn [id resource-type]
+  (fn [{:keys [uri body]}]
+    (if (= id (last (string/split uri #"/")))
+      {:status 200 :body (json/encode (assoc (json/decode (slurp body) true) :id id :resource_type resource-type))}
+      {:status 400 :body ""})))
+
+(deftest test-update-resource []
+  (let [{:keys [id name] resource-type :resource_type :as resource} (fake-resource {:name "e" :resource_type "app"})]
+    (with-fake-routes {(fake-url "resources" id) (update-resource-response-fn id resource-type)}
+      (is (= (pc/update-resource (create-fake-client) id name) resource)))))
+
+(def fake-resource-types
+  {:resource_types
+   [{:description "A resource type description."
+     :id          "a5ccd2c3-6e19-464f-8525-e108e62998e5"
+     :name        "rtype"}
+    {:description "Another resource type description."
+     :id          "c783abd0-5a91-49f4-82f3-3e2b5d495f59"
+     :name        "artype"}
+    {:description "A resource type description for pirates."
+     :id          "88fc2154-9b83-4a02-bcb4-221273b59f4e"
+     :name        "arrrrrrrtype"}]})
+
+(defn list-resource-types-response [_]
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    (json/encode fake-resource-types)})
+
+(deftest test-list-resource-types
+  (with-fake-routes {(fake-url "resource_types") {:get list-resource-types-response}}
+    (is (= (pc/list-resource-types (create-fake-client)) fake-resource-types))))
+
+(defn fake-resource-type [{:keys [name description]}]
+  {:id          "2bec53ae-4732-4768-86fd-344b9692332f"
+   :name        name
+   :description description})
+
+(defn add-resource-type-response [{:keys [body]}]
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    (json/encode (fake-resource-type (json/decode (slurp body) true)))})
+
+(deftest test-add-resource-type
+  (let [{:keys [name description] :as resource-type} (fake-resource-type {:name "a" :description "b"})]
+    (with-fake-routes {(fake-url "resource_types") {:post add-resource-type-response}}
+      (is (= (pc/add-resource-type (create-fake-client) name description) resource-type)))))
+
+(defn delete-resource-type-response-fn [id]
+  (fn [{:keys [uri]}]
+    (if (= id (last (string/split uri #"/")))
+      {:status 200 :body ""}
+      {:status 400 :body ""})))
+
+(deftest test-delete-resource-type []
+  (let [id "f41c182b-721a-4e6d-94a5-d9db7144ddc7"]
+    (with-fake-routes {(fake-url "resource_types" id) (delete-resource-type-response-fn id)}
+      (pc/delete-resource-type (create-fake-client) id)
+      (is true "Resource type deleted successfully."))))
+
+(defn update-resource-type-response-fn [id]
+  (fn [{:keys [uri body]}]
+    (if (= id (last (string/split uri #"/")))
+      {:status 200 :body (json/encode (assoc (json/decode (slurp body) true) :id id))}
+      {:status 400 :body ""})))
+
+(deftest test-update-resource-type []
+  (let [{:keys [id name description] :as resource-type} (fake-resource-type {:name "a" :description "b"})]
+    (with-fake-routes {(fake-url "resource_types" id) {:put (update-resource-type-response-fn id)}}
+      (is (= (pc/update-resource-type (create-fake-client) id name description) resource-type)))))
+
+(def fake-perms
+  {:permissions
+   [{:id               "b587bbab-4c5f-4adc-baa7-f4ce04690c8e"
+     :permission_level "read"
+     :resource         {:id            "bc689e70-e773-4f1e-8aae-afe61fdaec9e"
+                        :name          "a"
+                        :resource_type "app"}
+     :subject          {:id            "0e49e81b-1de3-4837-9b8b-77065fc946a2"
+                        :name          "ipcdev"
+                        :subject_type  "user"}}
+    {:id               "c36ea831-fa4d-418b-8afb-27a7b8f7d9d6"
+     :permission_level "own"
+     :resource         {:id            "beabd0f7-ac6b-4f5a-9d68-06b1232b3d89"
+                        :name          "a"
+                        :resource_type "app"}
+     :subject          {:id            "2aec85ff-ccda-4e29-b7eb-e4847a10c28c"
+                        :name          "ipcdev"
+                        :subject_type  "user"}}]})
+
+(defn list-perms-response [_]
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    (json/encode fake-perms)})
+
+(deftest test-list-perms []
+  (with-fake-routes {(fake-url "permissions") {:get list-perms-response}}
+    (is (= (pc/list-permissions (create-fake-client)) fake-perms))))
+
+(defn fake-perm [resource-type resource-name subject-type subject-id level]
+  {:id               "e3c73dd4-501f-40b2-9bf4-631b1ca93a89"
+   :permission_level level
+   :resource         (fake-resource {:name resource-name :resource_type resource-type})
+   :subject          (fake-subject {:subject_id subject-id :subject_type subject-type})})
+
+(defn grant-perm-response [{:keys [uri body]}]
+  (if-let [match (re-find #"^/permissions/resources/([^/]+)/([^/]+)/subjects/([^/]+)/([^/]+)" uri)]
+    (let [[_ resource-type resource-name subject-type subject-id] match
+          level (:permission_level (json/decode (slurp body) true))]
+      {:status  200
+       :headers {"Content-Type" "application/json"}
+       :body    (json/encode (fake-perm resource-type resource-name subject-type subject-id level))})
+    {:status 400 :body ""}))
+
+(deftest test-grant-perm []
+  (let [[rt rn st sn l] ["app" "a" "user" "ipcdev" "own"]]
+    (with-fake-routes {(fake-url "permissions" "resources" rt rn "subjects" st sn) {:put grant-perm-response}}
+      (is (= (pc/grant-permission (create-fake-client) "app" "a" "user" "ipcdev" "own")
+             (fake-perm "app" "a" "user" "ipcdev" "own"))))))

--- a/libs/permissions-client/test/permissions_client/integration_test.clj
+++ b/libs/permissions-client/test/permissions_client/integration_test.clj
@@ -4,6 +4,9 @@
 
 (def ^:dynamic base-uri "http://permissions:60000/")
 
+(defn create-permissions-client []
+  (pc/new-permissions-client base-uri))
+
 (defn run-integration-tests [f]
   (when (System/getenv "RUN_INTEGRATION_TESTS")
     (f)))
@@ -14,13 +17,251 @@
       (f))
     (f)))
 
-(use-fixtures :once run-integration-tests with-base-uri)
+(defn add-test-subjects []
+  (let [client (create-permissions-client)]
+    (pc/add-subject client "ipcdev" "user")
+    (pc/add-subject client "ipctest" "user")
+    (pc/add-subject client "ipcusers" "group")))
 
-(defn create-permissions-client []
-  (pc/new-permissions-client base-uri))
+(defn remove-test-subjects []
+  (let [client (create-permissions-client)]
+    (dorun (map (comp (partial pc/delete-subject client) :id)
+                (:subjects (pc/list-subjects client))))))
+
+(defn add-test-resources []
+  (let [client (create-permissions-client)]
+    (pc/add-resource client "a" "app")
+    (pc/add-resource client "b" "app")
+    (pc/add-resource client "C" "analysis")
+    (pc/add-resource client "D" "analysis")))
+
+(defn remove-test-resources []
+  (let [client (create-permissions-client)]
+    (dorun (map (comp (partial pc/delete-resource client) :id)
+                (:resources (pc/list-resources client))))))
+
+(defn remove-test-resource-types []
+  (let [client (create-permissions-client)]
+    (dorun (map (comp (partial pc/delete-resource-type client) :id)
+                (remove (comp #{"app" "analysis"} :name)
+                        (:resource_types (pc/list-resource-types client)))))))
+
+(defn add-test-permissions []
+  (let [client (create-permissions-client)]
+    (pc/grant-permission client "app" "a" "user" "ipcdev" "own")
+    (pc/grant-permission client "app" "b" "user" "ipctest" "write")
+    (pc/grant-permission client "app" "a" "group" "ipcusers" "read")
+    (pc/grant-permission client "app" "b" "group" "ipcusers" "admin")
+    (pc/grant-permission client "analysis" "C" "user" "ipcdev" "own")
+    (pc/grant-permission client "analysis" "D" "user" "ipctest" "own")
+    (pc/grant-permission client "analysis" "C" "group" "ipcusers" "read")))
+
+(defn permission-index
+  [perm]
+  (mapv (partial get-in perm)
+        [[:resource :resource_type] [:resource :name] [:subject :subject_type] [:subject :subject_id]]))
+
+(defn remove-test-permissions []
+  (let [client (create-permissions-client)]
+    (dorun (map (comp (partial apply pc/revoke-permission client) permission-index)
+                (:permissions (pc/list-permissions client))))))
+
+(defn with-test-data [f]
+  (add-test-subjects)
+  (add-test-resources)
+  (add-test-permissions)
+  (f)
+  (remove-test-subjects)
+  (remove-test-resources)
+  (remove-test-resource-types)
+  (remove-test-permissions))
+
+(use-fixtures :each run-integration-tests with-base-uri with-test-data)
 
 (deftest test-get-status
   (let [status-info (pc/get-status (create-permissions-client))]
     (is (:version status-info))
     (is (:service status-info))
     (is (:description status-info))))
+
+(defn get-subject-map
+  ([]
+   (get-subject-map (pc/list-subjects (create-permissions-client))))
+  ([listing]
+   (into {} (map (juxt :subject_id identity) (:subjects listing)))))
+
+(defn subject-correct? [subject subject-id subject-type]
+  (and (:id subject)
+       (= (:subject_id subject) subject-id)
+       (= (:subject_type subject) subject-type)))
+
+(deftest test-list-subjects
+  (let [subjects (get-subject-map)]
+    (is (subject-correct? (subjects "ipcdev") "ipcdev" "user"))
+    (is (subject-correct? (subjects "ipctest") "ipctest" "user"))
+    (is (subject-correct? (subjects "ipcusers") "ipcusers" "group"))))
+
+(deftest test-add-subject
+  (let [client (create-permissions-client)]
+    (is (subject-correct? (pc/add-subject client "dark-helmet" "user") "dark-helmet" "user"))
+    (let [subjects (get-subject-map)]
+      (is (subject-correct? (subjects "dark-helmet") "dark-helmet" "user")))))
+
+(deftest test-delete-subject
+  (let [client (create-permissions-client)
+        ipcdev ((get-subject-map) "ipcdev")]
+    (is (subject-correct? ipcdev "ipcdev" "user"))
+    (pc/delete-subject client (:id ipcdev))
+    (is (nil? ((get-subject-map) "ipcdev")))))
+
+(deftest test-update-subject
+  (let [client   (create-permissions-client)
+        lonestar (pc/add-subject client "lonestar" "user")
+        _        (is (subject-correct? lonestar "lonestar" "user"))
+        lonestar (pc/update-subject client (:id lonestar) "LONEstarrrr" "user")]
+    (is (subject-correct? lonestar "LONEstarrrr" "user"))
+    (is (subject-correct? ((get-subject-map) "LONEstarrrr") "LONEstarrrr" "user"))))
+
+(defn get-resource-map
+  ([]
+   (get-resource-map (pc/list-resources (create-permissions-client))))
+  ([listing]
+   (into {} (map (juxt :name identity) (:resources listing)))))
+
+(defn resource-correct? [resource name resource-type]
+  (and (:id resource)
+       (= (:name resource) name)
+       (= (:resource_type resource) resource-type)))
+
+(deftest test-list-resources
+  (let [resources (get-resource-map)]
+    (is (resource-correct? (resources "a") "a" "app"))
+    (is (resource-correct? (resources "b") "b" "app"))
+    (is (resource-correct? (resources "C") "C" "analysis"))
+    (is (resource-correct? (resources "D") "D" "analysis"))))
+
+(deftest test-add-resource
+  (let [client (create-permissions-client)]
+    (is (resource-correct? (pc/add-resource client "e" "app") "e" "app"))
+    (is (resource-correct? ((get-resource-map) "e") "e" "app"))))
+
+(deftest test-delete-resource
+  (let [client (create-permissions-client)
+        a      ((get-resource-map) "a")]
+    (is (resource-correct? a "a" "app"))
+    (pc/delete-resource client (:id a))
+    (is (nil? ((get-resource-map) "a")))))
+
+(deftest test-update-resource
+  (let [client   (create-permissions-client)
+        mr-radar (pc/add-resource client "mr-radar" "app")
+        _        (is (resource-correct? mr-radar "mr-radar" "app"))
+        mr-radar (pc/update-resource client (:id mr-radar) "bleeps-sweeps-creeps")]
+    (is (resource-correct? mr-radar "bleeps-sweeps-creeps" "app"))
+    (is (resource-correct? ((get-resource-map) "bleeps-sweeps-creeps") "bleeps-sweeps-creeps" "app"))))
+
+(defn get-resource-type-map
+  ([]
+   (get-resource-type-map (pc/list-resource-types (create-permissions-client))))
+  ([listing]
+   (into {} (map (juxt :name identity) (:resource_types listing)))))
+
+(defn resource-type-correct? [resource-type name & [description]]
+  (and (:id resource-type)
+       (= (:name resource-type) name)
+       (if description (= (:description resource-type) description) true)))
+
+(deftest test-list-resource-types
+  (let [rts (get-resource-type-map)]
+    (is (resource-type-correct? (rts "app") "app"))
+    (is (resource-type-correct? (rts "analysis") "analysis"))))
+
+(deftest test-add-resource-type
+  (let [client (create-permissions-client)]
+    (is (resource-type-correct? (pc/add-resource-type client "mog" "half-man-half-dog") "mog" "half-man-half-dog"))
+    (is (resource-type-correct? ((get-resource-type-map) "mog") "mog" "half-man-half-dog"))))
+
+(deftest test-delete-resource-type
+  (let [client (create-permissions-client)
+        mog    (pc/add-resource-type client "mog" "half-man-half-dog")]
+    (is (resource-type-correct? mog "mog" "half-man-half-dog"))
+    (pc/delete-resource-type client (:id mog))
+    (is (nil? ((get-resource-type-map) "mog")))))
+
+(deftest test-update-resource-type
+  (let [client (create-permissions-client)
+        mog    (pc/add-resource-type client "mog" "half-man-half-dog")
+        _      (is (resource-type-correct? mog "mog" "half-man-half-dog"))
+        mog    (pc/update-resource-type client (:id mog) "mog" "own-best-friend")]
+    (is (resource-type-correct? mog "mog" "own-best-friend"))
+    (is (resource-type-correct? ((get-resource-type-map) "mog") "mog" "own-best-friend"))))
+
+(defn get-permission-map
+  ([]
+   (get-permission-map (pc/list-permissions (create-permissions-client))))
+  ([listing]
+   (into {} (map (juxt permission-index identity) (:permissions listing)))))
+
+(defn get-perm [permissions-map rt rn st sn]
+  (permissions-map [rt rn st sn]))
+
+(defn permission-correct? [perm rt rn st sn l]
+  (and (:id perm)
+       (resource-correct? (:resource perm) rn rt)
+       (subject-correct? (:subject perm) sn st)
+       (= (:permission_level perm) l)))
+
+(defn looked-up-permission-correct? [perms rt rn st sn l]
+  (permission-correct? (get-perm perms rt rn st sn) rt rn st sn l))
+
+(deftest test-list-perms
+  (let [perms (get-permission-map)]
+    (is (looked-up-permission-correct? perms "app" "a" "user" "ipcdev" "own"))
+    (is (looked-up-permission-correct? perms "app" "b" "user" "ipctest" "write"))
+    (is (looked-up-permission-correct? perms "app" "a" "group" "ipcusers" "read"))
+    (is (looked-up-permission-correct? perms "app" "b" "group" "ipcusers" "admin"))
+    (is (looked-up-permission-correct? perms "analysis" "C" "user" "ipcdev" "own"))
+    (is (looked-up-permission-correct? perms "analysis" "D" "user" "ipctest" "own"))
+    (is (looked-up-permission-correct? perms "analysis" "C" "group" "ipcusers" "read"))))
+
+(deftest test-grant-perm
+  (let [client (create-permissions-client)
+        perm   (pc/grant-permission client "app" "mr-radar" "user" "dark-helmet" "read")]
+    (is (permission-correct? perm "app" "mr-radar" "user" "dark-helmet" "read"))
+    (is (looked-up-permission-correct? (get-permission-map) "app" "mr-radar" "user" "dark-helmet" "read"))))
+
+(deftest test-revoke-perm
+  (let [client (create-permissions-client)
+        perm   (pc/grant-permission client "app" "mr-radar" "user" "vespa" "read")]
+    (looked-up-permission-correct? (get-permission-map) "app" "mr-radar" "user" "vespa" "read")
+    (pc/revoke-permission client "app" "mr-radar" "user" "vespa")
+    (is (nil? (get-perm (get-permission-map) "app" "mr-radar" "user" "vespa")))))
+
+(deftest test-list-resource-perms
+  (let [client (create-permissions-client)
+        perms  (get-permission-map (pc/list-resource-permissions client "app" "a"))]
+    (is (= (count perms) 2))
+    (is (looked-up-permission-correct? perms "app" "a" "user" "ipcdev" "own"))
+    (is (looked-up-permission-correct? perms "app" "a" "group" "ipcusers" "read"))))
+
+(deftest test-get-subject-permissions
+  (let [client (create-permissions-client)
+        perms  (get-permission-map (pc/get-subject-permissions client "user" "ipcdev" false))]
+    (is (= (count perms) 2))
+    (is (looked-up-permission-correct? perms "app" "a" "user" "ipcdev" "own"))
+    (is (looked-up-permission-correct? perms "analysis" "C" "user" "ipcdev" "own"))))
+
+(deftest test-get-subject-permissions-for-resource-type
+  (let [client (create-permissions-client)
+        resp   (pc/get-subject-permissions-for-resource-type client "group" "ipcusers" "app" true)
+        perms  (get-permission-map resp)]
+    (is (= (count perms) 2))
+    (is (looked-up-permission-correct? perms "app" "a" "group" "ipcusers" "read"))
+    (is (looked-up-permission-correct? perms "app" "b" "group" "ipcusers" "admin"))))
+
+(deftest test-get-subject-permissions-for-resource
+  (let [client (create-permissions-client)
+        resp   (pc/get-subject-permissions-for-resource client "group" "ipcusers" "app" "a" true)
+        perms  (get-permission-map resp)]
+    (is (= (count perms) 1))
+    (is (looked-up-permission-correct? perms "app" "a" "group" "ipcusers" "read"))))

--- a/libs/permissions-client/test/permissions_client/integration_test.clj
+++ b/libs/permissions-client/test/permissions_client/integration_test.clj
@@ -1,0 +1,26 @@
+(ns permissions-client.integration-test
+  (:require [permissions-client.core :as pc])
+  (:use [clojure.test]))
+
+(def ^:dynamic base-uri "http://permissions:60000/")
+
+(defn run-integration-tests [f]
+  (when (System/getenv "RUN_INTEGRATION_TESTS")
+    (f)))
+
+(defn with-base-uri [f]
+  (if-let [uri (System/getenv "PERMISSIONS_BASE_URI")]
+    (binding [base-uri uri]
+      (f))
+    (f)))
+
+(use-fixtures :once run-integration-tests with-base-uri)
+
+(defn create-permissions-client []
+  (pc/new-permissions-client base-uri))
+
+(deftest test-get-status
+  (let [status-info (pc/get-status (create-permissions-client))]
+    (is (:version status-info))
+    (is (:service status-info))
+    (is (:description status-info))))


### PR DESCRIPTION
This change adds a client library for the permissions service. The testing for this is fairly thorough in that it attempts to verify that client correctly constructs all URIs and returns results in the appropriate format. An exhaustive test of all permissions service features is not done here. That level of detail is left to the permissions service integration tests.

Here's an integration test running against an instance of the permissions service running on my workstation:

```
$ RUN_INTEGRATION_TESTS=1 PERMISSIONS_BASE_URI=http://localhost:60000/ lein test

lein test permissions-client.core-test

lein test permissions-client.integration-test

Ran 40 tests containing 77 assertions.
0 failures, 0 errors.
```

*Warning:* do not attempt to run these integration tests against an existing permissions service instance. Doing so will erase all permissions information.

The unit tests can be run independently by not setting the `RUN_INTEGRATION_TESTS` environment variable:

```
$ lein test

lein test permissions-client.core-test

lein test permissions-client.integration-test

Ran 20 tests containing 23 assertions.
0 failures, 0 errors.
```
