### PR TITLE
Provide accurate byte ranges in anon-files

### DIFF
--- a/services/anon-files/src/anon_files/serve.clj
+++ b/services/anon-files/src/anon_files/serve.clj
@@ -310,10 +310,10 @@
       (str "bytes " lower "-" upper "/" filesize)
 
       "unbounded"
-      (str "bytes " lower "-" "/" filesize)
+      (str "bytes " lower "-" filesize "/" filesize)
 
       "unbounded-negative"
-      (str "bytes " lower "-" "/" filesize)
+      (str "bytes " lower "-" filesize "/" filesize)
 
       "byte"
       (str "bytes " lower "-" upper "/" filesize)


### PR DESCRIPTION
Previously, we were returning what RFC 2616 specifically mentions is
incorrect (a Content-Range header with no last-byte-pos). Though RFC
7233 which supersedes it does not include that line, we have a perfectly
accurate count of the last byte we are returning, and should return it
since the Content-Range header is intended to specify what was returned,
not what was requested. Therefore, this sets the filesize as the upper
end of the range for unbounded requests.

I don't actually know how important this is, but I do believe the changed value is more correct!