### PR TITLE
CORE-7760 Add ‘description’ column to metadata ‘templates’ table.

### DIFF
--- a/databases/metadata/src/main/conversions/c280_2016070501.clj
+++ b/databases/metadata/src/main/conversions/c280_2016070501.clj
@@ -1,0 +1,17 @@
+(ns facepalm.c280-2016070501
+  (:use [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version."
+  "2.8.0:20160705.01")
+
+(defn- add-templates-description
+  []
+  (println "\t* Adding 'description' column to templates table...")
+  (exec-sql-statement "ALTER TABLE templates ADD COLUMN description TEXT"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-templates-description))

--- a/databases/metadata/src/main/data/99_version.sql
+++ b/databases/metadata/src/main/data/99_version.sql
@@ -13,3 +13,4 @@ INSERT INTO version (version) VALUES ('2.6.0:20160331.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160513.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160614.01');
 INSERT INTO version (version) VALUES ('2.7.0:20160624.01');
+INSERT INTO version (version) VALUES ('2.8.0:20160705.01');

--- a/databases/metadata/src/main/tables/templates.sql
+++ b/databases/metadata/src/main/tables/templates.sql
@@ -6,6 +6,7 @@ SET search_path = public, pg_catalog;
 CREATE TABLE templates (
     id uuid NOT NULL DEFAULT uuid_generate_v1(),
     name varchar(64) NOT NULL,
+    description text,
     deleted boolean DEFAULT FALSE NOT NULL,
     created_by varchar(512) NOT NULL,
     modified_by varchar(512) NOT NULL,

--- a/libs/kameleon/project.clj
+++ b/libs/kameleon/project.clj
@@ -14,4 +14,4 @@
                  [slingshot "0.12.2"]]
   :plugins [[lein-marginalia "0.7.1"]
             [test2junit "1.1.3"]]
-  :manifest {"db-version" "2.7.0:20160624.01"})
+  :manifest {"db-version" "2.8.0:20160705.01"})


### PR DESCRIPTION
Adds metadata db conversion 2.8.0:20160705.01 and updates the metadata db SQL init scripts.