### PR TITLE
time_limit_seconds and restricted fields are available through tools …

### DIFF
--- a/services/apps/src/apps/persistence/app_metadata.clj
+++ b/services/apps/src/apps/persistence/app_metadata.clj
@@ -48,6 +48,8 @@
                      :location
                      :version
                      :integration_data_id
+                     :restricted
+                     :time_limit_seconds
                      :tool_type_id]))
 
 (defn- filter-valid-task-values

--- a/services/apps/src/apps/routes/domain/tool.clj
+++ b/services/apps/src/apps/routes/domain/tool.clj
@@ -12,6 +12,8 @@
 (def AttributionParam (describe String "The Tool's author or publisher"))
 (def SubmittedByParam (describe String "The username of the user that submitted the Tool Request"))
 (def ToolImplementationDocs "Information about the user who integrated the Tool into the DE")
+(def ToolRestricted (describe Boolean "Determines whether a time limit is applied and whether network access is granted"))
+(def ToolTimeLimit (describe Integer "The number of seconds that a tool is allowed to execute. A value of 0 means the time limit is disabled."))
 
 (defschema ToolUpdateParams
   (merge SecuredQueryParams
@@ -29,13 +31,15 @@
    :test              (describe ToolTestData "The test data for the Tool")})
 
 (defschema Tool
-  {:id                         ToolIdParam
-   :name                       ToolNameParam
-   (optional-key :description) ToolDescriptionParam
-   (optional-key :attribution) AttributionParam
-   :location                   (describe String "The path of the directory containing the Tool")
-   (optional-key :version)     VersionParam
-   :type                       (describe String "The Tool Type name")})
+  {:id                                ToolIdParam
+   :name                              ToolNameParam
+   (optional-key :description)        ToolDescriptionParam
+   (optional-key :attribution)        AttributionParam
+   :location                          (describe String "The path of the directory containing the Tool")
+   (optional-key :version)            VersionParam
+   :type                              (describe String "The Tool Type name")
+   (optional-key :restricted)         ToolRestricted
+   (optional-key :time_limit_seconds) ToolTimeLimit})
 
 (defschema ToolDetails
   (merge Tool

--- a/services/apps/src/apps/tools.clj
+++ b/services/apps/src/apps/tools.clj
@@ -44,7 +44,9 @@
                [:tools.location :location]
                [:tool_types.name :type]
                [:tools.version :version]
-               [:tools.attribution :attribution])
+               [:tools.attribution :attribution]
+               [:tools.restricted :restricted]
+               [:tools.time_limit_seconds :time_limit_seconds])
        (join tool_types)))
   ([{search-term :search :keys [sort-field sort-dir limit offset include-hidden]
                          :or {include-hidden false}}]

--- a/services/apps/test/apps/tools_test.clj
+++ b/services/apps/test/apps/tools_test.clj
@@ -1,0 +1,40 @@
+(ns apps.tools-test
+  (:use [clojure.test]
+        [apps.tools]
+        [korma.db]
+        [korma.core]
+        [kameleon.entities])
+  (:require [korma.core :as sql]))
+
+(defdb testdb
+  (postgres {:db "de"
+             :user "de"
+             :password "notprod"
+             :host (System/getenv "POSTGRES_PORT_5432_TCP_ADDR")
+             :port (System/getenv "POSTGRES_PORT_5432_TCP_PORT")
+             :delimiters ""}))
+
+(deftest test-get-tool
+  (let [tool-map (first (select tools (where {:name "notreal"})))]
+    (testing "(get-tool) returns the right tool"
+      (let [tool-id        (:id tool-map)
+            retrieved-tool (get-tool tool-id)]
+        (is (= tool-id (:id retrieved-tool)))
+        (is (contains? retrieved-tool :restricted))
+        (is (contains? retrieved-tool :time_limit_seconds))
+        (is (= (:restricted retrieved-tool) false))
+        (is (= (:time_limit_seconds retrieved-tool) 0))))))
+
+(deftest test-update-tool
+  (let [tool-map (first (select tools (where {:name "notreal"})))]
+    (testing "(update-tool) actually updates the tool"
+      (let [tool-id      (:id tool-map)
+            updated-tool (update-tool false (-> tool-map
+                                               (assoc :restricted true)
+                                               (assoc :time_limit_seconds 10)))]
+        (is (= tool-id (:id updated-tool)))
+        (is (contains? updated-tool :restricted))
+        (is (contains? updated-tool :time_limit_seconds))
+        (is (:restricted updated-tool))
+        (is (= (:time_limit_seconds updated-tool) 10))
+        (update-tool false tool-map)))))


### PR DESCRIPTION
…API.

The apps services's tools API has been updated to allow the GET tools/:tool-id endpoint to return the time_limit_seconds and restricted fields. The PATCH /admin/tools/:tool-id endpoint has been updated to enable updating the same fields.

This was tested with the new integration tests added in the test/apps/tools_test.clj file and through the swagger interface that I ran after building the apps service locally and running it with Docker against our integration test environment.