### PR TITLE
CORE-7713: switch nginx-consul-template to use entrykit

### DIFF
--- a/docker/nginx-consul-template/Dockerfile
+++ b/docker/nginx-consul-template/Dockerfile
@@ -7,15 +7,23 @@ ENV CONSUL_TEMPLATE_VERSION=0.14.0
 ENV CONSUL_CONNECT=localhost:8500
 ENV NGINX_TEMPLATE=/templates/nginx.conf.tmpl
 ENV NGINX_CONF=/etc/nginx/nginx.conf
+ENV ENTRYKIT_VERSION=0.4.0
 
 ADD https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip /
+ADD https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz /
 
 RUN unzip consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip \
     && mkdir -p /usr/local/bin \
     && mv consul-template /usr/local/bin/consul-template
 
-COPY run.sh /usr/local/bin/run.sh
+RUN tar -xzvf entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
+    && mkdir -p /usr/local/bin \
+    && mv entrykit /usr/local/bin/entrykit \
+    && entrykit --symlink
+
+COPY run-consul-template.sh /usr/local/bin/run-consul-template.sh
+COPY run-nginx.sh /usr/local/bin/run-nginx.sh
 COPY nginx.conf.tmpl /templates/nginx.conf.tmpl
 COPY nginx.conf.dummy /etc/nginx/nginx.conf
 
-CMD ["/usr/local/bin/run.sh"]
+ENTRYPOINT ["codep", "/usr/local/bin/run-consul-template.sh", "/usr/local/bin/run-nginx.sh"]

--- a/docker/nginx-consul-template/run-consul-template.sh
+++ b/docker/nginx-consul-template/run-consul-template.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-nginx -g "daemon off;" &
-
 exec consul-template -consul $CONSUL_CONNECT -template "$NGINX_TEMPLATE:$NGINX_CONF:nginx -s reload || true"

--- a/docker/nginx-consul-template/run-nginx.sh
+++ b/docker/nginx-consul-template/run-nginx.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec nginx -g "daemon off;"


### PR DESCRIPTION
https://github.com/progrium/entrykit is designed for exactly what we're doing here, which is running two codependent processes inside a container.

It's a little bit stupid about quoting, so I'm still running two shell scripts so that I can actually have the quoting work properly, but this is much better than just running it with `&` and hoping for the best, in particular because this means our restart policies can be much more useful if the containers actually exit when nginx is dead.