### PR TITLE
Add a Python 2.7 tool and app to the database

### DIFF
--- a/databases/de-database-schema/src/main/conversions/c270_2016061401.clj
+++ b/databases/de-database-schema/src/main/conversions/c270_2016061401.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c270-2016061401
+  (:use [korma.core]
+        [kameleon.sql-reader :only [load-sql-file]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.7.0:20160614.01")
+
+(defn- load-python-app
+  []
+  (println "\t* Adding Python 2.7 tool and app to the database")
+  (load-sql-file "data/22_python_app.sql"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (load-python-app))

--- a/databases/de-database-schema/src/main/data/22_python_app.sql
+++ b/databases/de-database-schema/src/main/data/22_python_app.sql
@@ -1,0 +1,157 @@
+SET search_path = public, pg_catalog;
+
+--
+-- The container image for Python 2.7
+--
+INSERT INTO container_images (id, "name", tag, url) VALUES
+	('bad7e301-4442-4e82-8cc4-8db681cae364',
+	 'python',
+	 '2.7',
+	 'https://hub.docker.com/_/python/');
+--
+-- The internal tool for Python 2.7
+--
+INSERT INTO tools (
+	id, 
+	"name", 
+	location, 
+	description, 
+	version, 
+	tool_type_id, 
+	integration_data_id, 
+	time_limit_seconds, 
+	container_images_id
+)
+	SELECT '4e3b1710-0f15-491f-aca9-812335356fdb',
+		   'python',
+		   '/usr/local/bin',
+		   'Python 2.7 with no networking, a 1GB RAM limit, and a 10% cpu share. Entrypoint is python.',
+		   '1.0.0',
+		   tool_types.id,
+		   integration_data.id,
+		   14400,
+		   'bad7e301-4442-4e82-8cc4-8db681cae364'
+	  FROM tool_types, integration_data
+	 WHERE tool_types."name" = 'internal'
+	   AND integration_data.integrator_name = 'Internal DE Tools'
+	 LIMIT 1;
+
+INSERT INTO container_settings (tools_id, network_mode, entrypoint, memory_limit, cpu_shares)
+  VALUES ('4e3b1710-0f15-491f-aca9-812335356fdb', 'none', 'python', 1000000000, 102);
+
+--
+-- The app for Python 2.7
+--
+INSERT INTO apps(
+	id,
+	"name",
+	description,
+	integration_data_id,
+	wiki_url,
+	integration_date
+)
+	SELECT '336bbfb3-7899-493a-b4a2-ed3bc353ead8',
+		   'Python 2.7',
+		   'Runs an arbitrary Python script with a time limit of 4 hours, a 1GB RAM limit, a 10% cpu share, and no networking. Accepts a script and a data file as inputs.',
+		   integration_data.id,
+		   '',
+		   now()
+	  FROM integration_data
+     WHERE integrator_name = 'Default DE Tools'
+     LIMIT 1;
+
+INSERT INTO tasks (id, "name", description, label, tool_id) VALUES
+	('66b59035-6036-46c3-a30a-ee3bd4af47b6',
+	 'Run a Python 2.7 script',
+	 'Runs a Python 2.7 script against a data file',
+	 'Run a Python 2.7 script',
+	 '4e3b1710-0f15-491f-aca9-812335356fdb');
+
+INSERT INTO parameter_groups (id, "name", description, label, task_id) VALUES
+	('f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
+	 'Parameters',
+	 'Python 2.7 parameters',
+	 'Parameters',
+	 '66b59035-6036-46c3-a30a-ee3bd4af47b6');
+
+INSERT INTO parameters 
+	(id,
+	 "name",
+	 description,
+	 label,
+	 ordering,
+	 parameter_group_id,
+	 parameter_type,
+	 display_order,
+	 required)
+  SELECT '5e1339f0-e01a-4fa3-8546-f7f16af547bf',
+         '',
+         'The Python script to run',
+		 'Script',
+		 0,
+		 'f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
+		 pt.id,
+		 0,
+		 TRUE
+    FROM parameter_types pt
+   WHERE pt."name" = 'FileInput'
+   LIMIT 1;
+
+INSERT INTO parameters
+	(id,
+	 "name",
+	 description,
+	 label,
+	 ordering,
+     parameter_group_id,
+	 parameter_type,
+	 display_order,
+	 required)
+  SELECT '41d1a467-17fa-4b25-ba5e-43c8cb88948b',
+         '',
+		 'The data file to process',
+		 'Data file',
+		 1,
+		 'f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
+		 pt.id,
+		 1,
+		 TRUE
+    FROM parameter_types pt
+   WHERE pt."name" = 'FileInput'
+   LIMIT 1;
+
+INSERT INTO file_parameters (id, parameter_id, info_type, data_format, data_source_id, retain)
+  SELECT '78244fb8-d5bb-479b-b73e-a12c20dbb774',
+         '5e1339f0-e01a-4fa3-8546-f7f16af547bf',
+		 info_type.id,
+		 data_formats.id,
+		 data_source.id,
+		 TRUE
+    FROM info_type, data_formats, data_source
+   WHERE info_type."name" = 'File'
+     AND data_formats."name" = 'Unspecified'
+	 AND data_source."name" = 'file'
+   LIMIT 1;
+
+INSERT INTO file_parameters (id, parameter_id, info_type, data_format, data_source_id, retain)
+  SELECT '73ec6e74-d5e6-4977-b999-620b4e79ebda',
+         '41d1a467-17fa-4b25-ba5e-43c8cb88948b',
+		 info_type.id,
+		 data_formats.id,
+		 data_source.id,
+		 TRUE
+    FROM info_type, data_formats, data_source
+   WHERE info_type."name" = 'File'
+     AND data_formats."name" = 'Unspecified'
+	 AND data_source."name" = 'file'
+   LIMIT 1;
+
+INSERT INTO app_category_app (app_category_id, app_id) VALUES
+	('5401bd146c144470aedd57b47ea1b979',
+	 '336bbfb3-7899-493a-b4a2-ed3bc353ead8');
+
+INSERT INTO app_steps (step, id, app_id, task_id) VALUES
+	(0,
+	 'b34736a8-aa68-4845-803d-c0d1942ccdff',
+	 '336bbfb3-7899-493a-b4a2-ed3bc353ead8',
+	 '66b59035-6036-46c3-a30a-ee3bd4af47b6');

--- a/databases/de-database-schema/src/main/data/22_python_app.sql
+++ b/databases/de-database-schema/src/main/data/22_python_app.sql
@@ -11,30 +11,29 @@ INSERT INTO container_images (id, "name", tag, url) VALUES
 --
 -- The internal tool for Python 2.7
 --
-INSERT INTO tools (
-	id, 
-	"name", 
-	location, 
-	description, 
-	version, 
-	tool_type_id, 
-	integration_data_id, 
-	time_limit_seconds, 
-	container_images_id
-)
-	SELECT '4e3b1710-0f15-491f-aca9-812335356fdb',
-		   'python',
-		   '/usr/local/bin',
-		   'Python 2.7 with no networking, a 1GB RAM limit, and a 10% cpu share. Entrypoint is python.',
-		   '1.0.0',
-		   tool_types.id,
-		   integration_data.id,
-		   14400,
-		   'bad7e301-4442-4e82-8cc4-8db681cae364'
-	  FROM tool_types, integration_data
-	 WHERE tool_types."name" = 'internal'
-	   AND integration_data.integrator_name = 'Internal DE Tools'
-	 LIMIT 1;
+INSERT INTO tools
+	(id,
+	 "name",
+	 location,
+	 description,
+	 version,
+	 tool_type_id,
+	 integration_data_id,
+	 time_limit_seconds,
+	 container_images_id)
+  SELECT '4e3b1710-0f15-491f-aca9-812335356fdb',
+         'python',
+		 '/usr/local/bin',
+		 'Python 2.7 with no networking, a 1GB RAM limit, and a 10% cpu share. Entrypoint is python.',
+		 '1.0.0',
+		 tool_types.id,
+		 integration_data.id,
+		 14400,
+		 'bad7e301-4442-4e82-8cc4-8db681cae364'
+	FROM tool_types, integration_data
+   WHERE tool_types."name" = 'internal'
+     AND integration_data.integrator_name = 'Internal DE Tools'
+   LIMIT 1;
 
 INSERT INTO container_settings (tools_id, network_mode, entrypoint, memory_limit, cpu_shares)
   VALUES ('4e3b1710-0f15-491f-aca9-812335356fdb', 'none', 'python', 1000000000, 102);
@@ -42,23 +41,22 @@ INSERT INTO container_settings (tools_id, network_mode, entrypoint, memory_limit
 --
 -- The app for Python 2.7
 --
-INSERT INTO apps(
-	id,
+INSERT INTO apps
+	(id,
 	"name",
 	description,
 	integration_data_id,
 	wiki_url,
-	integration_date
-)
-	SELECT '336bbfb3-7899-493a-b4a2-ed3bc353ead8',
-		   'Python 2.7',
-		   'Runs an arbitrary Python script with a time limit of 4 hours, a 1GB RAM limit, a 10% cpu share, and no networking. Accepts a script and a data file as inputs.',
-		   integration_data.id,
-		   '',
-		   now()
-	  FROM integration_data
-     WHERE integrator_name = 'Default DE Tools'
-     LIMIT 1;
+	integration_date)
+  SELECT '336bbfb3-7899-493a-b4a2-ed3bc353ead8',
+         'Python 2.7',
+		 'Runs an arbitrary Python script with a time limit of 4 hours, a 1GB RAM limit, a 10% cpu share, and no networking. Accepts a script and a data file as inputs.',
+		 integration_data.id,
+		 '',
+		 now()
+	FROM integration_data
+   WHERE integrator_name = 'Default DE Tools'
+   LIMIT 1;
 
 INSERT INTO tasks (id, "name", description, label, tool_id) VALUES
 	('66b59035-6036-46c3-a30a-ee3bd4af47b6',

--- a/databases/de-database-schema/src/main/data/22_python_app.sql
+++ b/databases/de-database-schema/src/main/data/22_python_app.sql
@@ -4,33 +4,33 @@ SET search_path = public, pg_catalog;
 -- The container image for Python 2.7
 --
 INSERT INTO container_images (id, "name", tag, url) VALUES
-	('bad7e301-4442-4e82-8cc4-8db681cae364',
-	 'python',
-	 '2.7',
-	 'https://hub.docker.com/_/python/');
+    ('bad7e301-4442-4e82-8cc4-8db681cae364',
+     'python',
+     '2.7',
+     'https://hub.docker.com/_/python/');
 --
 -- The internal tool for Python 2.7
 --
 INSERT INTO tools
-	(id,
-	 "name",
-	 location,
-	 description,
-	 version,
-	 tool_type_id,
-	 integration_data_id,
-	 time_limit_seconds,
-	 container_images_id)
+    (id,
+     "name",
+     location,
+     description,
+     version,
+     tool_type_id,
+     integration_data_id,
+     time_limit_seconds,
+     container_images_id)
   SELECT '4e3b1710-0f15-491f-aca9-812335356fdb',
          'python',
-		 '/usr/local/bin',
-		 'Python 2.7 with no networking, a 1GB RAM limit, and a 10% cpu share. Entrypoint is python.',
-		 '1.0.0',
-		 tool_types.id,
-		 integration_data.id,
-		 14400,
-		 'bad7e301-4442-4e82-8cc4-8db681cae364'
-	FROM tool_types, integration_data
+         '/usr/local/bin',
+         'Python 2.7 with no networking, a 1GB RAM limit, and a 10% cpu share. Entrypoint is python.',
+         '1.0.0',
+         tool_types.id,
+         integration_data.id,
+         14400,
+         'bad7e301-4442-4e82-8cc4-8db681cae364'
+    FROM tool_types, integration_data
    WHERE tool_types."name" = 'internal'
      AND integration_data.integrator_name = 'Internal DE Tools'
    LIMIT 1;
@@ -42,78 +42,78 @@ INSERT INTO container_settings (tools_id, network_mode, entrypoint, memory_limit
 -- The app for Python 2.7
 --
 INSERT INTO apps
-	(id,
-	"name",
-	description,
-	integration_data_id,
-	wiki_url,
-	integration_date)
+    (id,
+     "name",
+     description,
+     integration_data_id,
+     wiki_url,
+     integration_date)
   SELECT '336bbfb3-7899-493a-b4a2-ed3bc353ead8',
          'Python 2.7',
-		 'Runs an arbitrary Python script with a time limit of 4 hours, a 1GB RAM limit, a 10% cpu share, and no networking. Accepts a script and a data file as inputs.',
-		 integration_data.id,
-		 '',
-		 now()
-	FROM integration_data
+         'Runs an arbitrary Python script with a time limit of 4 hours, a 1GB RAM limit, a 10% cpu share, and no networking. Accepts a script and a data file as inputs.',
+         integration_data.id,
+         '',
+         now()
+    FROM integration_data
    WHERE integrator_name = 'Default DE Tools'
    LIMIT 1;
 
 INSERT INTO tasks (id, "name", description, label, tool_id) VALUES
-	('66b59035-6036-46c3-a30a-ee3bd4af47b6',
-	 'Run a Python 2.7 script',
-	 'Runs a Python 2.7 script against a data file',
-	 'Run a Python 2.7 script',
-	 '4e3b1710-0f15-491f-aca9-812335356fdb');
+    ('66b59035-6036-46c3-a30a-ee3bd4af47b6',
+     'Run a Python 2.7 script',
+     'Runs a Python 2.7 script against a data file',
+     'Run a Python 2.7 script',
+     '4e3b1710-0f15-491f-aca9-812335356fdb');
 
 INSERT INTO parameter_groups (id, "name", description, label, task_id) VALUES
-	('f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
-	 'Parameters',
-	 'Python 2.7 parameters',
-	 'Parameters',
-	 '66b59035-6036-46c3-a30a-ee3bd4af47b6');
+    ('f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
+     'Parameters',
+     'Python 2.7 parameters',
+     'Parameters',
+     '66b59035-6036-46c3-a30a-ee3bd4af47b6');
 
 INSERT INTO parameters 
-	(id,
-	 "name",
-	 description,
-	 label,
-	 ordering,
-	 parameter_group_id,
-	 parameter_type,
-	 display_order,
-	 required)
+      (id,
+     "name",
+     description,
+     label,
+     ordering,
+     parameter_group_id,
+     parameter_type,
+     display_order,
+     required)
   SELECT '5e1339f0-e01a-4fa3-8546-f7f16af547bf',
          '',
          'The Python script to run',
-		 'Script',
-		 0,
-		 'f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
-		 pt.id,
-		 0,
-		 TRUE
+         'Script',
+         0,
+         'f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
+         pt.id,
+         0,
+         TRUE
     FROM parameter_types pt
    WHERE pt."name" = 'FileInput'
    LIMIT 1;
 
 INSERT INTO parameters
-	(id,
-	 "name",
-	 description,
-	 label,
-	 ordering,
+    (id,
+     "name",
+     description,
+     label,
+     ordering,
      parameter_group_id,
-	 parameter_type,
-	 display_order,
-	 required)
+     parameter_type,
+     display_order,
+     required)
   SELECT '41d1a467-17fa-4b25-ba5e-43c8cb88948b',
          '',
-		 'The data file to process',
-		 'Data file',
-		 1,
-		 'f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
-		 pt.id,
-		 1,
-		 TRUE
+         'The data file to process',
+         'Data file',
+         1,
+         'f252f7b2-5c27-4a27-bbbb-f4f2f2acf407',
+         pt.id,
+         1,
+         TRUE
     FROM parameter_types pt
    WHERE pt."name" = 'FileInput'
    LIMIT 1;
@@ -121,35 +121,35 @@ INSERT INTO parameters
 INSERT INTO file_parameters (id, parameter_id, info_type, data_format, data_source_id, retain)
   SELECT '78244fb8-d5bb-479b-b73e-a12c20dbb774',
          '5e1339f0-e01a-4fa3-8546-f7f16af547bf',
-		 info_type.id,
-		 data_formats.id,
-		 data_source.id,
-		 TRUE
+         info_type.id,
+         data_formats.id,
+         data_source.id,
+         TRUE
     FROM info_type, data_formats, data_source
    WHERE info_type."name" = 'File'
      AND data_formats."name" = 'Unspecified'
-	 AND data_source."name" = 'file'
+     AND data_source."name" = 'file'
    LIMIT 1;
 
 INSERT INTO file_parameters (id, parameter_id, info_type, data_format, data_source_id, retain)
   SELECT '73ec6e74-d5e6-4977-b999-620b4e79ebda',
          '41d1a467-17fa-4b25-ba5e-43c8cb88948b',
-		 info_type.id,
-		 data_formats.id,
-		 data_source.id,
-		 TRUE
+         info_type.id,
+         data_formats.id,
+         data_source.id,
+         TRUE
     FROM info_type, data_formats, data_source
    WHERE info_type."name" = 'File'
      AND data_formats."name" = 'Unspecified'
-	 AND data_source."name" = 'file'
+     AND data_source."name" = 'file'
    LIMIT 1;
 
 INSERT INTO app_category_app (app_category_id, app_id) VALUES
-	('5401bd146c144470aedd57b47ea1b979',
-	 '336bbfb3-7899-493a-b4a2-ed3bc353ead8');
+    ('5401bd146c144470aedd57b47ea1b979',
+     '336bbfb3-7899-493a-b4a2-ed3bc353ead8');
 
 INSERT INTO app_steps (step, id, app_id, task_id) VALUES
-	(0,
-	 'b34736a8-aa68-4845-803d-c0d1942ccdff',
-	 '336bbfb3-7899-493a-b4a2-ed3bc353ead8',
-	 '66b59035-6036-46c3-a30a-ee3bd4af47b6');
+    (0,
+     'b34736a8-aa68-4845-803d-c0d1942ccdff',
+     '336bbfb3-7899-493a-b4a2-ed3bc353ead8',
+     '66b59035-6036-46c3-a30a-ee3bd4af47b6');

--- a/databases/de-database-schema/src/main/data/99_version.sql
+++ b/databases/de-database-schema/src/main/data/99_version.sql
@@ -76,3 +76,4 @@ INSERT INTO version (version) VALUES ('2.6.0:20160309.01');
 INSERT INTO version (version) VALUES ('2.6.0:20160420.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160525.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160526.01');
+INSERT INTO version (version) VALUES ('2.7.0:20160614.01');

--- a/libs/kameleon/project.clj
+++ b/libs/kameleon/project.clj
@@ -14,4 +14,4 @@
                  [slingshot "0.12.2"]]
   :plugins [[lein-marginalia "0.7.1"]
             [test2junit "1.1.3"]]
-  :manifest {"db-version" "2.7.0:20160526.01"})
+  :manifest {"db-version" "2.7.0:20160614.01"})


### PR DESCRIPTION
We need to have a Python 2.7 tool and app that uses the time, memory, and cpu limits, so I've added one to be included with the DE when the database is init'ed. I've also included a conversion to add the same tool and app to existing databases.

The SQL for adding a new tool and app to the database is convoluted enough that I didn't want to add it to the existing data file, 21_internal_apps.sql.

This has been tested by init'ing a new database with the discoenv/unittest-dedb:dev image as well as by upgrading an existing database with the same image.