### PR TITLE
Core 7764

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -107,6 +107,7 @@ de:
   rpc_name: discoveryenvironment
   notification_poll: 15
   maintenance_file: de-maintenance
+  local_ip_ranges:
   http_server:
     service_name: de-ui-nginx.service
     service_name_short: de-ui-nginx
@@ -743,4 +744,3 @@ systemd:
     - "{{tree_urls}}"
     - "{{user_preferences}}"
     - "{{user_sessions}}"
-    

--- a/ansible/roles/util-cfg-service/templates/ui/de.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/ui/de.properties.j2
@@ -144,6 +144,7 @@ org.iplantc.communitydata.path = /iplant/home/shared
 # Maintenance Settings
 ###############################################################################
 org.iplantc.discoveryenvironment.maintenance-file = {{ de.maintenance_file }}
+org.iplantc.discoveryenvironment.local-ip-ranges = {{ de.local_ip_ranges }}
 
 ###############################################################################
 # Environment Information

--- a/ui/de-webapp/src/main/java/org/iplantc/de/conf/AdminWebSecurityConfig.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/conf/AdminWebSecurityConfig.java
@@ -51,7 +51,7 @@ public class AdminWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Value("${org.iplantc.discoveryenvironment.cas.logout-url}") private String logoutUrl;
     @Value("${org.iplantc.discoveryenvironment.cas.server-name}/belphegor") private String serverName;
     @Value("${org.iplantc.discoveryenvironment.cas.validation}") private String validation;
-    @Value("${org.iplantc.discoveryenvironment.local-ip-ranges") private String localIpRanges;
+    @Value("${org.iplantc.discoveryenvironment.local-ip-ranges}") private String localIpRanges;
 
     @Bean
     public AuthenticationUserDetailsService<CasAssertionAuthenticationToken> adminAuthenticationUserDetailsService() {

--- a/ui/de-webapp/src/main/java/org/iplantc/de/conf/AdminWebSecurityConfig.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/conf/AdminWebSecurityConfig.java
@@ -51,6 +51,7 @@ public class AdminWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Value("${org.iplantc.discoveryenvironment.cas.logout-url}") private String logoutUrl;
     @Value("${org.iplantc.discoveryenvironment.cas.server-name}/belphegor") private String serverName;
     @Value("${org.iplantc.discoveryenvironment.cas.validation}") private String validation;
+    @Value("${org.iplantc.discoveryenvironment.local-ip-ranges") private String localIpRanges;
 
     @Bean
     public AuthenticationUserDetailsService<CasAssertionAuthenticationToken> adminAuthenticationUserDetailsService() {
@@ -91,6 +92,7 @@ public class AdminWebSecurityConfig extends WebSecurityConfigurerAdapter {
         landingPage.setCasService(adminServiceProperties());
         landingPage.setDeMaintenanceFile(deMaintenanceFile);
         landingPage.setLoginUrl(casLoginUrl);
+        landingPage.setLocalIpRanges(localIpRanges);
         return landingPage;
     }
 

--- a/ui/de-webapp/src/main/java/org/iplantc/de/conf/DeWebSecurityConfig.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/conf/DeWebSecurityConfig.java
@@ -45,6 +45,7 @@ public class DeWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Value("${org.iplantc.discoveryenvironment.cas.logout-url}") private String logoutUrl;
     @Value("${org.iplantc.discoveryenvironment.cas.server-name}/de") private String serverName;
     @Value("${org.iplantc.discoveryenvironment.cas.validation}") private String validation;
+    @Value("${org.iplantc.discoveryenvironment.local-ip-ranges") private String localIpRanges;
 
     @Bean
     public AuthenticationUserDetailsService<CasAssertionAuthenticationToken> deAuthenticationUserDetailsService() {
@@ -86,6 +87,7 @@ public class DeWebSecurityConfig extends WebSecurityConfigurerAdapter {
         landingPage.setCasService(deServiceProperties());
         landingPage.setDeMaintenanceFile(deMaintenanceFile);
         landingPage.setLoginUrl(casLoginUrl);
+        landingPage.setLocalIpRanges(localIpRanges);
         return landingPage;
     }
 

--- a/ui/de-webapp/src/main/java/org/iplantc/de/conf/DeWebSecurityConfig.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/conf/DeWebSecurityConfig.java
@@ -45,7 +45,7 @@ public class DeWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Value("${org.iplantc.discoveryenvironment.cas.logout-url}") private String logoutUrl;
     @Value("${org.iplantc.discoveryenvironment.cas.server-name}/de") private String serverName;
     @Value("${org.iplantc.discoveryenvironment.cas.validation}") private String validation;
-    @Value("${org.iplantc.discoveryenvironment.local-ip-ranges") private String localIpRanges;
+    @Value("${org.iplantc.discoveryenvironment.local-ip-ranges}") private String localIpRanges;
 
     @Bean
     public AuthenticationUserDetailsService<CasAssertionAuthenticationToken> deAuthenticationUserDetailsService() {

--- a/ui/de-webapp/src/main/java/org/iplantc/de/server/IpRange.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/server/IpRange.java
@@ -1,0 +1,119 @@
+package org.iplantc.de.server;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a range of IP addresses.
+ *
+ * @author Dennis Roberts
+ */
+public class IpRange {
+
+    // The regular expression used to validate address ranges.
+    private final static Pattern rangeRe
+            = Pattern.compile("^(\\d{1,3}(?:[.]\\d{1,3}){3})(?:/(\\d{1,2}))?$");
+
+    // The regular expression used to validated addresses.
+    private final static Pattern addressRe = Pattern.compile("^(\\d{1,3}(?:[.]\\d{1,3}){3})$");
+
+    private final long baseAddress;
+    private final long mask;
+
+    /**
+     * Creates a new IP Address range based on a string in the format ip/significantBits. For
+     * example: 127.0.0.1/24.
+     *
+     * @param s the string representing the IP address range.
+     */
+    public IpRange(String s) {
+
+        // Validate the string format.
+        Matcher m = rangeRe.matcher(s);
+        if (!m.find()) {
+            illegalIpRangeString(s);
+        }
+
+        // Extract and validate the number of significant bits.
+        int significantBits;
+        if (m.group(2) != null) {
+            significantBits = Integer.parseInt(m.group(2));
+            if (significantBits > 32) {
+                illegalIpRangeString(s);
+            }
+        } else {
+            significantBits = 32;
+        }
+
+        // Initialize the properties.
+        baseAddress = addressToInt(m.group(1));
+        mask = significantBitsToMask(significantBits);
+    }
+
+    /**
+     * Throws an exception indicating that an illegal IP address range string was specified.
+     *
+     * @param s the IP address range string.
+     */
+    private void illegalIpRangeString(String s) {
+        throw new IllegalArgumentException("Invalid IP address range string: " + s);
+    }
+
+    /**
+     * Throws an exception indicating that an illegal IP address string was specified.
+     *
+     * @param s the IP address string.
+     */
+    private void illegalIpAddressString(String s) {
+        throw new IllegalArgumentException("Invalid IP address string: " + s);
+    }
+
+    /**
+     * Converts an IP address string to a long integer.
+     *
+     * @param address the IP address string.
+     * @return the integer representation of the IP address string.
+     */
+    private long addressToInt(String address) {
+        if (!addressRe.matcher(address).matches()) {
+            illegalIpAddressString(address);
+        }
+
+        // Convert the address to an integer.
+        long result = 0;
+        String components[] = address.split("[.]");
+        for (int i = 0; i < components.length; i++) {
+            int x = Integer.parseInt(components[i]);
+            if (x > 255) {
+                illegalIpAddressString(address);
+            }
+            result = (result << 8) + x;
+        }
+        return result;
+    }
+
+    /**
+     * Converts the number of significant bits to an IP address mask.
+     *
+     * @param significantBits the number of significant bits.
+     * @return the IP address mask.
+     */
+    private long significantBitsToMask(int significantBits) {
+        long m = 0;
+        for (int i = 0; i < 32; i++) {
+            int digit = i < significantBits ? 1 : 0;
+            m = (m << 1) + digit;
+        }
+        return m;
+    }
+
+    /**
+     * Determines whether or not an IP address matches this range.
+     *
+     * @param address the IP address string.
+     * @return true if the address matches the string.
+     */
+    public boolean matches(String address) {
+        return (addressToInt(address) & mask) == (baseAddress & mask);
+    }
+}

--- a/ui/de-webapp/src/main/java/org/iplantc/de/server/IpRanges.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/server/IpRanges.java
@@ -1,5 +1,7 @@
 package org.iplantc.de.server;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,7 +21,9 @@ public class IpRanges {
     public IpRanges(String s) {
         List<IpRange> ranges = new ArrayList<IpRange>();
         for (String r : s.split("\\s*,\\s*")) {
-            ranges.add(new IpRange(r));
+            if (!StringUtils.isBlank(r)) {
+                ranges.add(new IpRange(r));
+            }
         }
         this.ranges = ranges;
     }

--- a/ui/de-webapp/src/main/java/org/iplantc/de/server/IpRanges.java
+++ b/ui/de-webapp/src/main/java/org/iplantc/de/server/IpRanges.java
@@ -1,0 +1,41 @@
+package org.iplantc.de.server;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a set of IP address ranges.
+ *
+ * @author Dennis Roberts
+ */
+public class IpRanges {
+    private final List<IpRange> ranges;
+
+    /**
+     * Constructs a set of IP address ranges from a comma-delimited string.
+     *
+     * @param s the comma-delimited string.
+     */
+    public IpRanges(String s) {
+        List<IpRange> ranges = new ArrayList<IpRange>();
+        for (String r : s.split("\\s*,\\s*")) {
+            ranges.add(new IpRange(r));
+        }
+        this.ranges = ranges;
+    }
+
+    /**
+     * Determines whether or not an IP address matches one of the ranges in the set.
+     *
+     * @param address the IP address.
+     * @return true if the address matches one of the ranges.
+     */
+    public boolean matches(String address) {
+        for (IpRange r : ranges) {
+            if (r.matches(address)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This change allows users from iPlant networks (or, really, any IP address range we want) to log into the DE when the DE is under maintenance. We have a new configuration setting that allows us to specify which IP address ranges to allow into the DE when it's under maintenance. The DE determines the original IP address of the request from the `X-Forwarded-For` header if it's present in the request or the remote IP address otherwise. Please see the Jira issue for more details.