### PR TITLE
Split job-status-to-apps-adapter and job-status-recorder into their own hostgroups

### DIFF
--- a/ansible/playbooks/de-deploy-services.yaml
+++ b/ansible/playbooks/de-deploy-services.yaml
@@ -376,7 +376,7 @@
       msg: ":heavy_check_mark: Done deploying infosquito"
 
 - name: Redeploy job-status-to-apps-adapter
-  hosts: jexevents
+  hosts: job-status-to-apps-adapter:&systems
   sudo: true
   gather_facts: false
   tags:
@@ -393,7 +393,7 @@
       msg: ":heavy_check_mark: Done deploying job-status-to-apps-adapter"
 
 - name: Redeploy job-status-recorder
-  hosts: jexevents
+  hosts: job-status-recorder:&systems
   sudo: true
   gather_facts: false
   tags:


### PR DESCRIPTION
(in de-deploy-services.yaml)

This is to accommodate the new split in prod. There's also a branch in private ansible named after the new server.

This branch, and that, are against their respective beta branches since we'll want them for release on Tuesday.