### PR TITLE
CORE-7712 Add 'avu' enum to metadata database target_enum type.

### DIFF
--- a/databases/metadata/src/main/conversions/c270_2016061401.clj
+++ b/databases/metadata/src/main/conversions/c270_2016061401.clj
@@ -1,0 +1,23 @@
+(ns facepalm.c270-2016061401
+  (:use [korma.core])
+  (:require [clojure.java.jdbc :as jdbc]
+            [facepalm.core :as migrator]
+            [korma.db :as db]))
+
+(def ^:private version
+  "The destination database version."
+  "2.7.0:20160614.01")
+
+;; This statement can't be run inside a transaction. That's why jdbc is directly used.
+(defn- add-target-enum-avu
+  []
+  (println "\t* Add 'avu' enum to target_enum type...")
+  (jdbc/db-do-prepared (db/get-connection @migrator/admin-db-spec)
+                       false
+                       "ALTER TYPE target_enum ADD VALUE 'avu' AFTER 'app'"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-target-enum-avu))

--- a/databases/metadata/src/main/data/99_version.sql
+++ b/databases/metadata/src/main/data/99_version.sql
@@ -11,3 +11,4 @@ INSERT INTO version (version) VALUES ('2.1.0:20150811.01');
 INSERT INTO version (version) VALUES ('2.4.0:20151210.01');
 INSERT INTO version (version) VALUES ('2.6.0:20160331.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160513.01');
+INSERT INTO version (version) VALUES ('2.7.0:20160614.01');

--- a/databases/metadata/src/main/extensions/target_enum.sql
+++ b/databases/metadata/src/main/extensions/target_enum.sql
@@ -1,6 +1,5 @@
 --
 -- target type enumeration
--- Currently, only analyses, apps, files, folders, and users may be targets of metadata.
+-- Currently, only analyses, apps, other AVUs, files, folders, and users may be targets of metadata.
 --
-CREATE TYPE target_enum AS ENUM ('analysis', 'app', 'file', 'folder', 'user');
-
+CREATE TYPE target_enum AS ENUM ('analysis', 'app', 'avu', 'file', 'folder', 'avu', 'user');


### PR DESCRIPTION
Allows AVUs in the metadata db to target other AVUs.