### PR TITLE
CORE-7727, CORE-7728: metadata template blank/template CSV and guide CSV endpoints

### DIFF
--- a/services/metadata/project.clj
+++ b/services/metadata/project.clj
@@ -19,6 +19,7 @@
                  [net.sourceforge.owlapi/owlapi-reasoner "3.3"]
                  [metosin/compojure-api "0.24.5"]
                  [cheshire "5.5.0"]
+                 [org.clojure/data.csv "0.1.3"]
                  [com.novemberain/langohr "3.5.1"]
                  [org.iplantc/clojure-commons "5.2.7.0"]
                  [org.iplantc/common-cfg "5.2.7.0"]

--- a/services/metadata/src/metadata/routes/domain/template.clj
+++ b/services/metadata/src/metadata/routes/domain/template.clj
@@ -1,5 +1,5 @@
 (ns metadata.routes.domain.template
-  (:use [common-swagger-api.schema :only [describe]])
+  (:use [common-swagger-api.schema :only [describe StandardUserQueryParams]])
   (:require [schema.core :as s]
             [metadata.persistence.templates :as tp])
   (:import [java.util Date UUID]))
@@ -105,3 +105,8 @@
 
    :name
    (describe String "The metadata template name")})
+
+(s/defschema CSVDownloadQueryParams
+  (assoc StandardUserQueryParams
+    (s/optional-key :attachment)
+    (describe Boolean "Download file contents as attachment. Default true.")))

--- a/services/metadata/src/metadata/routes/templates.clj
+++ b/services/metadata/src/metadata/routes/templates.clj
@@ -5,6 +5,14 @@
         [ring.util.http-response :only [ok]])
   (:require [metadata.services.templates :as templates]))
 
+(defn- csv-download-resp
+  [attachment filename body]
+  (let [attachment? (or (nil? attachment) attachment)
+        disposition (str (if attachment? "attachment; " "") "filename=\"" filename "\"")]
+    (assoc (ok body)
+           :headers {"Content-Type" "text/csv; charset=utf-8"
+                     "Content-Disposition" disposition})))
+
 (defroutes* templates
   (context* "/templates" []
     :tags ["template-info"]
@@ -38,13 +46,13 @@
         :query [{:keys [attachment]} CSVDownloadQueryParams]
         :summary "Get a blank CSV template file for a metadata template."
         :description "This endpoint returns a CSV file suitable for a specific template, ready to be filled in with specific values. It's intended to be downloaded to be filled out by the user, then reuploaded for use with the bulk metadata endpoints."
-        (templates/csv-download-resp attachment "metadata.csv" (templates/view-template-csv template-id)))
+        (csv-download-resp attachment "metadata.csv" (templates/view-template-csv template-id)))
 
       (GET* "/guide-csv" []
         :query [{:keys [attachment]} CSVDownloadQueryParams]
         :summary "Get a CSV guide file for a metadata template."
         :description "This endpoint returns a CSV file providing a guide for a specific template. It's intended to be downloaded to be used as a reference while filling out a file from the blank-csv endpoint for the same template."
-        (templates/csv-download-resp attachment "guide.csv" (templates/view-template-guide template-id))))))
+        (csv-download-resp attachment "guide.csv" (templates/view-template-guide template-id))))))
 
 (defroutes* admin-templates
   (context* "/admin/templates" []

--- a/services/metadata/src/metadata/routes/templates.clj
+++ b/services/metadata/src/metadata/routes/templates.clj
@@ -24,13 +24,31 @@
       :description "This endpoint returns the details of a single metadata attribute."
       (ok (templates/view-attribute attr-id)))
 
-    (GET* "/:template-id" []
+    (context* "/:template-id" []
       :path-params [template-id :- TemplateIdPathParam]
-      :query [params StandardUserQueryParams]
-      :return MetadataTemplate
-      :summary "View a Metadata Template"
-      :description "This endpoint returns the details of a single metadata template."
-      (ok (templates/view-template template-id)))))
+
+      (GET* "/" []
+        :query [params StandardUserQueryParams]
+        :return MetadataTemplate
+        :summary "View a Metadata Template"
+        :description "This endpoint returns the details of a single metadata template."
+        (ok (templates/view-template template-id)))
+
+      (GET* "/blank-csv" []
+        :query [params StandardUserQueryParams]
+        :summary "Get a blank CSV template file for a metadata template."
+        :description "This endpoint returns a CSV file suitable for a specific template, ready to be filled in with specific values. It's intended to be downloaded to be filled out by the user, then reuploaded for use with the bulk metadata endpoints."
+        (assoc (ok (templates/view-template-csv template-id))
+               :headers {"Content-Type" "text/csv; charset=utf-8"
+                         "Content-Disposition" "attachment; filename=\"metadata.csv\""}))
+
+      (GET* "/guide-csv" []
+        :query [params StandardUserQueryParams]
+        :summary "Get a CSV guide file for a metadata template."
+        :description "This endpoint returns a CSV file providing a guide for a specific template. It's intended to be downloaded to be used as a reference while filling out a file from the blank-csv endpoint for the same template."
+        (assoc (ok (templates/view-template-guide template-id))
+               :headers {"Content-Type" "text/csv; charset=utf-8"
+                         "Content-Disposition" "attachment; filename=\"guide.csv\""})))))
 
 (defroutes* admin-templates
   (context* "/admin/templates" []

--- a/services/metadata/src/metadata/routes/templates.clj
+++ b/services/metadata/src/metadata/routes/templates.clj
@@ -35,20 +35,16 @@
         (ok (templates/view-template template-id)))
 
       (GET* "/blank-csv" []
-        :query [params StandardUserQueryParams]
+        :query [{:keys [attachment]} CSVDownloadQueryParams]
         :summary "Get a blank CSV template file for a metadata template."
         :description "This endpoint returns a CSV file suitable for a specific template, ready to be filled in with specific values. It's intended to be downloaded to be filled out by the user, then reuploaded for use with the bulk metadata endpoints."
-        (assoc (ok (templates/view-template-csv template-id))
-               :headers {"Content-Type" "text/csv; charset=utf-8"
-                         "Content-Disposition" "attachment; filename=\"metadata.csv\""}))
+        (templates/csv-download-resp attachment "metadata.csv" (templates/view-template-csv template-id)))
 
       (GET* "/guide-csv" []
-        :query [params StandardUserQueryParams]
+        :query [{:keys [attachment]} CSVDownloadQueryParams]
         :summary "Get a CSV guide file for a metadata template."
         :description "This endpoint returns a CSV file providing a guide for a specific template. It's intended to be downloaded to be used as a reference while filling out a file from the blank-csv endpoint for the same template."
-        (assoc (ok (templates/view-template-guide template-id))
-               :headers {"Content-Type" "text/csv; charset=utf-8"
-                         "Content-Disposition" "attachment; filename=\"guide.csv\""})))))
+        (templates/csv-download-resp attachment "guide.csv" (templates/view-template-guide template-id))))))
 
 (defroutes* admin-templates
   (context* "/admin/templates" []

--- a/services/metadata/src/metadata/routes/templates.clj
+++ b/services/metadata/src/metadata/routes/templates.clj
@@ -45,13 +45,18 @@
       (GET* "/blank-csv" []
         :query [{:keys [attachment]} CSVDownloadQueryParams]
         :summary "Get a blank CSV template file for a metadata template."
-        :description "This endpoint returns a CSV file suitable for a specific template, ready to be filled in with specific values. It's intended to be downloaded to be filled out by the user, then reuploaded for use with the bulk metadata endpoints."
+        :description "This endpoint returns a CSV file suitable for a specific template,
+                     ready to be filled in with specific values. It's intended to be
+                     downloaded and filled out by the user, then reuploaded for use with
+                     the bulk metadata endpoints."
         (csv-download-resp attachment "metadata.csv" (templates/view-template-csv template-id)))
 
       (GET* "/guide-csv" []
         :query [{:keys [attachment]} CSVDownloadQueryParams]
         :summary "Get a CSV guide file for a metadata template."
-        :description "This endpoint returns a CSV file providing a guide for a specific template. It's intended to be downloaded to be used as a reference while filling out a file from the blank-csv endpoint for the same template."
+        :description "This endpoint returns a CSV file guide for a specific template.
+                     It's intended to be downloaded and used as a reference while
+                     filling out a file from the blank-csv endpoint for the same template."
         (csv-download-resp attachment "guide.csv" (templates/view-template-guide template-id))))))
 
 (defroutes* admin-templates

--- a/services/metadata/src/metadata/services/templates.clj
+++ b/services/metadata/src/metadata/services/templates.clj
@@ -30,7 +30,9 @@
     (->> (view-template template-id)
       :attributes
       (map (juxt :name :description :required :type #(if (:values %) (string/join ", " (map :value (:values %))) "")))
-      (cons ["attribute name", "attribute description", "required (If you cannot provide,  enter 'not collected', 'not applicable' or 'missing'.)", "value type definition", "enum value options (you must enter one of these values)"]))))
+      (cons ["attribute name", "attribute description",
+             "required (If you cannot provide,  enter 'not collected', 'not applicable' or 'missing'.)",
+             "value type definition", "enum value options (you must enter one of these values)"]))))
 
 ;; This function alias relies on view-template's error checking to throw an exception if a template
 ;; with the given ID doesn't exist.

--- a/services/metadata/src/metadata/services/templates.clj
+++ b/services/metadata/src/metadata/services/templates.clj
@@ -4,7 +4,6 @@
         [ring.util.http-response :only [ok]])
   (:require [clojure-commons.assertions :as ca]
             [clojure.string :as string]
-            [clojure.tools.logging :as log]
             [metadata.persistence.templates :as tp]
             [metadata.util.csv :as csv]))
 
@@ -36,7 +35,6 @@
 
 (defn csv-download-resp
   [attachment filename body]
-  (log/warn attachment filename body)
   (let [attachment? (or (nil? attachment) attachment)
         disposition (str (if attachment? "attachment; " "") "filename=\"" filename "\"")]
     (assoc (ok body)

--- a/services/metadata/src/metadata/services/templates.clj
+++ b/services/metadata/src/metadata/services/templates.clj
@@ -1,7 +1,6 @@
 (ns metadata.services.templates
   (:use [clojure-commons.core :only [remove-nil-values]]
-        [korma.db :only [transaction]]
-        [ring.util.http-response :only [ok]])
+        [korma.db :only [transaction]])
   (:require [clojure-commons.assertions :as ca]
             [clojure.string :as string]
             [metadata.persistence.templates :as tp]
@@ -32,14 +31,6 @@
       :attributes
       (map (juxt :name :description :required :type #(if (:values %) (string/join ", " (map :value (:values %))) "")))
       (cons ["attribute name", "attribute description", "required (If you cannot provide,  enter 'not collected', 'not applicable' or 'missing'.)", "value type definition", "enum value options (you must enter one of these values)"]))))
-
-(defn csv-download-resp
-  [attachment filename body]
-  (let [attachment? (or (nil? attachment) attachment)
-        disposition (str (if attachment? "attachment; " "") "filename=\"" filename "\"")]
-    (assoc (ok body)
-           :headers {"Content-Type" "text/csv; charset=utf-8"
-                     "Content-Disposition" disposition})))
 
 ;; This function alias relies on view-template's error checking to throw an exception if a template
 ;; with the given ID doesn't exist.

--- a/services/metadata/src/metadata/util/csv.clj
+++ b/services/metadata/src/metadata/util/csv.clj
@@ -1,0 +1,8 @@
+(ns metadata.util.csv
+  (:require [clojure.data.csv :as csv]))
+
+(defn csv-string
+  [data]
+  (let [string-writer (java.io.StringWriter.)]
+    (csv/write-csv string-writer data)
+    (. string-writer toString)))

--- a/services/terrain/src/terrain/clients/metadata/raw.clj
+++ b/services/terrain/src/terrain/clients/metadata/raw.clj
@@ -154,6 +154,14 @@
   [template-id]
   (http/get (metadata-url "templates" template-id) (get-options)))
 
+(defn get-template-csv
+  [template-id]
+  (http/get (metadata-url "templates" template-id "blank-csv") (get-options)))
+
+(defn get-template-guide
+  [template-id]
+  (http/get (metadata-url "templates" template-id "guide-csv") (get-options)))
+
 (defn get-attribute
   [attr-id]
   (http/get (metadata-url "templates" "attr" attr-id) (get-options)))

--- a/services/terrain/src/terrain/routes/filesystem.clj
+++ b/services/terrain/src/terrain/routes/filesystem.clj
@@ -7,6 +7,7 @@
             [terrain.services.filesystem.directory :as dir]
             [terrain.services.filesystem.metadata :as meta]
             [terrain.services.filesystem.metadata-templates :as mt]
+            [terrain.clients.metadata.raw :as meta-raw]
             [terrain.services.filesystem.root :as root]
             [terrain.services.filesystem.sharing :as sharing]
             [terrain.services.filesystem.stat :as stat]
@@ -105,6 +106,12 @@
 
     (GET "/filesystem/metadata/template/:template-id" [template-id :as req]
       (controller req mt/do-metadata-template-view template-id))
+
+    (GET "/filesystem/metadata/template/:template-id/blank-csv" [template-id :as req]
+      (controller req meta-raw/get-template-csv template-id))
+
+    (GET "/filesystem/metadata/template/:template-id/guide-csv" [template-id :as req]
+      (controller req meta-raw/get-template-guide template-id))
 
     (GET "/filesystem/metadata/template/attr/:attr-id" [attr-id :as req]
       (controller req mt/do-metadata-attribute-view attr-id))


### PR DESCRIPTION
This adds four endpoints between metadata and terrain:

# Metadata

* `/templates/:template-id/blank-csv`: blank CSV file suitable for filling out and using for bulk upload
* `/templates:template-id/guide-csv`: guide to fields in the template, in CSV form

# Terrain

* `/secured/filesystem/metadata/template/:template-id/blank-csv` passing to the metadata blank-csv endpoint
* `/secured/filesystem/metadata/template/:template-id/guide-csv` passing to the metadata guide-csv endpoint

The metadata endpoints accept an `attachment` query parameter, which if set to false (default true) will exclude the "attachment" bit from the content-disposition, which makes it easier to see the output in swagger docs.

There's a corresponding gh-pages-metadata-template-csv branch documenting the terrain changes.