### PR TITLE
CORE-7681 Update metadata csv-parser to no longer add iRODS AVUs.

### DIFF
--- a/services/data-info/src/data_info/routes/avus.clj
+++ b/services/data-info/src/data_info/routes/avus.clj
@@ -117,4 +117,38 @@
 (get-endpoint-delegate-block
   "metadata"
   "POST /avus/{target-type}/{target-id}/copy"))
-           (svc/trap uri meta/metadata-copy user force data-id destination_ids))))
+      (svc/trap uri meta/metadata-copy user force data-id destination_ids))
+
+    (POST* "/metadata/csv-parser" [:as {uri :uri}]
+      :query [params MetadataCSVParseParams]
+      :return MetadataCSVParseResult
+      :middlewares [wrap-metadata-base-url]
+      :summary "Add Batch Metadata from CSV File"
+      :description
+           (str "This endpoint will parse a CSV/TSV file of metadata to apply to data items.
+            The first column of the source file defines absolute or relative paths to items in the data store.
+            Relative paths in the first column are expected to exist under the path for the given `data-id`.
+            The remaining columns define the metadata to apply to each path in the first column,
+            with attribute names listed in the first row,
+            and the target paths and attribute values listed in the remaining rows.
+
+#### Request File Format
+
+    paths,            attribute 1, ..., attribute n
+    /absolute/path-1, value 1,     ..., value n
+    /absolute/path-n, value 1,     ..., value n
+    relative/path-1,  value 1,     ..., value n
+    relative/path-n,  value 1,     ..., value n
+
+For example (formatted in a table):
+
+target paths | template_item | template_institution | template_department | template_postal_code | test-attr-1 | test-attr-2 | test-attr-3
+---|---|---|---|---|---|---|---
+library1/fake.1.fastq.gz | fake-1 | UofA | CyVerse | 85719 | test-val-1 | test-val-2 | test-val-3
+/iplant/home/ipcuser/target-folder/library2/fake.2.fastq.gz | fake-2 | UofA | CyVerse | 85719 | test-val-1 | test-val-2 | test-val-3
+library1 | lib-1 | UofA | CyVerse | 85719 | test-val-1 | test-val-2 | test-val-3"
+(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED")
+(get-endpoint-delegate-block
+  "metadata"
+  "POST /avus/{target-type}/{target-id}"))
+      (svc/trap uri meta/parse-metadata-csv-file data-id params))))

--- a/services/data-info/src/data_info/routes/domain/avus.clj
+++ b/services/data-info/src/data_info/routes/domain/avus.clj
@@ -52,3 +52,21 @@
   (merge StandardUserQueryParams
          {:src   (describe String "The metadata source item's path")
           :paths (describe [String] "The list of paths to which metadata was copied")}))
+
+(s/defschema MetadataCSVParseParams
+  (merge StandardUserQueryParams
+         {:src
+          (describe String "Path to the CSV source file in IRODS")
+
+          (s/optional-key :separator)
+          (describe String
+                    "URL encoded separator character to use for parsing the CSV/TSV file.
+                     Comma (%2C) by default")}))
+
+(s/defschema MetadataCSVParseResultItem
+  {:path (describe NonBlankString "The iRODS path of the item where the metadata was applied")
+   :avus (describe [AVUMap] "The list of parsed AVUs applied to this data item")})
+
+(s/defschema MetadataCSVParseResult
+  {:path-metadata (describe [MetadataCSVParseResultItem]
+                            "The list of paths and their metadata that was parsed from the CSV file")})

--- a/services/data-info/src/data_info/services/page_tabular.clj
+++ b/services/data-info/src/data_info/services/page_tabular.clj
@@ -9,15 +9,19 @@
             [cemerick.url :as url]
             [clojure.string :as string]
             [clojure-commons.file-utils :as ft]
-            [cheshire.core :as json]
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [data-info.services.uuids :as uuids]
             [data-info.util.logging :as dul]
             [data-info.util.config :as cfg]
             [data-info.util.validators :as validators])
-  (:import [au.com.bytecode.opencsv CSVReader]))
+  (:import [au.com.bytecode.opencsv CSVReader]
+           [java.io InputStream]))
 
 (def ^:private ^String line-ending "\n")
+
+(defn read-csv-stream
+  [^String separator ^InputStream stream]
+  (.readAll (CSVReader. stream (.charAt separator 0))))
 
 (defn- chunk-start
   [page chunk-size]
@@ -62,7 +66,7 @@
     (let [ba  (java.io.ByteArrayInputStream. (.getBytes csv-str))
           isr (java.io.InputStreamReader. ba "UTF-8")]
       (map fix-record (mapv #(zipmap (mapv str (range (count %1))) %1)
-                           (mapv vec (.readAll (CSVReader. isr (.charAt separator 0)))))))
+                           (mapv vec (read-csv-stream separator isr)))))
     [{}]))
 
 (defn- num-pages

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -218,6 +218,12 @@
                        (json/encode copy-request)
                        (remove-vals nil? {:force force}))))
 
+(defn metadata-csv-parser
+  [user path-uuid params]
+  (request :post ["data" path-uuid "metadata" "csv-parser"]
+           (mk-req-map user
+                       (remove-vals nil? (select-keys params [:src :separator])))))
+
 (defn admin-add-avus
   "Add AVUs, allowing administrative AVUs to be included, for a data item."
   [user path-uuid avu-map]

--- a/services/terrain/src/terrain/services/filesystem/metadata.clj
+++ b/services/terrain/src/terrain/services/filesystem/metadata.clj
@@ -15,26 +15,6 @@
             [terrain.services.filesystem.validators :as validators]
             [terrain.util.service :as service]))
 
-(defn- service-response->json
-  [response]
-  (->> response :body service/decode-json))
-
-(defn- find-attributes
-  [attrs user uuid]
-  (let [{:keys [irods-avus path]} (data/get-metadata-json user uuid)
-        matching-avus (filter #(contains? attrs (:attr %)) irods-avus)]
-    (if-not (empty? matching-avus)
-      {:path path
-       :avus matching-avus}
-      nil)))
-
-(defn- validate-batch-add-attrs
-  "Throws an error if any of the given paths already have metadata set with any of the given attrs."
-  [user uuids attrs]
-  (let [duplicates (remove nil? (map (partial find-attributes attrs user) uuids))]
-    (when-not (empty? duplicates)
-      (validators/duplicate-attrs-error duplicates))))
-
 (defn do-metadata-get
   "Entrypoint for the API."
   [{user :user} data-id]
@@ -86,100 +66,16 @@
 
 (with-post-hook! #'do-metadata-save (log-func "do-metadata-save"))
 
-;; FIXME: The logic coordinating data-info endpoints with the metadata service should be migrated down into data-info
-(defn- bulk-add-file-avus
-  "Applies metadata from a list of attributes and values to the given path.
-   If an AVU's attribute is found in the given template-attrs map, then that AVU is stored in the
-   metadata db; all other AVUs are stored in IRODS."
-  [user template-attrs attrs [path path-info] values]
-  (let [avus (map (partial zipmap [:attr :value :unit]) (map vector attrs values (repeat "")))
-        template-attr? #(contains? template-attrs (:attr %))
-        [template-avus irods-avus] ((juxt filter remove) template-attr? avus)
-        metadata {:metadata   {:avus template-avus}
-                  :irods-avus irods-avus}]
-    (when-not (and (empty? template-avus) (empty? irods-avus))
-      (data-raw/add-avus user (get path-info "id") metadata))
-    (merge {:path path} metadata)))
-
-(defn- parse-template-attrs
-  "Fetches Metadata Template attributes from the metadata service if given a template-id UUID.
-   Returns a set of the attribute names."
-  [template-id]
-  (when template-id
-    (->> (metadata/get-template template-id)
-         :attributes
-         (map :name)
-         set)))
-
-(defn- format-csv-metadata-filename
-  [dest-dir ^String filename]
-  (ft/rm-last-slash
-    (if (.startsWith filename "/")
-      filename
-      (ft/path-join dest-dir filename))))
-
-(defn- bulk-add-avus
-  "Applies metadata from a list of attributes and filename/values to those files found under
-   dest-dir."
-  [user dest-dir force? template-attrs attrs csv-filename-values]
-  (let [format-path (partial format-csv-metadata-filename dest-dir)
-        paths (map (comp format-path first) csv-filename-values)
-        path-info-map (-> (data-raw/collect-stats user :paths paths :validation-behavior "write") :body json/decode (get "paths"))
-        value-lists (map rest csv-filename-values)
-        irods-attrs (clojure.set/difference (set attrs) template-attrs)]
-    (if-not force?
-      (validate-batch-add-attrs user (map #(get-in path-info-map [% "id"]) paths) irods-attrs))
-  (mapv (partial bulk-add-file-avus user template-attrs attrs)
-    path-info-map value-lists)))
-
-(defn- keyword-to-int [kw] (Integer/parseInt (name kw)))
-
-(defn- deparse-csv-line
-  [line]
-  (mapv (comp string/trim second) (into (sorted-map-by #(< (keyword-to-int %1) (keyword-to-int %2))) line)))
-
-(defn- get-csv
-  [user src separator]
-  (let [path-uuid (data/uuid-for-path user src)
-        chunk-size 1048576 ;; This corresponds to the largest size allowed by the UI's viewer, 1024KB.
-                           ;; It could probably be larger without issue, but this is the expected largest
-                           ;; value for the underlying endpoint in practice. Ideally, it'll never matter
-                           ;; and everything will fit in one page.
-        get-page  (fn [page] (service-response->json (data-raw/read-tabular-chunk user path-uuid separator page chunk-size)))]
-    (loop [page 1 max-pages nil csv []]
-      (let [{max-pages :number-pages new-csv :csv :as res} (get-page page)
-            csv (concat csv (map deparse-csv-line (remove empty? new-csv)))]
-        (if (< page (Integer/parseInt max-pages))
-            (recur (+ page 1) (Integer/parseInt max-pages) csv)
-            csv)))))
-
-(defn- parse-metadata-csv
-  "Parses filenames and metadata to apply from a CSV file input stream.
-   If a template-id is provided, then AVUs with template attributes are stored in the metadata db,
-   and all other AVUs are stored in IRODS."
-  [user dest-dir force? template-id ^String separator src]
-  (let [csv (get-csv user src separator)
-        attrs (-> csv first rest)
-        csv-filename-values (rest csv)
-        template-attrs (parse-template-attrs template-id)]
-    {:path-metadata
-     (bulk-add-avus user dest-dir force? template-attrs attrs csv-filename-values)}))
-
 (defn parse-metadata-csv-file
-  "Parses filenames and metadata to apply from a source CSV file in the data store"
-  [{:keys [user]} {:keys [src dest force template-id separator] :or {separator "%2C"}}]
-  (service/success-response
-    (parse-metadata-csv user dest
-      (Boolean/parseBoolean force)
-      (uuidify template-id)
-      separator
-      src)))
+  "Forwards request to data-info service by looking up the target data-id from the `dest` param."
+  [{:keys [user]} {:keys [dest] :as params}]
+  (let [dest-id (data/uuid-for-path user dest)]
+    (data-raw/metadata-csv-parser user dest-id params)))
 
 (with-pre-hook! #'parse-metadata-csv-file
   (fn [user-info params]
     (log-call "parse-metadata-csv-file" user-info params)
     (validate-map user-info {:user string?})
-    (validate-map params {:src string?
-                          :dest string?})))
+    (validate-map params {:dest string?})))
 
 (with-post-hook! #'parse-metadata-csv-file (log-func "parse-metadata-csv-file"))

--- a/services/terrain/src/terrain/services/filesystem/validators.clj
+++ b/services/terrain/src/terrain/services/filesystem/validators.clj
@@ -176,10 +176,3 @@
   (when (some #(ticket? cm (:username cm) %) ticket-ids)
     (throw+ {:ticket-ids (filterv #(ticket? cm (:username cm) %) ticket-ids)
              :error_code ERR_TICKET_EXISTS})))
-
-(defn duplicate-attrs-error
-  "Throws an ERR_NOT_UNIQUE error with the given duplicates list."
-  [duplicates]
-  (throw+ {:error_code ERR_NOT_UNIQUE
-           :message    "Some paths already have metadata with some of the given attributes."
-           :duplicates duplicates}))


### PR DESCRIPTION
This change also migrates the csv-parser logic into a new `POST /data/:data-id/metadata/csv-parser` endpoint in the data-info service, which no longer requires the `template-id` or `force` parameters.

The `force` parameter is no longer required since AVUs with duplicate attributes (but different values) are now allowed by the metadata service.
