### PR TITLE
CORE-7653 Script Tag Failure error

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/presenter/BelphegorPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/presenter/BelphegorPresenterImpl.java
@@ -1,23 +1,33 @@
 package org.iplantc.de.admin.desktop.client.presenter;
 
 import org.iplantc.de.admin.desktop.client.views.BelphegorView;
+import org.iplantc.de.client.events.EventBus;
+import org.iplantc.de.shared.events.UserLoggedOutEvent;
 
+
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.inject.Inject;
 
-public class BelphegorPresenterImpl implements BelphegorView.Presenter {
+public class BelphegorPresenterImpl implements BelphegorView.Presenter,
+                                               UserLoggedOutEvent.UserLoggedOutEventHandler {
 
     private final BelphegorView view;
 
     @Inject
     public BelphegorPresenterImpl(BelphegorView view) {
         this.view = view;
+        EventBus.getInstance().addHandler(UserLoggedOutEvent.TYPE, this);
     }
 
     @Override
     public void go(HasWidgets hasWidgets) {
-
-        hasWidgets.add(view.asWidget());
+       hasWidgets.add(view.asWidget());
     }
 
+    @Override
+    public void OnLoggedOut(UserLoggedOutEvent event) {
+        GWT.log("belphegor on logged out...");
+        view.doLogout();
+    }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/presenter/ToolAdminPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/presenter/ToolAdminPresenterImpl.java
@@ -19,8 +19,8 @@ import org.iplantc.de.client.models.tool.ToolList;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.inject.Inject;
@@ -47,8 +47,8 @@ public class ToolAdminPresenterImpl implements ToolAdminView.Presenter,
     private final ToolAdminView.ToolAdminViewAppearance appearance;
     private final ListStore<Tool> listStore;
     @Inject IplantAnnouncer announcer;
-    @Inject AsyncProvider<OverwriteToolDialog> overwriteAppDialog;
-    @Inject AsyncProvider<DeleteToolDialog> deleteAppDialog;
+    @Inject AsyncProviderWrapper<OverwriteToolDialog> overwriteAppDialog;
+    @Inject AsyncProviderWrapper<DeleteToolDialog> deleteAppDialog;
 
     @Inject
     public ToolAdminPresenterImpl(final ToolAdminViewFactory viewFactory,

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/ToolAdminViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/ToolAdminViewImpl.java
@@ -11,13 +11,13 @@ import org.iplantc.de.admin.desktop.client.toolAdmin.view.dialogs.ToolAdminDetai
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.tool.Tool;
 import org.iplantc.de.commons.client.ErrorHandler;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
@@ -86,7 +86,7 @@ public class ToolAdminViewImpl extends Composite implements ToolAdminView {
     @UiField TextField filterField;
     @UiField(provided = true) ListStore<Tool> listStore;
     @UiField(provided = true) ToolAdminViewAppearance appearance;
-    @Inject AsyncProvider<ToolAdminDetailsDialog> toolDetailsDialog;
+    @Inject AsyncProviderWrapper<ToolAdminDetailsDialog> toolDetailsDialog;
 
     private final ToolProperties toolProps;
     private final NameFilter nameFilter;

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorView.java
@@ -57,4 +57,6 @@ public interface BelphegorView extends IsWidget {
 
         String footer();
     }
+
+    void doLogout();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorViewImpl.java
@@ -120,7 +120,7 @@ public class BelphegorViewImpl extends Composite implements BelphegorView {
         userMenu.add(new IPlantAnchor(appearance.logout(), -1, new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
-                Window.Location.assign(appearance.logoutWindowUrl());
+                doLogout();
             }
         }));
 
@@ -160,5 +160,10 @@ public class BelphegorViewImpl extends Composite implements BelphegorView {
 
         permIdPanel.ensureDebugId(baseID + Belphegor.Ids.PERMID);
         permIdPresenter.setViewDebugId(baseID + Belphegor.Ids.PERMID);
+    }
+
+    @Override
+    public void doLogout() {
+        Window.Location.assign(appearance.logoutWindowUrl());
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/parameters/AnalysisParametersPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/parameters/AnalysisParametersPresenterImpl.java
@@ -1,6 +1,11 @@
 package org.iplantc.de.analysis.client.presenter.parameters;
 
-import static org.iplantc.de.client.models.apps.integration.ArgumentType.*;
+import static org.iplantc.de.client.models.apps.integration.ArgumentType.FileFolderInput;
+import static org.iplantc.de.client.models.apps.integration.ArgumentType.FileInput;
+import static org.iplantc.de.client.models.apps.integration.ArgumentType.FolderInput;
+import static org.iplantc.de.client.models.apps.integration.ArgumentType.Input;
+import static org.iplantc.de.client.models.apps.integration.ArgumentType.MultiFileSelector;
+
 import org.iplantc.de.analysis.client.AnalysisParametersView;
 import org.iplantc.de.analysis.client.events.SaveAnalysisParametersEvent;
 import org.iplantc.de.analysis.client.events.selection.AnalysisParamValueSelectedEvent;
@@ -24,9 +29,9 @@ import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.diskResource.client.events.ShowFilePreviewEvent;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.collect.Lists;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -160,8 +165,8 @@ public class AnalysisParametersPresenterImpl implements AnalysisParametersView.P
         }
     }
 
-    @Inject AsyncProvider<FileEditorServiceFacade> fileEditorServiceAsyncProvider;
-    @Inject AsyncProvider<DiskResourceServiceFacade> diskResourceServiceAsyncProvider;
+    @Inject AsyncProviderWrapper<FileEditorServiceFacade> fileEditorServiceAsyncProvider;
+    @Inject AsyncProviderWrapper<DiskResourceServiceFacade> diskResourceServiceAsyncProvider;
     @Inject AnalysisServiceFacade analysisService;
     @Inject EventBus eventBus;
     @Inject DiskResourceUtil diskResourceUtil;

--- a/ui/de-lib/src/main/java/org/iplantc/de/analysis/client/views/AnalysesToolBarImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/analysis/client/views/AnalysesToolBarImpl.java
@@ -19,6 +19,7 @@ import org.iplantc.de.client.models.analysis.Analysis;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.validators.DiskResourceNameValidator;
 import org.iplantc.de.commons.client.views.dialogs.IPlantPromptDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -28,7 +29,6 @@ import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
@@ -94,8 +94,7 @@ public class AnalysesToolBarImpl extends Composite implements AnalysisToolBarVie
     @UiField(provided = true)
     SimpleComboBox<AnalysisFilter> filterCombo;
 
-    @Inject
-    AsyncProvider<AnalysisParametersDialog> analysisParametersDialogAsyncProvider;
+    @Inject AsyncProviderWrapper<AnalysisParametersDialog> analysisParametersDialogAsyncProvider;
 
     @Inject
     UserInfo userInfo;

--- a/ui/de-lib/src/main/java/org/iplantc/de/analysis/client/views/parameters/AnalysisParametersViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/analysis/client/views/parameters/AnalysisParametersViewImpl.java
@@ -8,10 +8,10 @@ import org.iplantc.de.client.models.IsHideable;
 import org.iplantc.de.client.models.analysis.AnalysisParameter;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.diskResource.client.views.dialogs.SaveAsDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
@@ -51,7 +51,7 @@ public class AnalysisParametersViewImpl extends Composite implements AnalysisPar
     @UiField BorderLayoutData northData;
     @UiField TextButton btnSave;
 
-    @Inject AsyncProvider<SaveAsDialog> saveAsDialogProvider;
+    @Inject AsyncProviderWrapper<SaveAsDialog> saveAsDialogProvider;
 
     @Inject
     AnalysisParametersViewImpl(final AnalysesView.Appearance appearance,

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
@@ -30,10 +30,10 @@ import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -88,7 +88,7 @@ public class AppCategoriesPresenterImpl implements AppCategoriesView.Presenter,
     protected static String WORKSPACE;
     protected String searchRegexPattern;
     @Inject IplantAnnouncer announcer;
-    @Inject AsyncProvider<AppDetailsDialog> appDetailsDlgAsyncProvider;
+    @Inject AsyncProviderWrapper<AppDetailsDialog> appDetailsDlgAsyncProvider;
     @Inject AppServiceFacade appService;
     @Inject AppUserServiceFacade appUserService;
     @Inject AppCategoriesView.AppCategoriesAppearance appearance;

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/grid/AppsGridPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/grid/AppsGridPresenterImpl.java
@@ -27,12 +27,12 @@ import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.comments.view.dialogs.CommentsDialog;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 import org.iplantc.de.shared.exceptions.HttpRedirectException;
 
 import com.google.common.base.Preconditions;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
@@ -60,7 +60,7 @@ public class AppsGridPresenterImpl implements AppsGridView.Presenter,
     @Inject AppServiceFacade appService;
     @Inject AppUserServiceFacade appUserService;
     @Inject AppsGridView.AppsGridAppearance appearance;
-    @Inject AsyncProvider<CommentsDialog> commentsDialogProvider;
+    @Inject AsyncProviderWrapper<CommentsDialog> commentsDialogProvider;
     @Inject AppMetadataServiceFacade metadataFacade;
     @Inject UserInfo userInfo;
     private final EventBus eventBus;

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/dialogs/AppDetailsDialog.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/dialogs/AppDetailsDialog.java
@@ -7,8 +7,8 @@ import org.iplantc.de.apps.client.events.selection.AppRatingSelected;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
@@ -19,7 +19,7 @@ import java.util.List;
  */
 public class AppDetailsDialog extends IPlantDialog {
 
-    @Inject AsyncProvider<AppDetailsView.Presenter> presenterProvider;
+    @Inject AsyncProviderWrapper<AppDetailsView.Presenter> presenterProvider;
 
     @Inject
     AppDetailsDialog() {

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
@@ -23,13 +23,13 @@ import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.diskResources.PermissionValue;
 import org.iplantc.de.commons.client.ErrorHandler;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
@@ -98,8 +98,7 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     MenuItem requestTool;
     @UiField
     MenuItem shareCollab, sharePublic;
-    @Inject
-    AsyncProvider<SubmitAppForPublicDialog> submitAppDialogAsyncProvider;
+    @Inject AsyncProviderWrapper<SubmitAppForPublicDialog> submitAppDialogAsyncProvider;
     @UiField
     MenuItem wfRun;
     @UiField

--- a/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -218,7 +218,7 @@ public interface DesktopView extends IsWidget {
 
         void onIntroClick();
 
-        void doLogout();
+        void doLogout(boolean sessionTimeout);
 
         void onSystemMessagesClick();
     }

--- a/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterEventHandler.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterEventHandler.java
@@ -9,8 +9,10 @@ import org.iplantc.de.desktop.client.DesktopView;
 import org.iplantc.de.diskResource.client.events.DefaultUploadCompleteHandler;
 import org.iplantc.de.diskResource.client.events.FileUploadedEvent;
 import org.iplantc.de.notifications.client.events.NotificationCountUpdateEvent;
+import org.iplantc.de.shared.events.UserLoggedOutEvent;
 
 import com.google.common.collect.Lists;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.json.client.JSONObject;
 import com.google.inject.Inject;
@@ -25,7 +27,8 @@ import java.util.List;
  */
 public class DesktopPresenterEventHandler implements LastSelectedPathChangedEvent.LastSelectedPathChangedEventHandler,
                                                      NotificationCountUpdateEvent.NotificationCountUpdateEventHandler,
-                                                     FileUploadedEvent.FileUploadedEventHandler {
+                                                     FileUploadedEvent.FileUploadedEventHandler,
+                                                     UserLoggedOutEvent.UserLoggedOutEventHandler {
 
     @Inject EventBus eventBus;
     @Inject UserSessionServiceFacade userSessionService;
@@ -77,5 +80,14 @@ public class DesktopPresenterEventHandler implements LastSelectedPathChangedEven
         handlerRegistrations.add(handlerRegistration);
         handlerRegistration = eventBus.addHandler(NotificationCountUpdateEvent.TYPE, this);
         handlerRegistrations.add(handlerRegistration);
+        handlerRegistration = eventBus.addHandler(UserLoggedOutEvent.TYPE,this);
+        handlerRegistrations.add(handlerRegistration);
+    }
+
+    @Override
+    public void OnLoggedOut(UserLoggedOutEvent event) {
+        GWT.log("logout request received...");
+        presenter.doLogout(true);
+        eventBus.clearHandlers();
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopWindowManager.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopWindowManager.java
@@ -7,11 +7,11 @@ import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
 import org.iplantc.de.desktop.client.views.windows.IPlantWindowInterface;
 import org.iplantc.de.desktop.client.views.windows.util.WindowFactory;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -208,7 +208,7 @@ public class DesktopWindowManager {
      * @param config an object used to uniquely identify a window.
      * @return the window corresponding to the given config, null is the window could not be found.
      */
-    AsyncProvider<? extends IPlantWindowInterface> getOrCreateWindow(final WindowConfig config) {
+    AsyncProviderWrapper<? extends IPlantWindowInterface> getOrCreateWindow(final WindowConfig config) {
         return windowFactory.build(config);
     }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
@@ -366,7 +366,7 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
 
     @UiHandler("logoutBtn")
     void onLogoutClick(ClickEvent event){
-        presenter.doLogout();
+        presenter.doLogout(false);
     }
 
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/util/WindowFactory.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/util/WindowFactory.java
@@ -3,9 +3,20 @@ package org.iplantc.de.desktop.client.views.windows.util;
 import org.iplantc.de.client.DEClientConstants;
 import org.iplantc.de.commons.client.util.WindowUtil;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
-import org.iplantc.de.desktop.client.views.windows.*;
+import org.iplantc.de.desktop.client.views.windows.AboutApplicationWindow;
+import org.iplantc.de.desktop.client.views.windows.AppEditorWindow;
+import org.iplantc.de.desktop.client.views.windows.AppLaunchWindow;
+import org.iplantc.de.desktop.client.views.windows.DEAppsWindow;
+import org.iplantc.de.desktop.client.views.windows.DeDiskResourceWindow;
+import org.iplantc.de.desktop.client.views.windows.FileViewerWindow;
+import org.iplantc.de.desktop.client.views.windows.IPlantWindowInterface;
+import org.iplantc.de.desktop.client.views.windows.MyAnalysesWindow;
+import org.iplantc.de.desktop.client.views.windows.NotificationWindow;
+import org.iplantc.de.desktop.client.views.windows.PipelineEditorWindow;
+import org.iplantc.de.desktop.client.views.windows.SimpleDownloadWindow;
+import org.iplantc.de.desktop.client.views.windows.SystemMessagesWindow;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.inject.Inject;
 
 /**
@@ -17,17 +28,17 @@ public class WindowFactory {
 
     @Inject DEClientConstants constants;
 
-    @Inject AsyncProvider<AboutApplicationWindow> aboutApplicationWindowAsyncProvider;
-    @Inject AsyncProvider<MyAnalysesWindow> analysesWindowAsyncProvider;
-    @Inject AsyncProvider<AppEditorWindow> appEditorWindowAsyncProvider;
-    @Inject AsyncProvider<AppLaunchWindow> appLaunchWindowAsyncProvider;
-    @Inject AsyncProvider<DEAppsWindow> appsWindowAsyncProvider;
-    @Inject AsyncProvider<DeDiskResourceWindow> diskResourceWindowAsyncProvider;
-    @Inject AsyncProvider<FileViewerWindow> fileViewerWindowAsyncProvider;
-    @Inject AsyncProvider<NotificationWindow> notificationWindowAsyncProvider;
-    @Inject AsyncProvider<SimpleDownloadWindow> simpleDownloadWindowAsyncProvider;
-    @Inject AsyncProvider<PipelineEditorWindow> pipelineEditorWindowAsyncProvider;
-    @Inject AsyncProvider<SystemMessagesWindow> systemMessagesWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<AboutApplicationWindow> aboutApplicationWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<MyAnalysesWindow> analysesWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<AppEditorWindow> appEditorWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<AppLaunchWindow> appLaunchWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<DEAppsWindow> appsWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<DeDiskResourceWindow> diskResourceWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<FileViewerWindow> fileViewerWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<NotificationWindow> notificationWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<SimpleDownloadWindow> simpleDownloadWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<PipelineEditorWindow> pipelineEditorWindowAsyncProvider;
+    @Inject AsyncProviderWrapper<SystemMessagesWindow> systemMessagesWindowAsyncProvider;
 
     @Inject
     WindowFactory() { }
@@ -38,8 +49,8 @@ public class WindowFactory {
      * 
      * @return an asynchronous provider for the appropriate window.
      */
-    public <C extends WindowConfig> AsyncProvider<? extends IPlantWindowInterface> build(C config) {
-        AsyncProvider<? extends IPlantWindowInterface> ret = null;
+    public <C extends WindowConfig> AsyncProviderWrapper<? extends IPlantWindowInterface> build(C config) {
+        AsyncProviderWrapper<? extends IPlantWindowInterface> ret = null;
         switch (config.getWindowType()) {
             case ABOUT:
                 ret = aboutApplicationWindowAsyncProvider;

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
@@ -57,10 +57,10 @@ import org.iplantc.de.diskResource.client.views.dialogs.RenameFileDialog;
 import org.iplantc.de.diskResource.client.views.dialogs.RenameFolderDialog;
 import org.iplantc.de.diskResource.client.views.search.DiskResourceSearchField;
 import org.iplantc.de.diskResource.share.DiskResourceModule;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Strings;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -101,7 +101,7 @@ public class DiskResourcePresenterImpl implements
     @Inject DiskResourceView.Presenter.Appearance appearance;
     @Inject DiskResourceServiceFacade diskResourceService;
     @Inject DiskResourceUtil diskResourceUtil;
-    @Inject AsyncProvider<FolderSelectDialog> folderSelectDialogProvider;
+    @Inject AsyncProviderWrapper<FolderSelectDialog> folderSelectDialogProvider;
     @Inject UserInfo userInfo;
     @Inject CommonUiConstants commonUiConstants;
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -55,6 +55,7 @@ import org.iplantc.de.diskResource.client.views.grid.DiskResourceColumnModel;
 import org.iplantc.de.diskResource.client.views.metadata.dialogs.ManageMetadataDialog;
 import org.iplantc.de.diskResource.client.views.sharing.dialogs.DataSharingDialog;
 import org.iplantc.de.diskResource.client.views.sharing.dialogs.ShareResourceLinkDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -63,7 +64,6 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -204,17 +204,16 @@ public class GridViewPresenterImpl implements
     @Inject
     FileSystemMetadataServiceFacade metadataService;
     @Inject
-    AsyncProvider<InfoTypeEditorDialog> infoTypeDialogProvider;
+    AsyncProviderWrapper<InfoTypeEditorDialog> infoTypeDialogProvider;
+    @Inject AsyncProviderWrapper<CommentsDialog> commentDialogProvider;
     @Inject
-    AsyncProvider<CommentsDialog> commentDialogProvider;
+    AsyncProviderWrapper<ManageMetadataDialog> metadataDialogProvider;
     @Inject
-    AsyncProvider<ManageMetadataDialog> metadataDialogProvider;
+    AsyncProviderWrapper<DataSharingDialog> dataSharingDialogProvider;
     @Inject
-    AsyncProvider<DataSharingDialog> dataSharingDialogProvider;
+    AsyncProviderWrapper<ShareResourceLinkDialog> shareLinkDialogProvider;
     @Inject
-    AsyncProvider<ShareResourceLinkDialog> shareLinkDialogProvider;
-    @Inject
-    AsyncProvider<SaveAsDialog> saveAsDialogProvider;
+    AsyncProviderWrapper<SaveAsDialog> saveAsDialogProvider;
     @Inject
     DiskResourceErrorAutoBeanFactory drFactory;
     @Inject

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FileFolderSelectorField.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FileFolderSelectorField.java
@@ -12,12 +12,12 @@ import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.events.LastSelectedPathChangedEvent;
 import org.iplantc.de.diskResource.client.views.dialogs.FileFolderSelectDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.TakesValue;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
@@ -77,8 +77,7 @@ public class FileFolderSelectorField extends AbstractDiskResourceSelector<DiskRe
         }
     }
 
-    @Inject
-    AsyncProvider<FileFolderSelectDialog> fileFolderSelectDialogProvider;
+    @Inject AsyncProviderWrapper<FileFolderSelectDialog> fileFolderSelectDialogProvider;
     @Inject
     UserSettings userSettings;
     @Inject

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FileSelectorField.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FileSelectorField.java
@@ -12,10 +12,10 @@ import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.events.LastSelectedPathChangedEvent;
 import org.iplantc.de.diskResource.client.views.dialogs.FileSelectDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.TakesValue;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
@@ -68,7 +68,7 @@ public class FileSelectorField extends AbstractDiskResourceSelector<File> {
 
     @Inject UserSettings userSettings;
     @Inject EventBus eventBus;
-    @Inject AsyncProvider<FileSelectDialog> fileSelectDialogProvider;
+    @Inject AsyncProviderWrapper<FileSelectDialog> fileSelectDialogProvider;
     @Inject DiskResourceUtil diskResourceUtil;
     @Inject CommonModelUtils commonModelUtils;
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FolderSelectorField.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FolderSelectorField.java
@@ -12,9 +12,9 @@ import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.events.LastSelectedPathChangedEvent;
 import org.iplantc.de.diskResource.client.views.dialogs.FolderSelectDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.TakesValue;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
@@ -65,7 +65,7 @@ public class FolderSelectorField extends AbstractDiskResourceSelector<Folder> {
 
     @Inject UserSettings userSettings;
     @Inject EventBus eventBus;
-    @Inject AsyncProvider<FolderSelectDialog> folderSelectDialogProvider;
+    @Inject AsyncProviderWrapper<FolderSelectDialog> folderSelectDialogProvider;
     @Inject DiskResourceUtil diskResourceUtil;
     @Inject CommonModelUtils commonModelUtils;
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/MultiFileSelectorField.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/MultiFileSelectorField.java
@@ -21,6 +21,7 @@ import org.iplantc.de.diskResource.client.model.DiskResourceProperties;
 import org.iplantc.de.diskResource.client.views.dialogs.FileFolderSelectDialog;
 import org.iplantc.de.diskResource.client.views.dialogs.FileSelectDialog;
 import org.iplantc.de.resources.client.constants.IplantValidationConstants;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -32,7 +33,6 @@ import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -214,10 +214,9 @@ public class MultiFileSelectorField extends Composite implements
     IplantValidationConstants validationConstants;
     @Inject
     EventBus eventBus;
+    @Inject AsyncProviderWrapper<FileSelectDialog> fileSelectDialogProvider;
     @Inject
-    AsyncProvider<FileSelectDialog> fileSelectDialogProvider;
-    @Inject
-    AsyncProvider<FileFolderSelectDialog> fileFolderSelectDialogProvider;
+    AsyncProviderWrapper<FileFolderSelectDialog> fileFolderSelectDialogProvider;
     @Inject
     DiskResourceUtil diskResourceUtil;
     private final boolean allowFolderSelect;

--- a/ui/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
@@ -36,6 +36,7 @@ import org.iplantc.de.fileViewers.client.views.ExternalVisualizationURLViewerImp
 import org.iplantc.de.fileViewers.client.views.SaveAsDialogCancelSelectHandler;
 import org.iplantc.de.fileViewers.client.views.SaveAsDialogOkSelectHandler;
 import org.iplantc.de.fileViewers.client.views.TextViewerImpl;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -43,7 +44,6 @@ import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsonUtils;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
@@ -135,7 +135,7 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
     @Inject CommonModelAutoBeanFactory factory;
     @Inject FileEditorServiceFacade fileEditorService;
     @Inject FileViewer.FileViewerPresenterAppearance appearance;
-    @Inject AsyncProvider<SaveAsDialog> saveAsDialogProvider;
+    @Inject AsyncProviderWrapper<SaveAsDialog> saveAsDialogProvider;
     @Inject UserSessionServiceFacade userSessionService;
     @Inject DiskResourceServiceFacade diskResourceServiceFacade;
     @Inject DiskResourceUtil diskResourceUtil;

--- a/ui/de-lib/src/main/java/org/iplantc/de/shared/AsyncCallbackWrapper.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/shared/AsyncCallbackWrapper.java
@@ -5,7 +5,6 @@ import org.iplantc.de.shared.events.UserLoggedOutEvent;
 import org.iplantc.de.shared.exceptions.AuthenticationException;
 import org.iplantc.de.shared.exceptions.HttpRedirectException;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.rpc.StatusCodeException;
@@ -23,7 +22,6 @@ import java.util.logging.Logger;
  * @param <T> the type of the result we're expecting to get from the server.
  */
 public class AsyncCallbackWrapper<T> implements AsyncCallback<T> {
-    private static final String LANDING_PAGE = "logged-out";
 
     Logger LOG = Logger.getLogger(AsyncCallbackWrapper.class.getName());
     /**
@@ -39,13 +37,6 @@ public class AsyncCallbackWrapper<T> implements AsyncCallback<T> {
 
     public AsyncCallbackWrapper(AsyncCallback<T> callback) {
         this.callback = callback;
-    }
-
-    /**
-     * Redirects the user to the DE landing page.
-     */
-    private void redirectToLandingPage() {
-        Window.Location.replace(GWT.getHostPageBaseURL() + LANDING_PAGE);
     }
 
     /**

--- a/ui/de-lib/src/main/java/org/iplantc/de/shared/AsyncCallbackWrapper.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/shared/AsyncCallbackWrapper.java
@@ -15,9 +15,7 @@ import java.util.logging.Logger;
 
 /**
  * Detects when the user is not logged in to the application and redirects the user to the login page.  Under normal
- * circumstances, we'll receive a 302 status code if the user is not authenticated, but we also have to check for a
- * status code of 0 because GWT doesn't currently return the correct status code.
- *
+ * circumstances, we'll receive a 302 or 401 status code if the user is not authenticated.
  * @author Dennis Roberts
  *
  * @param <T> the type of the result we're expecting to get from the server.
@@ -50,7 +48,7 @@ public class AsyncCallbackWrapper<T> implements AsyncCallback<T> {
 
     /**
      * Called whenever a call to the server fails. If the call failed because of an HTTP status code and
-     * that status code represents a redirect request or wasn't recorded then we assume that the user isn't
+     * that status code represents a redirect request or user was unauthorized, then we assume that the user isn't
      * logged in and redirect the user to the login page. The callback that we're wrapping deals with all
      * other errors.
      *
@@ -63,23 +61,25 @@ public class AsyncCallbackWrapper<T> implements AsyncCallback<T> {
             redirectToLandingPage();
             return;
         }
+
         if (error instanceof StatusCodeException) {
             int statusCode = ((StatusCodeException)error).getStatusCode();
             LOG.log(Level.SEVERE, "Status code: " + statusCode, error);
-            if (statusCode == HttpStatus.SC_MOVED_TEMPORARILY || statusCode == 0) {
+            if (statusCode == HttpStatus.SC_MOVED_TEMPORARILY
+                || statusCode == HttpStatus.SC_UNAUTHORIZED) {
                 redirectToLandingPage();
                 return;
             }
         }
 
-        callback.onFailure(error);
-
         if (error instanceof HttpRedirectException) {
             LOG.log(Level.INFO, "Redirecting to", error);
-            HttpRedirectException e = (HttpRedirectException) error;
+            HttpRedirectException e = (HttpRedirectException)error;
             Window.Location.replace(e.getLocation());
+            return;
         }
 
+        callback.onFailure(error);
     }
 
     /**

--- a/ui/de-lib/src/main/java/org/iplantc/de/shared/AsyncProviderWrapper.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/shared/AsyncProviderWrapper.java
@@ -1,0 +1,55 @@
+package org.iplantc.de.shared;
+
+import org.iplantc.de.client.events.EventBus;
+import org.iplantc.de.shared.events.UserLoggedOutEvent;
+
+import com.google.gwt.inject.client.AsyncProvider;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.inject.Inject;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+
+/**
+ * @author aramsey
+ *
+ * AsyncProviderWrapper should be used in place of AsyncProvider in order to
+ * standardize how we handle failures during the callback.
+ *
+ * AsyncProvider is used to perform code splitting in GWT.  When the code splitting download
+ * fails, like in the case where the user is deauthenticated prior to downloading the code split,
+ * DeCasAuthenticationEntryPoint correctly responds with a 401, but the client needs to handle
+ * the redirect to the landing page properly.
+ *
+ * When the failure happens, note that it's not an AuthenticationException or StatusCodeException,
+ * it's some sort of AsyncFragmentLoader$HttpDownloadFailure that I haven't found a way to explicitly
+ * check for.  If a method is found, you can probably switch from AsyncCallback to AsyncCallbackWrapper
+ * so all failures (RPC, websockets, or code splits) are handled in AsyncCallbackWrapper.
+ *
+ * Also note: it is NOT possible to test out code splitting with SDM running.
+ */
+public class AsyncProviderWrapper<T> {
+
+    Logger LOG = Logger.getLogger(AsyncProviderWrapper.class.getName());
+    
+    @Inject AsyncProvider<T> provider;
+    public AsyncProviderWrapper() {
+
+    }
+
+    public void get(final AsyncCallback callback) {
+        provider.get(new AsyncCallback<T>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                LOG.log(Level.SEVERE, caught.getMessage());
+                EventBus.getInstance().fireEvent(new UserLoggedOutEvent());
+            }
+
+            @Override
+            public void onSuccess(T result) {
+                callback.onSuccess(result);
+            }
+        });
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/shared/events/UserLoggedOutEvent.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/shared/events/UserLoggedOutEvent.java
@@ -1,0 +1,28 @@
+package org.iplantc.de.shared.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * Created by sriram on 6/2/16.
+ */
+public class UserLoggedOutEvent extends GwtEvent<UserLoggedOutEvent.UserLoggedOutEventHandler> {
+
+    public interface UserLoggedOutEventHandler extends EventHandler {
+        void OnLoggedOut(UserLoggedOutEvent event);
+    }
+
+
+    public static final GwtEvent.Type<UserLoggedOutEventHandler> TYPE = new GwtEvent.Type<>();
+
+    @Override
+    public Type<UserLoggedOutEventHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+
+    @Override
+    protected void dispatch(UserLoggedOutEventHandler handler) {
+        handler.OnLoggedOut(this);
+    }
+}

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/toolAdmin/presenter/ToolAdminPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/toolAdmin/presenter/ToolAdminPresenterImplTest.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.admin.desktop.client.toolAdmin.presenter;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -7,8 +8,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
-import static org.junit.Assert.assertEquals;
 
 import org.iplantc.de.admin.desktop.client.toolAdmin.ToolAdminView;
 import org.iplantc.de.admin.desktop.client.toolAdmin.events.AddToolSelectedEvent;
@@ -26,9 +25,9 @@ import org.iplantc.de.client.models.tool.Tool;
 import org.iplantc.de.client.models.tool.ToolAutoBeanFactory;
 import org.iplantc.de.client.models.tool.ToolList;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.collect.Lists;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.web.bindery.autobean.shared.AutoBean;
@@ -64,8 +63,8 @@ public class ToolAdminPresenterImplTest {
     @Mock List<Tool> listToolMock;
     @Mock ListStore<Tool> listStoreToolMock;
     @Mock IplantAnnouncer iplantAnnouncerMock;
-    @Mock AsyncProvider<OverwriteToolDialog> overwriteAppDialogMock;
-    @Mock AsyncProvider<DeleteToolDialog> deleteAppDialogMock;
+    @Mock AsyncProviderWrapper<OverwriteToolDialog> overwriteAppDialogMock;
+    @Mock AsyncProviderWrapper<DeleteToolDialog> deleteAppDialogMock;
 
     @Captor ArgumentCaptor<AsyncCallback<Tool>> asyncCallbackToolCaptor;
     @Captor ArgumentCaptor<AsyncCallback<List<Tool>>> asyncCallbackToolListCaptor;

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/ToolAdminViewImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/ToolAdminViewImplTest.java
@@ -14,8 +14,8 @@ import org.iplantc.de.admin.desktop.client.toolAdmin.events.SaveToolSelectedEven
 import org.iplantc.de.admin.desktop.client.toolAdmin.model.ToolProperties;
 import org.iplantc.de.admin.desktop.client.toolAdmin.view.dialogs.ToolAdminDetailsDialog;
 import org.iplantc.de.client.models.tool.Tool;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwtmockito.GxtMockitoTestRunner;
 
@@ -43,7 +43,7 @@ public class ToolAdminViewImplTest {
     @Mock Grid<Tool> toolGridMock;
     @Mock GridSelectionModel<Tool> gridSelectionModelMock;
     @Mock Tool toolMock;
-    @Mock AsyncProvider<ToolAdminDetailsDialog> toolDetailsDialogMock;
+    @Mock AsyncProviderWrapper<ToolAdminDetailsDialog> toolDetailsDialogMock;
 
     @Captor ArgumentCaptor<AsyncCallback<ToolAdminDetailsDialog>> asyncCallbackDialogCaptor;
     @Captor ArgumentCaptor<SaveToolSelectedEvent.SaveToolSelectedEventHandler>

--- a/ui/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
@@ -1,9 +1,20 @@
 package org.iplantc.de.apps.client.presenter.categories;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.iplantc.de.apps.client.AppCategoriesView;
 import org.iplantc.de.apps.client.events.AppFavoritedEvent;
-import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.AppSavedEvent;
+import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.AppUpdatedEvent;
 import org.iplantc.de.apps.client.events.selection.AppFavoriteSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
@@ -22,10 +33,10 @@ import org.iplantc.de.client.models.apps.integration.AppTemplate;
 import org.iplantc.de.client.services.AppServiceFacade;
 import org.iplantc.de.client.services.AppUserServiceFacade;
 import org.iplantc.de.client.util.JsonUtil;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.event.shared.GwtEvent;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwtmockito.GxtMockitoTestRunner;
 
@@ -37,7 +48,6 @@ import com.sencha.gxt.data.shared.event.StoreRemoveEvent;
 import com.sencha.gxt.widget.core.client.tree.Tree;
 import com.sencha.gxt.widget.core.client.tree.TreeSelectionModel;
 
-import static org.mockito.Mockito.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,7 +89,7 @@ public class AppCategoriesPresenterImplTest {
     @Captor ArgumentCaptor<AsyncCallback<Void>> voidCallbackCaptor;
 
 
-    @Mock AsyncProvider<AppDetailsDialog> mockDetailsProvider;
+    @Mock AsyncProviderWrapper<AppDetailsDialog> mockDetailsProvider;
     @Captor ArgumentCaptor<AsyncCallback<AppDetailsDialog>> detailsCallbackCaptor;
 
     private AppCategoriesPresenterImpl uut;

--- a/ui/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/grid/AppsGridPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/grid/AppsGridPresenterImplTest.java
@@ -1,5 +1,15 @@
 package org.iplantc.de.apps.client.presenter.grid;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.iplantc.de.apps.client.AppsGridView;
 import org.iplantc.de.apps.client.events.AppFavoritedEvent;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
@@ -23,10 +33,10 @@ import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.services.AppMetadataServiceFacade;
 import org.iplantc.de.client.services.AppUserServiceFacade;
 import org.iplantc.de.commons.client.comments.view.dialogs.CommentsDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.event.shared.GwtEvent;
-import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -39,7 +49,6 @@ import com.sencha.gxt.data.shared.event.StoreUpdateEvent;
 import com.sencha.gxt.widget.core.client.grid.Grid;
 import com.sencha.gxt.widget.core.client.grid.GridSelectionModel;
 
-import static org.mockito.Mockito.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,7 +80,7 @@ public class AppsGridPresenterImplTest {
     @Mock UserInfo userInfoMock;
     @Mock AppUserServiceFacade appUserServiceMock;
 
-    @Mock AsyncProvider<CommentsDialog> commentsProviderMock;
+    @Mock AsyncProviderWrapper<CommentsDialog> commentsProviderMock;
     @Captor ArgumentCaptor<AsyncCallback<CommentsDialog>> commentsDlgCaptor;
 
     @Captor ArgumentCaptor<AsyncCallback<String>> stringCallbackCaptor;

--- a/ui/de-webapp/src/main/java/org/iplantc/de/conf/AdminWebSecurityConfig.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/conf/AdminWebSecurityConfig.java
@@ -98,11 +98,6 @@ public class AdminWebSecurityConfig extends WebSecurityConfigurerAdapter {
     public CasLogoutSuccessHandler adminLogoutSuccessHandler() {
         CasLogoutSuccessHandler logoutSuccessHandler = new CasLogoutSuccessHandler();
         logoutSuccessHandler.setLogoutUrl(casLogoutUrl);
-        logoutSuccessHandler.setDefaultRedirectUrl(serverName + "/logged-out");
-        logoutSuccessHandler.setRedirectUrlSelectorName("reason");
-        Map<String, String> redirectUrls = new HashMap<>();
-        redirectUrls.put("unauthorized", serverName);
-        logoutSuccessHandler.setRedirectUrls(redirectUrls);
         return logoutSuccessHandler;
     }
 

--- a/ui/de-webapp/src/main/java/org/iplantc/de/server/DeCasAuthenticationEntryPoint.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/server/DeCasAuthenticationEntryPoint.java
@@ -1,6 +1,5 @@
 package org.iplantc.de.server;
 
-import org.eclipse.jetty.server.Authentication;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -8,7 +7,7 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 import org.springframework.util.Assert;
 
 import java.io.IOException;
-
+import java.util.logging.Logger;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -20,6 +19,8 @@ import javax.servlet.http.HttpServletResponse;
  * @author jstroot
  */
 public class DeCasAuthenticationEntryPoint implements AuthenticationEntryPoint, InitializingBean {
+
+    Logger LOG = Logger.getLogger(DeCasAuthenticationEntryPoint.class.getName());
 
     private LandingPage landingPage;
 
@@ -49,12 +50,8 @@ public class DeCasAuthenticationEntryPoint implements AuthenticationEntryPoint, 
     public void commence(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse,
                          final AuthenticationException e) throws IOException, ServletException {
 
-        // Respond with a redirect if this is an RPC call.
-        if (isRpcCall(httpServletRequest)) {
-          // logoutSuccessHandler.onLogoutSuccess(httpServletRequest, httpServletResponse, null);
+        if (isRpcCall(httpServletRequest) || isGWTCodeSplit(httpServletRequest)) {
             httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-            //throw authentication exception
-         //   throw new org.iplantc.de.shared.exceptions.AuthenticationException("Session timed out or redirect request received!");
         }
 
         // Display the landing page.
@@ -64,4 +61,13 @@ public class DeCasAuthenticationEntryPoint implements AuthenticationEntryPoint, 
     private boolean isRpcCall(HttpServletRequest req) {
         return req.getRequestURI().endsWith(rpcSuffix);
     }
+
+    private boolean isGWTCodeSplit(HttpServletRequest req) {
+        if (req.getRequestURI().contains("/deferredjs/")) {
+            return true;
+        }
+        return false;
+    }
+
+
 }

--- a/ui/de-webapp/src/main/java/org/iplantc/de/server/DeCasAuthenticationEntryPoint.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/server/DeCasAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.server;
 
+import org.eclipse.jetty.server.Authentication;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -50,7 +51,10 @@ public class DeCasAuthenticationEntryPoint implements AuthenticationEntryPoint, 
 
         // Respond with a redirect if this is an RPC call.
         if (isRpcCall(httpServletRequest)) {
-            logoutSuccessHandler.onLogoutSuccess(httpServletRequest, httpServletResponse, null);
+          // logoutSuccessHandler.onLogoutSuccess(httpServletRequest, httpServletResponse, null);
+            httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            //throw authentication exception
+         //   throw new org.iplantc.de.shared.exceptions.AuthenticationException("Session timed out or redirect request received!");
         }
 
         // Display the landing page.


### PR DESCRIPTION
This PR is to close the issue where users are getting Script Tag Failure errors in random places around the DE.  This error occurs when the user is navigating somewhere within the DE after their session has expired and then a GWT code split is requested and fails.  The solution here is to make sure that the code split requests first get returned with a status of 401, then the UI has to handle the redirect to the landing page properly.

This PR also pulls in some required changes to handling StatusCode 0 exceptions from dev that are also needed for this fix.

