### PR TITLE
CORE-7745 Add deleted flag to metadata db ontologies table.

### DIFF
--- a/databases/metadata/src/main/conversions/c270_2016062401.clj
+++ b/databases/metadata/src/main/conversions/c270_2016062401.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c270-2016062401
+  (:use [korma.core :exclude [update]]
+        [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version."
+  "2.7.0:20160624.01")
+
+(defn- add-ontologies-deleted-flag
+  []
+  (println "\t* Add 'deleted' flag to ontologies table...")
+  (exec-sql-statement "ALTER TABLE ontologies ADD COLUMN deleted BOOLEAN DEFAULT FALSE"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-ontologies-deleted-flag))

--- a/databases/metadata/src/main/data/99_version.sql
+++ b/databases/metadata/src/main/data/99_version.sql
@@ -12,3 +12,4 @@ INSERT INTO version (version) VALUES ('2.4.0:20151210.01');
 INSERT INTO version (version) VALUES ('2.6.0:20160331.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160513.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160614.01');
+INSERT INTO version (version) VALUES ('2.7.0:20160624.01');

--- a/databases/metadata/src/main/tables/ontologies.sql
+++ b/databases/metadata/src/main/tables/ontologies.sql
@@ -6,6 +6,7 @@ SET search_path = public, pg_catalog;
 CREATE TABLE ontologies (
   version VARCHAR NOT NULL,
   iri VARCHAR,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
   created_by VARCHAR(512) NOT NULL,
   created_on TIMESTAMP DEFAULT now() NOT NULL,
   xml TEXT NOT NULL

--- a/libs/kameleon/project.clj
+++ b/libs/kameleon/project.clj
@@ -14,4 +14,4 @@
                  [slingshot "0.12.2"]]
   :plugins [[lein-marginalia "0.7.1"]
             [test2junit "1.1.3"]]
-  :manifest {"db-version" "2.7.0:20160614.01"})
+  :manifest {"db-version" "2.7.0:20160624.01"})


### PR DESCRIPTION
A deleted flag won't be necessary for the `ontology_classes` or `ontology_hierarchies` tables.
A hierarchy will be deleted directly, which will delete the associated `ontology_classes` (and `ontology_hierarchies` by cascade).
They can easily be added back with the "save hierarchies" endpoint, which will add the exact same classes and hierarchies under a hierarchy root, parsed from the saved ontology in the `ontologies` table.