### PR TITLE
CORE-7708 Remove dup attr checks from POST /data/{data-id}/metadata/copy

### DIFF
--- a/services/data-info/src/data_info/routes/avus.clj
+++ b/services/data-info/src/data_info/routes/avus.clj
@@ -105,7 +105,7 @@
       (svc/trap uri meta/metadata-set user data-id body))
 
     (POST* "/metadata/copy" [:as {uri :uri}]
-      :query [{:keys [user force]} MetadataCopyRequestParams]
+      :query [{:keys [user]} StandardUserQueryParams]
       :body [{:keys [destination_ids]} (describe MetadataCopyRequest "The destination data items.")]
       :return MetadataCopyResult
       :middlewares [wrap-metadata-base-url]
@@ -113,11 +113,11 @@
       :description
            (str "Copies all IRODS AVUs visible to the client and Metadata AVUs from the data
             item with the ID given in the URL to other data items with the IDs sent in the request body."
-(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED, ERR_NOT_UNIQUE")
+(get-error-code-block "ERR_NOT_A_USER, ERR_NOT_READABLE, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_NOT_AUTHORIZED")
 (get-endpoint-delegate-block
   "metadata"
   "POST /avus/{target-type}/{target-id}/copy"))
-      (svc/trap uri meta/metadata-copy user force data-id destination_ids))
+      (svc/trap uri meta/metadata-copy user data-id destination_ids))
 
     (POST* "/metadata/csv-parser" [:as {uri :uri}]
       :query [params MetadataCSVParseParams]

--- a/services/data-info/src/data_info/routes/domain/avus.clj
+++ b/services/data-info/src/data_info/routes/domain/avus.clj
@@ -35,16 +35,6 @@
    :user
    (describe NonBlankString "The effective user who performed the request.")})
 
-(s/defschema MetadataCopyRequestParams
-  (merge StandardUserQueryParams
-         {(s/optional-key :force)
-          (describe Boolean
-                    "Omitting this parameter, or setting its value to anything other than `true`,
-                     will cause this endpoint to validate that none of the given `destination_ids`
-                     already have Metadata Template AVUs set with any of the attributes found in any of
-                     the Metadata AVUs associated with the source `data-id`,
-                     otherwise an `ERR_NOT_UNIQUE` error is returned")}))
-
 (s/defschema MetadataCopyRequest
   {:destination_ids (describe [UUID] "The IDs of the target data items")})
 

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -212,11 +212,9 @@
            (mk-req-map user (json/encode avu-map))))
 
 (defn metadata-copy
-  [user force path-uuid copy-request]
+  [user path-uuid copy-request]
   (request :post ["data" path-uuid "metadata" "copy"]
-           (mk-req-map user
-                       (json/encode copy-request)
-                       (remove-vals nil? {:force force}))))
+           (mk-req-map user (json/encode copy-request))))
 
 (defn metadata-csv-parser
   [user path-uuid params]

--- a/services/terrain/src/terrain/routes/filesystem.clj
+++ b/services/terrain/src/terrain/routes/filesystem.clj
@@ -116,8 +116,8 @@
     (POST "/filesystem/:data-id/metadata" [data-id :as req]
       (controller req meta/do-metadata-set data-id :params :body))
 
-    (POST "/filesystem/:data-id/metadata/copy" [data-id force :as req]
-      (controller req meta/do-metadata-copy :params data-id force :body))
+    (POST "/filesystem/:data-id/metadata/copy" [data-id :as req]
+      (controller req meta/do-metadata-copy :params data-id :body))
 
     (POST "/filesystem/:data-id/metadata/save" [data-id :as req]
       (controller req meta/do-metadata-save data-id :params :body))))

--- a/services/terrain/src/terrain/services/filesystem/metadata.clj
+++ b/services/terrain/src/terrain/services/filesystem/metadata.clj
@@ -42,15 +42,13 @@
 
 (defn do-metadata-copy
   "Entrypoint for the API that calls (metadata-copy)."
-  [{:keys [user]} data-id force body]
-  (data-raw/metadata-copy user force data-id body))
+  [{:keys [user]} data-id body]
+  (data-raw/metadata-copy user data-id body))
 
 (with-pre-hook! #'do-metadata-copy
-  (fn [{:keys [user] :as params} data-id force {dest-ids :destination_ids :as body}]
+  (fn [params data-id body]
     (log-call "do-metadata-copy" params data-id body)
-    (validate-map params {:user string?})
-    (validate-map body {:destination_ids sequential?})
-    (validate-num-paths dest-ids)))
+    (validate-map params {:user string?})))
 
 (with-post-hook! #'do-metadata-copy (log-func "do-metadata-copy"))
 


### PR DESCRIPTION
Remove duplicate attribute checks and the corresponding `force` param
from the POST /data/{data-id}/metadata/copy endpoint.
Move path-count validation from the terrain endpoint and into data-info.