### PR TITLE
CORE-7758: schema validation when emptying an already-empty trash

### DIFF
--- a/services/data-info/src/data_info/routes/domain/trash.clj
+++ b/services/data-info/src/data_info/routes/domain/trash.clj
@@ -4,7 +4,7 @@
   (:require [schema.core :as s]))
 
 (s/defschema Trash
-  (assoc Paths
+  (assoc OptionalPaths
          :trash (describe String "The path of the trash directory that was emptied.")))
 
 (s/defschema RestoredFile


### PR DESCRIPTION
This changes the schema to use OptionalPaths rather than Paths, since
that makes the key optional but more importantly allows the list of
paths to be empty.

n.b. I don't have any huge preference that this go directly into master, though it is an annoying thing which was reported by a user, so it might be good to have this be a hotfix. Perhaps it should go into beta rather than dev, but not right into master? I'd love to hear thoughts!