### PR TITLE
CORE-7642 and CORE-5906

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/propertyEditors/DecimalInputPropertyEditor.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/propertyEditors/DecimalInputPropertyEditor.java
@@ -4,6 +4,7 @@ import static org.iplantc.de.apps.integration.shared.AppIntegrationModule.Ids;
 import static org.iplantc.de.apps.integration.shared.AppIntegrationModule.PropertyPanelIds;
 import static org.iplantc.de.apps.integration.shared.AppIntegrationModule.PropertyPanelIds.ARGUMENT_OPTION;
 import static org.iplantc.de.apps.integration.shared.AppIntegrationModule.PropertyPanelIds.LABEL;
+
 import org.iplantc.de.apps.integration.client.view.propertyEditors.widgets.ArgumentValidatorEditor;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ArgumentEditorConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.SplittableToDoubleConverter;
@@ -151,6 +152,7 @@ public class DecimalInputPropertyEditor extends AbstractArgumentPropertyEditor {
 
     @UiHandler("validatorsEditor")
     void onValidatorListChanged(@SuppressWarnings("unused") ValueChangeEvent<List<ArgumentValidator>> event) {
+        model.setValidators(event.getValue());
         editorDriver.flush();
         this.getBoundEditorDelegate().accept(new Refresher());
     }

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/propertyEditors/IntegerInputPropertyEditor.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/propertyEditors/IntegerInputPropertyEditor.java
@@ -2,6 +2,7 @@ package org.iplantc.de.apps.integration.client.view.propertyEditors;
 
 import static org.iplantc.de.apps.integration.shared.AppIntegrationModule.Ids;
 import static org.iplantc.de.apps.integration.shared.AppIntegrationModule.PropertyPanelIds;
+
 import org.iplantc.de.apps.integration.client.view.propertyEditors.widgets.ArgumentValidatorEditor;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ArgumentEditorConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.SplittableToIntegerConverter;
@@ -157,6 +158,7 @@ public class IntegerInputPropertyEditor extends AbstractArgumentPropertyEditor {
 
     @UiHandler("validatorsEditor")
     void onValidatorListChanged(@SuppressWarnings("unused") ValueChangeEvent<List<ArgumentValidator>> event) {
+        model.setValidators(event.getValue());
         editorDriver.flush();
         this.getBoundEditorDelegate().accept(new Refresher());
     }

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/propertyEditors/TextInputPropertyEditor.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/propertyEditors/TextInputPropertyEditor.java
@@ -2,6 +2,7 @@ package org.iplantc.de.apps.integration.client.view.propertyEditors;
 
 import static org.iplantc.de.apps.integration.shared.AppIntegrationModule.Ids;
 import static org.iplantc.de.apps.integration.shared.AppIntegrationModule.PropertyPanelIds;
+
 import org.iplantc.de.apps.integration.client.view.propertyEditors.widgets.ArgumentValidatorEditor;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ArgumentEditorConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.SplittableToStringConverter;
@@ -149,6 +150,7 @@ public class TextInputPropertyEditor extends AbstractArgumentPropertyEditor {
 
     @UiHandler("validatorsEditor")
     void onValidatorListChanged(@SuppressWarnings("unused") ValueChangeEvent<List<ArgumentValidator>> event) {
+        model.setValidators(event.getValue());
         editorDriver.flush();
         this.getBoundEditorDelegate().accept(new Refresher());
     }

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/propertyEditors/widgets/ArgumentValidatorEditor.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/propertyEditors/widgets/ArgumentValidatorEditor.java
@@ -81,7 +81,7 @@ public class ArgumentValidatorEditor extends Composite implements ValueAwareEdit
             final AutoBean<ArgumentValidator> autoBean = AutoBeanUtils.getAutoBean(dlg.getArgumentValidator());
             autoBean.setTag(ArgumentValidator.TMP_ID_TAG, "tmpId-" + uniqueIdNum++);
             validators.getStore().add(autoBean.as());
-            ValueChangeEvent.fire(ArgumentValidatorEditor.this, validators.getStore().getAll());
+            ValueChangeEvent.fire(ArgumentValidatorEditor.this, getValidators());
         }
     }
 
@@ -317,7 +317,7 @@ public class ArgumentValidatorEditor extends Composite implements ValueAwareEdit
         for (ArgumentValidator av : selection) {
             validatorStore.remove(av);
         }
-        ValueChangeEvent.fire(this, selection);
+        ValueChangeEvent.fire(this, getValidators());
     }
 
     @UiHandler("edit")
@@ -329,13 +329,19 @@ public class ArgumentValidatorEditor extends Composite implements ValueAwareEdit
         // JDS Remove
         final int selectedItemIndex = validators.getStore().indexOf(selectedItem);
         validators.getStore().remove(selectedItem);
-        ValueChangeEvent.fire(this, Lists.newArrayList(selectedItem));
+        ValueChangeEvent.fire(this, getValidators());
         AddValidatorDialog dlg = new AddValidatorDialog(supportedValidatorTypes, avMessages);
         dlg.addOkButtonSelectHandler(new AddValidatorOkBtnSelectHandler(dlg));
         dlg.addCancelButtonSelectHandler(new AddValidatorCancelBtnSelectHandler(selectedItemIndex, selectedItem));
 
         dlg.setArgumentValidator(selectedItem);
         dlg.show();
+    }
+
+    List<ArgumentValidator> getValidators() {
+        List<ArgumentValidator> values = Lists.newArrayList();
+        values.addAll(validatorStore.getAll());
+        return values;
     }
 
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/converters/ArgumentEditorConverter.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/converters/ArgumentEditorConverter.java
@@ -142,14 +142,11 @@ public class ArgumentEditorConverter<T> extends Composite implements IArgumentEd
 
                 }
 
-                // If validation is not disabled, Re-apply the actual validator
-                if (!isValidationDisabled) {
-                    Object validator = autoBean.getTag(ArgumentValidator.VALIDATOR);
-                    if ((field instanceof Field<?>) && (validator != null)) {
-                        @SuppressWarnings("unchecked")
-                        Validator<T> val = (Validator<T>)validator;
-                        ((Field<T>)field).addValidator(val);
-                    }
+                // Re-apply the actual validator
+                Object validator = autoBean.getTag(ArgumentValidator.VALIDATOR);
+                if ((field instanceof Field<?>) && (validator != null)) {
+                    @SuppressWarnings("unchecked") Validator<T> val = (Validator<T>)validator;
+                    ((Field<T>)field).addValidator(val);
                 }
             }
         }

--- a/ui/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -24,6 +24,7 @@ import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.container.BorderLayoutContainer;
 import com.sencha.gxt.widget.core.client.container.HorizontalLayoutContainer;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.grid.CheckBoxSelectionModel;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -68,6 +69,12 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
         grid.setSelectionModel(checkBoxModel);
         checkBoxModel.setSelectionMode(SelectionMode.MULTI);
         grid.getView().setEmptyText(I18N.DISPLAY.noCollaborators());
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                setGridCheckBoxDebugIds();
+            }
+        });
         init();
         setMode(mode);
     }
@@ -75,9 +82,7 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     @Override
     public void addCollaborators(List<Collaborator> models) {
         listStore.addAll(models);
-        for (int i = 0; i < listStore.size(); i++) {
-            grid.getView().getCell(i, 0).setId(baseID + CollaboratorsModule.Ids.CHECKBOX_ITEM + i);
-        }
+        setGridCheckBoxDebugIds();
     }
 
     @Override
@@ -165,10 +170,13 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
         deleteBtn.ensureDebugId(baseID + CollaboratorsModule.Ids.DELETE);
         //Checkbox column config is at index 0
         grid.getView().getHeader().getHead(0).getElement().setId(baseID + CollaboratorsModule.Ids.CHECKBOX_HEADER);
+        searchField.setViewDebugId(CollaboratorsModule.Ids.SEARCH_LIST);
+    }
+
+    void setGridCheckBoxDebugIds() {
         for (int i = 0; i < listStore.size(); i++) {
             grid.getView().getCell(i, 0).setId(baseID + CollaboratorsModule.Ids.CHECKBOX_ITEM + i);
         }
-        searchField.setViewDebugId(CollaboratorsModule.Ids.SEARCH_LIST);
     }
 
     @UiFactory


### PR DESCRIPTION
CORE-7642 - This fixes a bug where validations added to an App (in particular for Integer ranges, Decimal ranges, and Text regex/max char which all use liststores) were not saved in the App Editor window.  There were two issues. First issue was that sometimes the validators in App Editor were never actually saved.  The second issue was that when a user went to launch the app, there was logic preventing the saved validators from ever being applied.

CORE-5906 - The static IDs in this ticket have all been validated previously except for the checkboxes in the grid in the Collaborators dialog. My assumption was that setting the IDs after the dialog had been shown (show method) would be sufficient, but since the checkboxes are inside the grid you have to wait to set the IDs after the grid itself has been rendered (ViewReadyHandler).