### PR TITLE
CORE-7700

### DIFF
--- a/docker/images.txt
+++ b/docker/images.txt
@@ -1,4 +1,5 @@
 anon-files
+app-registration
 clockwork
 condor-log-monitor
 curl-wrapper

--- a/docker/manifest-images.txt
+++ b/docker/manifest-images.txt
@@ -1,4 +1,5 @@
 anon-files
+app-registration
 clockwork
 data-info
 de
@@ -13,6 +14,7 @@ apps
 metadata
 monkey
 notification-agent
+permissions
 porklock
 saved-searches
 templeton

--- a/golang/build.sh
+++ b/golang/build.sh
@@ -27,4 +27,4 @@ docker run --rm \
 	-v $(pwd):/build \
 	-w /build \
 	$DOCKER_USER/buildenv:latest \
-	gb build -f -F --ldflags "-X main.appver=$VERSION -X main.gitref=$GIT_COMMIT -X main.builtby=$BUILD_USER"
+	gb build -f -F --ldflags "-X version.appver=$VERSION -X version.gitref=$GIT_COMMIT -X version.builtby=$BUILD_USER"

--- a/golang/src/condor-launcher/condor.go
+++ b/golang/src/condor-launcher/condor.go
@@ -45,15 +45,10 @@ import (
 	"path/filepath"
 	"text/template"
 	"time"
+	"version"
 
 	"github.com/olebedev/config"
 	"github.com/streadway/amqp"
-)
-
-var (
-	gitref  string
-	appver  string
-	builtby string
 )
 
 // CondorLauncher contains the condor-launcher application state.
@@ -390,31 +385,18 @@ func (cl *CondorLauncher) startHeldTicker(client *messaging.Client) (*time.Ticke
 	return t, nil
 }
 
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
-
 func main() {
 	var (
-		cfgPath = flag.String("config", "", "Path to the config file. Required.")
-		version = flag.Bool("version", false, "Print the version information")
+		cfgPath     = flag.String("config", "", "Path to the config file. Required.")
+		showVersion = flag.Bool("version", false, "Print the version information")
 	)
 
 	flag.Parse()
 
 	logcabin.Init("condor-launcher", "condor-launcher")
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/de-job-killer/main.go
+++ b/golang/src/de-job-killer/main.go
@@ -10,32 +10,13 @@ package main
 import (
 	"configurate"
 	"flag"
-	"fmt"
 	"log"
 	"logcabin"
 	"messaging"
 	"model"
 	"os"
+	"version"
 )
-
-var (
-	gitref  string
-	appver  string
-	builtby string
-)
-
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 func doKillJob(client *messaging.Client, uuid string) error {
 	var err error
@@ -63,17 +44,17 @@ func doStatusMessage(client *messaging.Client, uuid string) error {
 
 func main() {
 	var (
-		killJob   = flag.Bool("kill", false, "Send out a stop request. Conflicts with --send-status.")
-		statusMsg = flag.Bool("send-status", false, "Send out a job status. Conflicts with --kill.")
-		version   = flag.Bool("version", false, "Print the version information.")
-		config    = flag.String("config", "", "Path to the jobservices config. Required.")
-		uuid      = flag.String("uuid", "", "The job UUID to operate against.")
+		killJob     = flag.Bool("kill", false, "Send out a stop request. Conflicts with --send-status.")
+		statusMsg   = flag.Bool("send-status", false, "Send out a job status. Conflicts with --kill.")
+		showVersion = flag.Bool("version", false, "Print the version information.")
+		config      = flag.String("config", "", "Path to the jobservices config. Required.")
+		uuid        = flag.String("uuid", "", "The job UUID to operate against.")
 	)
 
 	flag.Parse()
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/image-janitor/main.go
+++ b/golang/src/image-janitor/main.go
@@ -14,29 +14,14 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"version"
 
 	"github.com/olebedev/config"
 )
 
 var (
-	gitref        string
-	appver        string
-	builtby       string
 	filenameRegex = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.json$`)
 )
-
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 // ImageJanitor contains application state for image-janitor
 type ImageJanitor struct {
@@ -251,7 +236,7 @@ func (i *ImageJanitor) readExcludes(readFrom string) (map[string]bool, error) {
 
 func main() {
 	var (
-		version       = flag.Bool("version", false, "Print version information.")
+		showVersion   = flag.Bool("version", false, "Print version information.")
 		interval      = flag.String("interval", "1m", "Time between clean up attempts.")
 		cfgPath       = flag.String("config", "/etc/jobservices.yml", "Path to the config.")
 		readFrom      = flag.String("read-from", "/opt/image-janitor", "The directory that job files are read from.")
@@ -265,8 +250,8 @@ func main() {
 
 	logcabin.Init("image-janitor", "image-janitor")
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/jex-adapter/main.go
+++ b/golang/src/jex-adapter/main.go
@@ -19,29 +19,11 @@ import (
 	"model"
 	"net/http"
 	"os"
+	"version"
 
 	"github.com/gorilla/mux"
 	"github.com/olebedev/config"
 )
-
-var (
-	gitref  string
-	appver  string
-	builtby string
-)
-
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 // JEXAdapter contains the application state for jex-adapter.
 type JEXAdapter struct {
@@ -257,18 +239,18 @@ func (j *JEXAdapter) NewRouter() *mux.Router {
 
 func main() {
 	var (
-		version = flag.Bool("version", false, "Print version information")
-		cfgPath = flag.String("config", "", "Path to the configuration file")
-		addr    = flag.String("addr", ":60000", "The port to listen on for HTTP requests")
-		amqpURI string
+		showVersion = flag.Bool("version", false, "Print version information")
+		cfgPath     = flag.String("config", "", "Path to the configuration file")
+		addr        = flag.String("addr", ":60000", "The port to listen on for HTTP requests")
+		amqpURI     string
 	)
 
 	flag.Parse()
 
 	logcabin.Init("jex-adapter", "jex-adapter")
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/job-status-recorder/main.go
+++ b/golang/src/job-status-recorder/main.go
@@ -11,36 +11,17 @@ import (
 	"database/sql"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"logcabin"
 	"messaging"
 	"net"
 	"os"
 	"strconv"
+	"version"
 
 	_ "github.com/lib/pq"
 	"github.com/olebedev/config"
 	"github.com/streadway/amqp"
 )
-
-var (
-	gitref  string
-	appver  string
-	builtby string
-)
-
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 // JobStatusRecorder contains the application state for job-status-recorder
 type JobStatusRecorder struct {
@@ -161,21 +142,21 @@ func (r *JobStatusRecorder) msg(delivery amqp.Delivery) {
 
 func main() {
 	var (
-		err     error
-		app     *JobStatusRecorder
-		cfg     *config.Config
-		version = flag.Bool("version", false, "Print the version information")
-		cfgPath = flag.String("config", "", "The path to the config file")
-		dbURI   = flag.String("db", "", "The URI used to connect to the database")
-		amqpURI = flag.String("amqp", "", "The URI used to connect to the amqp broker")
+		err         error
+		app         *JobStatusRecorder
+		cfg         *config.Config
+		showVersion = flag.Bool("version", false, "Print the version information")
+		cfgPath     = flag.String("config", "", "The path to the config file")
+		dbURI       = flag.String("db", "", "The URI used to connect to the database")
+		amqpURI     = flag.String("amqp", "", "The URI used to connect to the amqp broker")
 	)
 
 	flag.Parse()
 
 	logcabin.Init("job-status-recorder", "job-status-recorder")
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/job-status-to-apps-adapter/main.go
+++ b/golang/src/job-status-to-apps-adapter/main.go
@@ -25,29 +25,11 @@ import (
 	"net/http"
 	"os"
 	"time"
+	"version"
 
 	_ "github.com/lib/pq"
 	"github.com/olebedev/config"
 )
-
-var (
-	gitref  string
-	appver  string
-	builtby string
-)
-
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 // JobStatusUpdate contains the data POSTed to the apps service.
 type JobStatusUpdate struct {
@@ -320,22 +302,22 @@ func ScanAndPropagate(d *sql.DB, maxRetries int64, appsURI string) error {
 
 func main() {
 	var (
-		cfgPath    = flag.String("config", "", "Path to the config file. Required.")
-		version    = flag.Bool("version", false, "Print the version information")
-		dbURI      = flag.String("db", "", "The URI used to connect to the database")
-		maxRetries = flag.Int64("retries", 3, "The maximum number of propagation retries to make")
-		err        error
-		cfg        *config.Config
-		db         *sql.DB
-		appsURI    string
+		cfgPath     = flag.String("config", "", "Path to the config file. Required.")
+		showVersion = flag.Bool("version", false, "Print the version information")
+		dbURI       = flag.String("db", "", "The URI used to connect to the database")
+		maxRetries  = flag.Int64("retries", 3, "The maximum number of propagation retries to make")
+		err         error
+		cfg         *config.Config
+		db          *sql.DB
+		appsURI     string
 	)
 
 	flag.Parse()
 
 	logcabin.Init("job-status-to-apps-adapter", "job-status-to-apps-adapter")
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/permissions/conversions/app-registration/main.go
+++ b/golang/src/permissions/conversions/app-registration/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"logcabin"
 	"net/url"
+	"os"
+	"version"
 
 	_ "github.com/lib/pq"
 )
@@ -243,9 +245,16 @@ func main() {
 	config := flag.String("config", "", "The path to the configuration file.")
 	deDburi := flag.String("de-database-uri", "", "The URI to use when connecting to the DE database.")
 	deDbname := flag.String("de-database-name", "de", "The name of the DE database.")
+	showVersion := flag.Bool("version", false, "Display version information and exit.")
 
 	// Parse the command line arguments.
 	flag.Parse()
+
+	// Print the version information and exit if we're told to.
+	if *showVersion {
+		version.AppVersion()
+		os.Exit(0)
+	}
 
 	// Validate the command-line options.
 	if *config == "" {

--- a/golang/src/permissions/conversions/grouper-to-perms/main.go
+++ b/golang/src/permissions/conversions/grouper-to-perms/main.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"github.com/go-swagger/go-swagger/httpkit/middleware"
 	"logcabin"
+	"os"
 	"permissions/models"
 	perms_impl "permissions/restapi/impl/permissions"
 	perms "permissions/restapi/operations/permissions"
 	"strings"
+	"version"
 
 	_ "github.com/lib/pq"
 )
@@ -84,9 +86,16 @@ func runConversion(handler requestHandler, grouperDb *sql.DB, permissionDefName 
 func main() {
 	config := flag.String("config", "", "The path to the configuration file.")
 	convertJobs := flag.Bool("jobs", true, "True if jobs should be included in the conversion.")
+	showVersion := flag.Bool("version", false, "Display the version information and exit.")
 
 	// Parse the command line arguments.
 	flag.Parse()
+
+	// Display the version information and exit if we're told to.
+	if *showVersion {
+		version.AppVersion()
+		os.Exit(0)
+	}
 
 	// Validate the command-line options.
 	if *config == "" {

--- a/golang/src/permissions/restapi/configure_permissions.go
+++ b/golang/src/permissions/restapi/configure_permissions.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"logcabin"
 	"net/http"
+	"os"
 	"strings"
+	"version"
 
 	errors "github.com/go-swagger/go-swagger/errors"
 	httpkit "github.com/go-swagger/go-swagger/httpkit"
@@ -35,7 +37,8 @@ import (
 
 // Command line options that aren't managed by go-swagger.
 var options struct {
-	CfgPath string `long:"config" default:"/etc/iplant/de/permissions.yaml" description:"The path to the config file"`
+	CfgPath     string `long:"config" default:"/etc/iplant/de/permissions.yaml" description:"The path to the config file"`
+	ShowVersion bool   `short:"v" long:"version" description:"Print the app version and exit"`
 }
 
 // Register the command-line options.
@@ -60,6 +63,11 @@ var grouperClient *grouper.GrouperClient
 
 // Initialize the service.
 func initService() error {
+	if options.ShowVersion {
+		version.AppVersion()
+		os.Exit(0)
+	}
+
 	var (
 		err error
 		cfg *config.Config

--- a/golang/src/road-runner/main.go
+++ b/golang/src/road-runner/main.go
@@ -23,18 +23,16 @@ import (
 	"path"
 	"syscall"
 	"time"
+	"version"
 
 	"github.com/olebedev/config"
 	"github.com/streadway/amqp"
 )
 
 var (
-	gitref  string
-	appver  string
-	builtby string
-	job     *model.Job
-	dckr    *dockerops.Docker
-	client  *messaging.Client
+	job    *model.Job
+	dckr   *dockerops.Docker
+	client *messaging.Client
 )
 
 func signals() {
@@ -70,19 +68,6 @@ func signals() {
 func init() {
 	logcabin.Init("road-runner", "road-runner")
 	signals()
-}
-
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
 }
 
 func hostname() string {
@@ -262,19 +247,19 @@ func deleteJobFile(uuid, toDir string) {
 
 func main() {
 	var (
-		version   = flag.Bool("version", false, "Print the version information")
-		jobFile   = flag.String("job", "", "The path to the job description file")
-		cfgPath   = flag.String("config", "", "The path to the config file")
-		writeTo   = flag.String("write-to", "/opt/image-janitor", "The directory to copy job files to.")
-		dockerURI = flag.String("docker", "unix:///var/run/docker.sock", "The URI for connecting to docker.")
-		err       error
-		cfg       *config.Config
+		showVersion = flag.Bool("version", false, "Print the version information")
+		jobFile     = flag.String("job", "", "The path to the job description file")
+		cfgPath     = flag.String("config", "", "The path to the config file")
+		writeTo     = flag.String("write-to", "/opt/image-janitor", "The directory to copy job files to.")
+		dockerURI   = flag.String("docker", "unix:///var/run/docker.sock", "The URI for connecting to docker.")
+		err         error
+		cfg         *config.Config
 	)
 
 	flag.Parse()
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/saved-searches/main.go
+++ b/golang/src/saved-searches/main.go
@@ -13,30 +13,12 @@ import (
 	"os"
 	"queries"
 	"strings"
+	"version"
 
 	"github.com/gorilla/mux"
 	_ "github.com/lib/pq"
 	"github.com/olebedev/config"
 )
-
-var (
-	gitref  string
-	appver  string
-	builtby string
-)
-
-// AppVersion prints the version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 func badRequest(writer http.ResponseWriter, msg string) {
 	writer.WriteHeader(http.StatusBadRequest)
@@ -377,17 +359,17 @@ func fixAddr(addr string) string {
 
 func main() {
 	var (
-		version = flag.Bool("version", false, "Print the version information")
-		cfgPath = flag.String("config", "/etc/iplant/de/jobservices.yml", "The path to the config file")
-		port    = flag.String("port", "60000", "The port number to listen on")
-		err     error
-		cfg     *config.Config
+		showVersion = flag.Bool("version", false, "Print the version information")
+		cfgPath     = flag.String("config", "/etc/iplant/de/jobservices.yml", "The path to the config file")
+		port        = flag.String("port", "60000", "The port number to listen on")
+		err         error
+		cfg         *config.Config
 	)
 
 	flag.Parse()
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/slot-cacher/main.go
+++ b/golang/src/slot-cacher/main.go
@@ -12,27 +12,12 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"version"
 )
 
 var (
-	gitref       string
-	appver       string
-	builtby      string
 	condorStatus = "condor_status"
 )
-
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 type slotStorer struct {
 	numSlots  int64
@@ -130,19 +115,19 @@ func (s *slotStorer) Respond(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	var (
-		interval = flag.String("interval", "5s", "The length of time between cache refreshes. Must be in Go's duration string format.")
-		port     = flag.String("port", ":60000", "The port to listen on.")
-		version  = flag.Bool("version", false, "Print the version information")
-		err      error
-		duration time.Duration
-		t        *time.Ticker
-		s        *slotStorer
+		interval    = flag.String("interval", "5s", "The length of time between cache refreshes. Must be in Go's duration string format.")
+		port        = flag.String("port", ":60000", "The port to listen on.")
+		showVersion = flag.Bool("version", false, "Print the version information")
+		err         error
+		duration    time.Duration
+		t           *time.Ticker
+		s           *slotStorer
 	)
 
 	flag.Parse()
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/templeton/main.go
+++ b/golang/src/templeton/main.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"version"
 
 	"templeton/database"
 	"templeton/elasticsearch"
@@ -19,36 +20,19 @@ import (
 )
 
 var (
-	version            = flag.Bool("version", false, "Print version information")
+	showVersion        = flag.Bool("version", false, "Print version information")
 	mode               = flag.String("mode", "", "One of 'periodic', 'incremental', or 'full'. Required except for --version.")
 	cfgPath            = flag.String("config", "", "Path to the configuration file. Required except for --version.")
 	amqpURI            string
 	elasticsearchBase  string
 	elasticsearchIndex string
 	dbURI              string
-	gitref             string
-	appver             string
-	builtby            string
 	cfg                *config.Config
 )
 
 func init() {
 	flag.Parse()
 	logcabin.Init("templeton", "templeton")
-}
-
-// AppVersion prints version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
 }
 
 func checkMode() {
@@ -163,8 +147,8 @@ func doIncrementalMode(es *elasticsearch.Elasticer, d *database.Databaser, clien
 }
 
 func main() {
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/tree-urls/main.go
+++ b/golang/src/tree-urls/main.go
@@ -13,30 +13,12 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"version"
 
 	"github.com/gorilla/mux"
 	_ "github.com/lib/pq"
 	"github.com/olebedev/config"
 )
-
-var (
-	gitref  string
-	appver  string
-	builtby string
-)
-
-// AppVersion prints the version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 func badRequest(writer http.ResponseWriter, msg string) {
 	writer.WriteHeader(http.StatusBadRequest)
@@ -356,17 +338,17 @@ func fixAddr(addr string) string {
 
 func main() {
 	var (
-		version = flag.Bool("version", false, "Print the version information")
-		cfgPath = flag.String("config", "/etc/iplant/de/jobservices.yml", "The path to the config file")
-		port    = flag.String("port", "60000", "The port number to listen on")
-		err     error
-		cfg     *config.Config
+		showVersion = flag.Bool("version", false, "Print the version information")
+		cfgPath     = flag.String("config", "/etc/iplant/de/jobservices.yml", "The path to the config file")
+		port        = flag.String("port", "60000", "The port number to listen on")
+		err         error
+		cfg         *config.Config
 	)
 
 	flag.Parse()
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/user-preferences/main.go
+++ b/golang/src/user-preferences/main.go
@@ -13,30 +13,12 @@ import (
 	"os"
 	"queries"
 	"strings"
+	"version"
 
 	"github.com/gorilla/mux"
 	_ "github.com/lib/pq"
 	"github.com/olebedev/config"
 )
-
-var (
-	gitref  string
-	appver  string
-	builtby string
-)
-
-// AppVersion prints the version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 // App defines the interface for a user-preferences application
 type App interface {
@@ -410,17 +392,17 @@ func fixAddr(addr string) string {
 
 func main() {
 	var (
-		version = flag.Bool("version", false, "Print the version information")
-		cfgPath = flag.String("config", "/etc/iplant/de/jobservices.yml", "The path to the config file")
-		port    = flag.String("port", "60000", "The port number to listen on")
-		err     error
-		cfg     *config.Config
+		showVersion = flag.Bool("version", false, "Print the version information")
+		cfgPath     = flag.String("config", "/etc/iplant/de/jobservices.yml", "The path to the config file")
+		port        = flag.String("port", "60000", "The port number to listen on")
+		err         error
+		cfg         *config.Config
 	)
 
 	flag.Parse()
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/user-sessions/main.go
+++ b/golang/src/user-sessions/main.go
@@ -13,30 +13,12 @@ import (
 	"os"
 	"queries"
 	"strings"
+	"version"
 
 	"github.com/gorilla/mux"
 	_ "github.com/lib/pq"
 	"github.com/olebedev/config"
 )
-
-var (
-	gitref  string
-	appver  string
-	builtby string
-)
-
-// AppVersion prints the version information to stdout
-func AppVersion() {
-	if appver != "" {
-		fmt.Printf("App-Version: %s\n", appver)
-	}
-	if gitref != "" {
-		fmt.Printf("Git-Ref: %s\n", gitref)
-	}
-	if builtby != "" {
-		fmt.Printf("Built-By: %s\n", builtby)
-	}
-}
 
 // App defines the interface for a user-sessions application
 type App interface {
@@ -390,17 +372,17 @@ func fixAddr(addr string) string {
 
 func main() {
 	var (
-		version = flag.Bool("version", false, "Print the version information")
-		cfgPath = flag.String("config", "/etc/iplant/de/jobservices.yml", "The path to the config file")
-		port    = flag.String("port", "60000", "The port number to listen on")
-		err     error
-		cfg     *config.Config
+		showVersion = flag.Bool("version", false, "Print the version information")
+		cfgPath     = flag.String("config", "/etc/iplant/de/jobservices.yml", "The path to the config file")
+		port        = flag.String("port", "60000", "The port number to listen on")
+		err         error
+		cfg         *config.Config
 	)
 
 	flag.Parse()
 
-	if *version {
-		AppVersion()
+	if *showVersion {
+		version.AppVersion()
 		os.Exit(0)
 	}
 

--- a/golang/src/version/version.go
+++ b/golang/src/version/version.go
@@ -1,0 +1,24 @@
+package version
+
+import (
+	"fmt"
+)
+
+var (
+	gitref  string
+	appver  string
+	builtby string
+)
+
+// AppVersion prints the version information to stdout
+func AppVersion() {
+	if appver != "" {
+		fmt.Printf("App-Version: %s\n", appver)
+	}
+	if gitref != "" {
+		fmt.Printf("Git-Ref: %s\n", gitref)
+	}
+	if builtby != "" {
+		fmt.Printf("Built-By: %s\n", builtby)
+	}
+}


### PR DESCRIPTION
This change adds `app-registration` and `permissions` to the lists of images to be tagged automatically and to be included in the QA drop manifest file. Because I'm using `go-swagger` in the permissions service, I can't easily add variables to the `main` package. Because of this, I created a new `version` package and modified all existing Go services and utilities to use it.
