### PR TITLE
CORE-7741 Allow null ontology IRI’s in metadata responses.

### DIFF
--- a/libs/common-swagger-api/src/common_swagger_api/schema/ontologies.clj
+++ b/libs/common-swagger-api/src/common_swagger_api/schema/ontologies.clj
@@ -7,7 +7,7 @@
 (def OntologyClassIRIParam (describe String "A unique Class IRI"))
 
 (s/defschema OntologyDetails
-  {:iri        (describe String "The unique IRI for this Ontology")
+  {:iri        (describe (s/maybe String) "The unique IRI for this Ontology")
    :version    OntologyVersionParam
    :created_by (describe NonBlankString "The user who uploaded this Ontology")
    :created_on (describe Date "The date this Ontology was uploaded")})


### PR DESCRIPTION
Updated common-swagger-api.schema.ontologies/OntologyDetails to allow null `iri` fields.

This prevents `ERR_SCHEMA_VALIDATION` errors when uploading an ontology XML document that does not define the ontology's IRI.

Storing the ontology with a null IRI should not break any other functionality, since a unique ontology version is still created by the metadata service that's used in all other endpoints.