### PR TITLE
CORE-7746 Add metadata admin DELETE ontology and hierarchy endpoints.

### DIFF
--- a/libs/iplant-clojure-commons/src/clojure_commons/exception_util.clj
+++ b/libs/iplant-clojure-commons/src/clojure_commons/exception_util.clj
@@ -22,6 +22,11 @@
   [reason & {:as ex-info}]
   (throw+ (assoc ex-info :type ::cx/bad-request :error reason)))
 
+(defn illegal-argument
+  "Throws an error indicating that that a bad request argument was received."
+  [reason & {:as ex-info}]
+  (throw+ (assoc ex-info :type ::cx/illegal-argument :error reason)))
+
 (defn not-found
   "Throws an error indicating that a resource could not be found."
   [reason & {:as ex-info}]

--- a/libs/metadata-client/src/metadata_client/core.clj
+++ b/libs/metadata-client/src/metadata_client/core.clj
@@ -35,7 +35,13 @@
    :as               as
    :follow-redirects false})
 
+(def ^:private delete-options get-options)
 (def ^:private put-options post-options)
+
+(defn delete-ontology
+  [username ontology-version]
+  (http/delete (metadata-url-encoded "admin" "ontologies" ontology-version)
+               (delete-options {:user username})))
 
 (defn list-ontologies
   [username]

--- a/services/apps/src/apps/routes/admin.clj
+++ b/services/apps/src/apps/routes/admin.clj
@@ -181,6 +181,19 @@
   "GET /ontologies"))
         (ok (admin/list-ontologies current-user)))
 
+  (DELETE* "/:ontology-version" []
+           :path-params [ontology-version :- OntologyVersionParam]
+           :query [params SecuredQueryParams]
+           :middlewares [wrap-metadata-base-url]
+           :summary "Delete an Ontology"
+           :description (str
+"Marks an Ontology as deleted in the metadata service.
+ Returns `ERR_ILLEGAL_ARGUMENT` when attempting to delete the active `ontology-version`."
+(get-endpoint-delegate-block
+  "metadata"
+  "DELETE /admin/ontologies/{ontology-version}"))
+           (admin/delete-ontology current-user ontology-version))
+
   (POST* "/:ontology-version" []
          :path-params [ontology-version :- OntologyVersionParam]
          :query [params SecuredQueryParams]

--- a/services/apps/src/apps/service/apps/de/admin.clj
+++ b/services/apps/src/apps/service/apps/de/admin.clj
@@ -28,43 +28,38 @@
   "Validates the length of an App Category name."
   [name]
   (when (> (count name) max-app-category-name-len)
-    (throw+ {:type  :clojure-commons.exception/illegal-argument
-             :error "App Category name too long."
-             :name  name})))
+    (ex-util/illegal-argument "App Category name too long."
+                              :name  name)))
 
 (defn- validate-subcategory-name
   "Validates that the given subcategory name is available under the given App Category parent ID."
   [parent-id name]
   (when (app-groups/category-contains-subcategory? parent-id name)
-    (throw+ {:type      :clojure-commons.exception/illegal-argument
-             :error     "Parent App Category already contains a subcategory with that name"
-             :parent_id parent-id
-             :name      name})))
+    (ex-util/illegal-argument "Parent App Category already contains a subcategory with that name"
+                              :parent_id parent-id
+                              :name      name)))
 
 (defn- validate-category-empty
   "Validates that the given App Category contains no Apps directly under it."
   [parent-id]
   (when (app-groups/category-contains-apps? parent-id)
-    (throw+ {:type      :clojure-commons.exception/illegal-argument
-             :error     "Parent App Category already contains Apps"
-             :parent_id parent-id})))
+    (ex-util/illegal-argument "Parent App Category already contains Apps"
+                              :parent_id parent-id)))
 
 (defn- validate-category-hierarchy-empty
   "Validates that the given App Category and its subcategories contain no Apps."
   [category-id requestor]
   (when (app-groups/category-hierarchy-contains-apps? category-id)
-    (throw+ {:type         :clojure-commons.exception/illegal-argument
-             :error        "App Category, or one of its subcategories, still contain Apps"
-             :category_id  category-id
-             :requested_by requestor})))
+    (ex-util/illegal-argument "App Category, or one of its subcategories, still contain Apps"
+                              :category_id  category-id
+                              :requested_by requestor)))
 
 (defn- validate-category-not-ancestor-of-parent
   [category-id parent-id]
   (when (app-groups/category-ancestor-of-subcategory? category-id parent-id)
-    (throw+ {:type        :clojure-commons.exception/illegal-argument
-             :error       "App Category is an ancestor of the destination Category"
-             :category_id category-id
-             :parent_id   parent-id})))
+    (ex-util/illegal-argument "App Category is an ancestor of the destination Category"
+                              :category_id category-id
+                              :parent_id   parent-id)))
 
 (defn delete-app
   "This service marks an existing app as deleted in the database."

--- a/services/apps/src/apps/service/apps/de/admin.clj
+++ b/services/apps/src/apps/service/apps/de/admin.clj
@@ -9,6 +9,7 @@
             [apps.persistence.app-metadata :as persistence]
             [apps.persistence.categories :as db-categories]
             [apps.service.apps.de.validation :as av]
+            [clojure-commons.exception-util :as ex-util]
             [metadata-client.core :as metadata-client]))
 
 (def ^:private max-app-category-name-len 255)
@@ -170,3 +171,10 @@
   [{:keys [username]} ontology-version]
   (let [version-details (db-categories/add-hierarchy-version username ontology-version)]
     (assoc version-details :applied_by username)))
+
+(defn delete-ontology
+  [{:keys [username]} ontology-version]
+  (let [active-version (db-categories/get-active-hierarchy-version)]
+    (when (= ontology-version active-version)
+      (ex-util/illegal-argument "The active app hierarchy version cannot be marked as deleted.")))
+  (metadata-client/delete-ontology username ontology-version))

--- a/services/metadata/src/metadata/routes/ontologies.clj
+++ b/services/metadata/src/metadata/routes/ontologies.clj
@@ -62,6 +62,23 @@
            :description "Saves an Ontology XML document in the database."
            (ok (service/save-ontology-xml user ontology-xml)))
 
+    (DELETE* "/:ontology-version" []
+             :path-params [ontology-version :- OntologyVersionParam]
+             :query [{:keys [user]} StandardUserQueryParams]
+             :summary "Delete an Ontology"
+             :description "Marks an Ontology as deleted in the database."
+             (ok (service/delete-ontology user ontology-version)))
+
+    (DELETE* "/:ontology-version/:root-iri" []
+             :path-params [ontology-version :- OntologyVersionParam
+                           root-iri :- OntologyClassIRIParam]
+             :query [{:keys [user]} StandardUserQueryParams]
+             :summary "Delete an Ontology Hierarchy"
+             :description
+             "Removes an Ontology Hierarchy and all associated Ontology Classes saved under the given
+              `root-iri` for the given `ontology-version`."
+             (ok (service/delete-hierarchy user ontology-version root-iri)))
+
     (PUT* "/:ontology-version/:root-iri" []
           :path-params [ontology-version :- OntologyVersionParam
                         root-iri :- OntologyClassIRIParam]

--- a/services/metadata/src/metadata/services/ontology.clj
+++ b/services/metadata/src/metadata/services/ontology.clj
@@ -6,6 +6,7 @@
             [clj-time.core :as time]
             [clj-time.format :as time-format]
             [clojure.tools.logging :as log]
+            [clojure-commons.exception-util :as ex-util]
             [metadata.persistence.avu :as avu-db]
             [metadata.persistence.ontologies :as ont-db]
             [metadata.util.ontology :as util]
@@ -78,9 +79,8 @@
   (transaction
     (let [ontology (ont-db/get-ontology-details ontology-version)]
       (when-not ontology
-        (throw+ {:type    :clojure-commons.exception/not-found
-                 :version ontology-version
-                 :error   "An ontology with this version was not found."}))
+        (ex-util/not-found "An ontology with this version was not found."
+                           :version ontology-version))
       (log/info user "deleting ontology" ontology-version)
       (ont-db/mark-ontology-deleted ontology-version)))
   nil)

--- a/services/terrain/src/terrain/clients/apps/raw.clj
+++ b/services/terrain/src/terrain/clients/apps/raw.clj
@@ -38,6 +38,13 @@
                :as               :stream
                :follow-redirects false}))
 
+(defn delete-ontology
+  [ontology-version]
+  (client/delete (apps-url-encoded "admin" "ontologies" ontology-version)
+                 {:query-params     (secured-params)
+                  :as               :stream
+                  :follow-redirects false}))
+
 (defn set-ontology-version
   [ontology-version]
   (client/post (apps-url-encoded "admin" "ontologies" ontology-version)

--- a/services/terrain/src/terrain/clients/metadata/raw.clj
+++ b/services/terrain/src/terrain/clients/metadata/raw.clj
@@ -197,6 +197,10 @@
                                   :content   istream}]
               :follow-redirects false}))
 
+(defn delete-app-category-hierarchy
+  [ontology-version root-iri]
+  (http/delete (metadata-url-encoded "admin" "ontologies" ontology-version root-iri) (delete-options)))
+
 (defn save-ontology-hierarchy
   [ontology-version root-iri]
   (http/put (metadata-url-encoded "admin" "ontologies" ontology-version root-iri) (get-options)))

--- a/services/terrain/src/terrain/routes/metadata.clj
+++ b/services/terrain/src/terrain/routes/metadata.clj
@@ -72,11 +72,17 @@
    (POST "/ontologies" [:as request]
      (service/success-response (metadata/upload-ontology request)))
 
+   (DELETE "/ontologies/:ontology-version" [ontology-version]
+     (service/success-response (apps/delete-ontology ontology-version)))
+
    (GET "/ontologies/:ontology-version" [ontology-version]
      (service/success-response (metadata-client/get-ontology-hierarchies ontology-version)))
 
    (POST "/ontologies/:ontology-version" [ontology-version]
      (service/success-response (apps/set-ontology-version ontology-version)))
+
+   (DELETE "/ontologies/:ontology-version/:root-iri" [ontology-version root-iri]
+     (service/success-response (metadata-client/delete-app-category-hierarchy ontology-version root-iri)))
 
    (GET "/ontologies/:ontology-version/:root-iri" [ontology-version root-iri :as {params :params}]
      (service/success-response (apps/get-app-category-hierarchy ontology-version root-iri params)))


### PR DESCRIPTION
These changes allow an admin to mark an ontology as deleted (so it no longer displays in the ontology listing), and to delete all classes under an ontology hierarchy for a given `ontology-version`.
This will allow the admin to add an ontology hierarchy root, and then selectively remove sub-hierarchies, or the entire hierarchy from the root.

Classes and sub-hierarchies removed with the new endpoint can easily be re-added by re-saving the hierarchy root with the `PUT /admin/ontologies/{ontology-version}/{root-iri}` endpoint (it will only save classes and hierarchies that are not already saved under the given root).

## New metadata service endpoints
* `DELETE /admin/ontologies/{ontology-version}`
* `DELETE /admin/ontologies/{ontology-version}/{root-iri}`

## New apps service endpoint
* `DELETE /admin/ontologies/{ontology-version}`
    * Returns an error if the admin tries to mark the `active` ontology deleted, otherwise it acts as a passthrough to the metadata service endpoint.

## New terrain passthrough endpoints
* `DELETE /admin/ontologies/{ontology-version}`
    * Passthrough to apps
* `DELETE /admin/ontologies/{ontology-version}/{root-iri}`
    * Passthrough to metadata