### PR TITLE
Database Connection Retries

### DIFF
--- a/golang/src/dbutil/connector.go
+++ b/golang/src/dbutil/connector.go
@@ -1,4 +1,4 @@
-package util
+package dbutil
 
 import (
 	"database/sql"

--- a/golang/src/permissions/clients/grouper/grouper.go
+++ b/golang/src/permissions/clients/grouper/grouper.go
@@ -3,7 +3,7 @@ package grouper
 import (
 	"database/sql"
 
-	"permissions/util"
+	"dbutil"
 
 	_ "github.com/lib/pq"
 )
@@ -25,7 +25,7 @@ type GrouperClient struct {
 }
 
 func NewGrouperClient(dburi, prefix string) (*GrouperClient, error) {
-	connector, err := util.NewDefaultConnector("1m")
+	connector, err := dbutil.NewDefaultConnector("1m")
 	if err != nil {
 		return nil, err
 	}

--- a/golang/src/permissions/restapi/configure_permissions.go
+++ b/golang/src/permissions/restapi/configure_permissions.go
@@ -4,6 +4,7 @@ import (
 	"configurate"
 	"crypto/tls"
 	"database/sql"
+	"dbutil"
 	"fmt"
 	"logcabin"
 	"net/http"
@@ -22,8 +23,6 @@ import (
 	"permissions/restapi/operations/resources"
 	"permissions/restapi/operations/status"
 	"permissions/restapi/operations/subjects"
-
-	"permissions/util"
 
 	permissions_impl "permissions/restapi/impl/permissions"
 	resource_types_impl "permissions/restapi/impl/resource_types"
@@ -69,7 +68,7 @@ func initService() error {
 		return err
 	}
 
-	connector, err := util.NewDefaultConnector("1m")
+	connector, err := dbutil.NewDefaultConnector("1m")
 	if err != nil {
 		return err
 	}

--- a/golang/src/saved-searches/main.go
+++ b/golang/src/saved-searches/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"configurate"
 	"database/sql"
+	"dbutil"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -403,8 +404,13 @@ func main() {
 		logcabin.Error.Fatal(err)
 	}
 
+	connector, err := dbutil.NewDefaultConnector("1m")
+	if err != nil {
+		logcabin.Error.Fatal(err)
+	}
+
 	logcabin.Info.Println("Connecting to the database...")
-	db, err := sql.Open("postgres", dburi)
+	db, err := connector.Connect("postgres", dburi)
 	if err != nil {
 		logcabin.Error.Fatal(err)
 	}

--- a/golang/src/tree-urls/main.go
+++ b/golang/src/tree-urls/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"configurate"
 	"database/sql"
+	"dbutil"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -382,8 +383,13 @@ func main() {
 		logcabin.Error.Fatal(err)
 	}
 
+	connector, err := dbutil.NewDefaultConnector("1m")
+	if err != nil {
+		logcabin.Error.Fatal(err)
+	}
+
 	logcabin.Info.Println("Connecting to the database...")
-	db, err := sql.Open("postgres", dburi)
+	db, err := connector.Connect("postgres", dburi)
 	if err != nil {
 		logcabin.Error.Fatal(err)
 	}


### PR DESCRIPTION
`saved-searches` and `tree-urls` are often crashing upon startup when launched in our integration testing environment. This happens because these services start fast and often attempt to connect to Postgres before the database is ready. This change modifies both services so that they attempt to connect for a minute before giving up.