### PR TITLE
CORE-7762 Update metadata templates in Belphegor with 'description' field and name limit

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/events/AddMetadataSelectedEvent.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/events/AddMetadataSelectedEvent.java
@@ -1,0 +1,29 @@
+package org.iplantc.de.admin.desktop.client.metadata.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class AddMetadataSelectedEvent
+        extends GwtEvent<AddMetadataSelectedEvent.AddMetadataSelectedEventHandler> {
+    public static interface AddMetadataSelectedEventHandler extends EventHandler {
+        void onAddMetadataSelected(AddMetadataSelectedEvent event);
+    }
+
+    public interface HasAddMetadataSelectedEventHandlers {
+        HandlerRegistration addAddMetadataSelectedEventHandler(AddMetadataSelectedEventHandler handler);
+    }
+    public static Type<AddMetadataSelectedEventHandler> TYPE =
+            new Type<AddMetadataSelectedEventHandler>();
+
+    public Type<AddMetadataSelectedEventHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(AddMetadataSelectedEventHandler handler) {
+        handler.onAddMetadataSelected(this);
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/events/DeleteMetadataSelectedEvent.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/events/DeleteMetadataSelectedEvent.java
@@ -1,0 +1,42 @@
+package org.iplantc.de.admin.desktop.client.metadata.events;
+
+import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class DeleteMetadataSelectedEvent
+        extends GwtEvent<DeleteMetadataSelectedEvent.DeleteMetadataSelectedEventHandler> {
+    public static interface DeleteMetadataSelectedEventHandler extends EventHandler {
+        void onDeleteMetadataSelectedHandler(DeleteMetadataSelectedEvent event);
+    }
+
+    public interface HasDeleteMetadataSelectedEventHandlers {
+        HandlerRegistration addDeleteMetadataSelectedEventHandler(DeleteMetadataSelectedEventHandler handler);
+    }
+
+    public static Type<DeleteMetadataSelectedEventHandler> TYPE =
+            new Type<DeleteMetadataSelectedEventHandler>();
+
+    private MetadataTemplateInfo templateInfo;
+
+    public DeleteMetadataSelectedEvent(MetadataTemplateInfo templateInfo) {
+        this.templateInfo = templateInfo;
+    }
+
+    public Type<DeleteMetadataSelectedEventHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(DeleteMetadataSelectedEventHandler handler) {
+        handler.onDeleteMetadataSelectedHandler(this);
+    }
+
+    public MetadataTemplateInfo getTemplateInfo() {
+        return templateInfo;
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/events/EditMetadataSelectedEvent.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/events/EditMetadataSelectedEvent.java
@@ -1,0 +1,42 @@
+package org.iplantc.de.admin.desktop.client.metadata.events;
+
+import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class EditMetadataSelectedEvent
+        extends GwtEvent<EditMetadataSelectedEvent.EditMetadataSelectedEventHandler> {
+    public static interface EditMetadataSelectedEventHandler extends EventHandler {
+        void onEditMetadataSelected(EditMetadataSelectedEvent event);
+    }
+
+    public interface HasEditMetadataSelectedEventHandlers {
+        HandlerRegistration addEditMetadataSelectedEventHandler(EditMetadataSelectedEventHandler handler);
+    }
+
+    public static Type<EditMetadataSelectedEventHandler> TYPE =
+            new Type<EditMetadataSelectedEventHandler>();
+
+    private MetadataTemplateInfo templateInfo;
+
+    public EditMetadataSelectedEvent(MetadataTemplateInfo templateInfo) {
+        this.templateInfo = templateInfo;
+    }
+
+    public Type<EditMetadataSelectedEventHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(EditMetadataSelectedEventHandler handler) {
+        handler.onEditMetadataSelected(this);
+    }
+
+    public MetadataTemplateInfo getTemplateInfo() {
+        return templateInfo;
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/presenter/MetadataTemplatesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/presenter/MetadataTemplatesPresenterImpl.java
@@ -1,5 +1,8 @@
 package org.iplantc.de.admin.desktop.client.metadata.presenter;
 
+import org.iplantc.de.admin.desktop.client.metadata.events.AddMetadataSelectedEvent;
+import org.iplantc.de.admin.desktop.client.metadata.events.DeleteMetadataSelectedEvent;
+import org.iplantc.de.admin.desktop.client.metadata.events.EditMetadataSelectedEvent;
 import org.iplantc.de.admin.desktop.client.metadata.service.MetadataTemplateAdminServiceFacade;
 import org.iplantc.de.admin.desktop.client.metadata.view.EditMetadataTemplateView;
 import org.iplantc.de.admin.desktop.client.metadata.view.TemplateListingView;
@@ -33,7 +36,10 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class MetadataTemplatesPresenterImpl implements TemplateListingView.Presenter {
+public class MetadataTemplatesPresenterImpl implements TemplateListingView.Presenter,
+                                                       EditMetadataSelectedEvent.EditMetadataSelectedEventHandler,
+                                                       AddMetadataSelectedEvent.AddMetadataSelectedEventHandler,
+                                                       DeleteMetadataSelectedEvent.DeleteMetadataSelectedEventHandler {
 
     private final TemplateListingView view;
     private final DiskResourceServiceFacade drSvcFac;
@@ -57,12 +63,15 @@ public class MetadataTemplatesPresenterImpl implements TemplateListingView.Prese
         this.mdSvcFac = mdSvcFac;
         this.drFac = drFac;
         this.appearance = appearance;
+
+        view.addAddMetadataSelectedEventHandler(this);
+        view.addDeleteMetadataSelectedEventHandler(this);
+        view.addEditMetadataSelectedEventHandler(this);
     }
 
     @Override
     public void go(HasOneWidget container) {
         container.setWidget(view.asWidget());
-        view.setPresenter(this);
         loadTemplates();
     }
 
@@ -86,7 +95,8 @@ public class MetadataTemplatesPresenterImpl implements TemplateListingView.Prese
     }
 
     @Override
-    public void deleteTemplate(final MetadataTemplateInfo template) {
+    public void onDeleteMetadataSelectedHandler(DeleteMetadataSelectedEvent event) {
+        final MetadataTemplateInfo template = event.getTemplateInfo();
         ConfirmMessageBox cmb = new ConfirmMessageBox("Confirm", appearance.deleteTemplateConfirm());
         cmb.addDialogHideHandler(new DialogHideHandler(){
 
@@ -125,7 +135,8 @@ public class MetadataTemplatesPresenterImpl implements TemplateListingView.Prese
     }
 
     @Override
-    public void editTemplate(MetadataTemplateInfo template) {
+    public void onEditMetadataSelected(EditMetadataSelectedEvent event) {
+        MetadataTemplateInfo template = event.getTemplateInfo();
         drSvcFac.getMetadataTemplate(template.getId(), new AsyncCallback<MetadataTemplate>() {
 
             @Override
@@ -212,7 +223,7 @@ public class MetadataTemplatesPresenterImpl implements TemplateListingView.Prese
     }
 
     @Override
-    public void addTemplate() {
+    public void onAddMetadataSelected(AddMetadataSelectedEvent event) {
         final IPlantDialog d = createEditDialog();
         d.addOkButtonSelectHandler(new SelectHandler() {
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/presenter/MetadataTemplatesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/presenter/MetadataTemplatesPresenterImpl.java
@@ -139,7 +139,7 @@ public class MetadataTemplatesPresenterImpl implements TemplateListingView.Prese
                         if (editView.validate()) {
                             MetadataTemplate template = editView.getTemplate();
                             Splittable sp = AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(template));
-                            LOG.log(Level.SEVERE, sp.getPayload());
+                            LOG.log(Level.INFO, sp.getPayload());
                             doAddOrUpdate(id, template.getId(), sp.getPayload());
                         } else {
                             IplantAnnouncer.getInstance()

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateView.java
@@ -25,6 +25,7 @@ public interface EditMetadataTemplateView extends IsWidget, IsMaskable {
 
         String enumError();
 
+        int tempNameMaxLength();
     }
 
     void setPresenter(Presenter p);

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateView.java
@@ -1,6 +1,5 @@
 package org.iplantc.de.admin.desktop.client.metadata.view;
 
-import org.iplantc.de.admin.desktop.client.metadata.view.TemplateListingView.Presenter;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.diskResources.MetadataTemplate;
 
@@ -27,8 +26,6 @@ public interface EditMetadataTemplateView extends IsWidget, IsMaskable {
 
         int tempNameMaxLength();
     }
-
-    void setPresenter(Presenter p);
 
     MetadataTemplate getTemplate();
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
@@ -10,10 +10,12 @@ import org.iplantc.de.client.models.diskResources.TemplateAttributeSelectionItem
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
+import org.iplantc.de.commons.client.widgets.PreventEntryAfterLimitHandler;
 
 import com.google.common.base.Strings;
 import com.google.gwt.cell.client.Cell.Context;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.safecss.shared.SafeStyles;
 import com.google.gwt.safecss.shared.SafeStylesUtils;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -23,6 +25,7 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.TakesValue;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -76,6 +79,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
 
     @UiField
     TextField tempName;
+    @UiField TextField tempDescription;
     @UiField
     TextButton addBtn, delBtn;
     @UiField
@@ -122,7 +126,16 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
         tar.setFeedback(Feedback.INSERT);
         tar.setOperation(Operation.MOVE);
 
+        addTempNameMaxCharLimit();
+
         ensureDebugId(Belphegor.MetadataIds.EDIT_DIALOG + Belphegor.MetadataIds.VIEW);
+    }
+
+    private void addTempNameMaxCharLimit() {
+        TakesValue<String> takesValue = (TakesValue<String>)tempName;
+        PreventEntryAfterLimitHandler
+                newHandler = new PreventEntryAfterLimitHandler(takesValue, appearance.tempNameMaxLength());
+        tempName.asWidget().addDomHandler(newHandler, KeyDownEvent.getType());
     }
 
     @Override
@@ -130,6 +143,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
         super.onEnsureDebugId(baseID);
 
         tempName.setId(baseID + Belphegor.MetadataIds.TEMPLATE_NAME);
+        tempDescription.ensureDebugId(baseID + Belphegor.MetadataIds.TEMPLATE_DESCRIPTION);
         addBtn.ensureDebugId(baseID + Belphegor.MetadataIds.ADD);
         delBtn.ensureDebugId(baseID + Belphegor.MetadataIds.DELETE);
         grid.ensureDebugId(baseID + Belphegor.MetadataIds.GRID);
@@ -323,6 +337,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
             mt.setId(templateId);
         }
         mt.setName(tempName.getValue());
+        mt.setDescription(tempDescription.getValue());
         mt.setAttributes(store.getAll());
         mt.setDeleted(chkDeleted.getValue());
         return mt;
@@ -355,6 +370,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
     @Override
     public void edit(MetadataTemplate result) {
         tempName.setValue(result.getName());
+        tempDescription.setValue(result.getDescription());
         templateId = result.getId();
         store.addAll(result.getAttributes());
         chkDeleted.setValue(result.isDeleted());
@@ -363,6 +379,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
     @Override
     public void reset() {
         tempName.clear();
+        tempDescription.clear();
         store.clear();
         templateId = null;
     }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
@@ -1,6 +1,5 @@
 package org.iplantc.de.admin.desktop.client.metadata.view;
 
-import org.iplantc.de.admin.desktop.client.metadata.view.TemplateListingView.Presenter;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.apps.widgets.client.view.editors.widgets.CheckBoxAdapter;
 import org.iplantc.de.client.models.diskResources.DiskResourceAutoBeanFactory;
@@ -93,7 +92,6 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
     @UiField CheckBoxAdapter chkDeleted;
 
     private final MetadataTemplateAttributeProperties mta_props;
-    private Presenter presenter;
     private final DiskResourceAutoBeanFactory drFac;
     private GridEditing<MetadataTemplateAttribute> editing;
     private String templateId; // cache id when editing existing template
@@ -323,11 +321,6 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
     @UiHandler("delBtn")
     void delButtonClicked(SelectEvent event) {
         store.remove(grid.getSelectionModel().getSelectedItem());
-    }
-
-    @Override
-    public void setPresenter(Presenter p) {
-        this.presenter = p;
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
@@ -78,7 +78,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
 
     @UiField
     TextField tempName;
-    @UiField TextField tempDescription;
+    @UiField TextArea tempDescription;
     @UiField
     TextButton addBtn, delBtn;
     @UiField

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.ui.xml
@@ -46,8 +46,9 @@
 		<container:child layoutData="{toolBarLayoutData}">
 			<form:FieldLabel text="Description">
 				<form:widget>
-					<form:TextField ui:field="tempDescription" allowBlank="true"
-									emptyText="Enter Template description..." />
+					<form:TextArea ui:field="tempDescription" allowBlank="true"
+									emptyText="Enter Template description..."
+									height="50"/>
 				</form:widget>
 			</form:FieldLabel>
 		</container:child>

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.ui.xml
@@ -44,6 +44,14 @@
 			</form:FieldLabel>
 		</container:child>
 		<container:child layoutData="{toolBarLayoutData}">
+			<form:FieldLabel text="Description">
+				<form:widget>
+					<form:TextField ui:field="tempDescription" allowBlank="true"
+									emptyText="Enter Template description..." />
+				</form:widget>
+			</form:FieldLabel>
+		</container:child>
+		<container:child layoutData="{toolBarLayoutData}">
           <form:FieldLabel text="Options">
             <form:widget>
               <g:HorizontalPanel>

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/MetadataTemplateProperties.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/MetadataTemplateProperties.java
@@ -14,6 +14,8 @@ public interface MetadataTemplateProperties extends PropertyAccess<MetadataTempl
 
     ValueProvider<MetadataTemplateInfo, String> name();
 
+    ValueProvider<MetadataTemplateInfo, String> description();
+
     ValueProvider<MetadataTemplateInfo, Date> createdDate();
 
     ValueProvider<MetadataTemplateInfo, String> createdBy();

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplateListingView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplateListingView.java
@@ -1,5 +1,8 @@
 package org.iplantc.de.admin.desktop.client.metadata.view;
 
+import org.iplantc.de.admin.desktop.client.metadata.events.AddMetadataSelectedEvent;
+import org.iplantc.de.admin.desktop.client.metadata.events.DeleteMetadataSelectedEvent;
+import org.iplantc.de.admin.desktop.client.metadata.events.EditMetadataSelectedEvent;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
 
@@ -9,7 +12,10 @@ import com.google.gwt.user.client.ui.IsWidget;
 
 import java.util.List;
 
-public interface TemplateListingView extends IsWidget, IsMaskable {
+public interface TemplateListingView extends IsWidget, IsMaskable,
+                                             EditMetadataSelectedEvent.HasEditMetadataSelectedEventHandlers,
+                                             AddMetadataSelectedEvent.HasAddMetadataSelectedEventHandlers,
+                                             DeleteMetadataSelectedEvent.HasDeleteMetadataSelectedEventHandlers {
 
     public interface TemplateListingAppearance {
         String add();
@@ -70,18 +76,10 @@ public interface TemplateListingView extends IsWidget, IsMaskable {
 
         void go(HasOneWidget container);
 
-        void deleteTemplate(MetadataTemplateInfo template);
-
-        void editTemplate(MetadataTemplateInfo template);
-
-        void addTemplate();
-
         void setViewDebugId(String baseId);
     }
 
     void loadTemplates(List<MetadataTemplateInfo> result);
-
-    void setPresenter(Presenter p);
 
     void remove(MetadataTemplateInfo template);
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplateListingView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplateListingView.java
@@ -39,6 +39,8 @@ public interface TemplateListingView extends IsWidget, IsMaskable {
         String lastModBy();
 
         String nameColumn();
+
+        String descriptionColumn();
     }
 
     public interface Presenter {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
@@ -110,8 +110,11 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
     @UiFactory
     ColumnModel<MetadataTemplateInfo> createColumnModel() {
         ColumnConfig<MetadataTemplateInfo, String> nameCol = new ColumnConfig<>(props.name(),
-                                                                                300,
+                                                                                150,
                                                                                 appearance.nameColumn());
+        ColumnConfig<MetadataTemplateInfo, String> descriptionCol = new ColumnConfig<MetadataTemplateInfo, String>(props.description(),
+                                                                                                                   200,
+                                                                                                                   appearance.descriptionColumn());
         ColumnConfig<MetadataTemplateInfo, Date> createdOnCol = new ColumnConfig<>(props.createdDate(),
                                                                                    192,
                                                                                    appearance.createdOn());
@@ -123,6 +126,7 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
                                                                                     appearance.deleted());
         List<ColumnConfig<MetadataTemplateInfo, ?>> columns = new ArrayList<ColumnConfig<MetadataTemplateInfo, ?>>();
         columns.add(nameCol);
+        columns.add(descriptionCol);
         columns.add(createdOnCol);
         columns.add(createdByCol);
         columns.add(deletedCol);

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
@@ -136,9 +136,6 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
         ColumnConfig<MetadataTemplateInfo, String> nameCol = new ColumnConfig<>(props.name(),
                                                                                 150,
                                                                                 appearance.nameColumn());
-        ColumnConfig<MetadataTemplateInfo, String> descriptionCol = new ColumnConfig<MetadataTemplateInfo, String>(props.description(),
-                                                                                                                   200,
-                                                                                                                   appearance.descriptionColumn());
         ColumnConfig<MetadataTemplateInfo, Date> createdOnCol = new ColumnConfig<>(props.createdDate(),
                                                                                    192,
                                                                                    appearance.createdOn());
@@ -150,7 +147,6 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
                                                                                     appearance.deleted());
         List<ColumnConfig<MetadataTemplateInfo, ?>> columns = new ArrayList<ColumnConfig<MetadataTemplateInfo, ?>>();
         columns.add(nameCol);
-        columns.add(descriptionCol);
         columns.add(createdOnCol);
         columns.add(createdByCol);
         columns.add(deletedCol);

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
@@ -1,9 +1,13 @@
 package org.iplantc.de.admin.desktop.client.metadata.view;
 
+import org.iplantc.de.admin.desktop.client.metadata.events.AddMetadataSelectedEvent;
+import org.iplantc.de.admin.desktop.client.metadata.events.DeleteMetadataSelectedEvent;
+import org.iplantc.de.admin.desktop.client.metadata.events.EditMetadataSelectedEvent;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
@@ -47,7 +51,6 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
     TemplateListingView.TemplateListingAppearance appearance;
 
     private final MetadataTemplateProperties props;
-    private Presenter presenter;
 
     @Inject
     public TemplatesListingViewImpl(final MetadataTemplateProperties props,
@@ -79,16 +82,31 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
 
     }
 
+    @Override
+    public HandlerRegistration addEditMetadataSelectedEventHandler(EditMetadataSelectedEvent.EditMetadataSelectedEventHandler handler) {
+        return addHandler(handler, EditMetadataSelectedEvent.TYPE);
+    }
+
+    @Override
+    public HandlerRegistration addAddMetadataSelectedEventHandler(AddMetadataSelectedEvent.AddMetadataSelectedEventHandler handler) {
+        return addHandler(handler, AddMetadataSelectedEvent.TYPE);
+    }
+
+    @Override
+    public HandlerRegistration addDeleteMetadataSelectedEventHandler(DeleteMetadataSelectedEvent.DeleteMetadataSelectedEventHandler handler) {
+        return addHandler(handler, DeleteMetadataSelectedEvent.TYPE);
+    }
+
     @UiHandler("addBtn")
     void addButtonClicked(SelectEvent event) {
-        presenter.addTemplate();
+        fireEvent(new AddMetadataSelectedEvent());
     }
 
     @UiHandler("editBtn")
     void editButtonClicked(SelectEvent event) {
         MetadataTemplateInfo selectedItem = grid.getSelectionModel().getSelectedItem();
         if (selectedItem != null) {
-            presenter.editTemplate(grid.getSelectionModel().getSelectedItem());
+            fireEvent(new EditMetadataSelectedEvent(selectedItem));
         }
     }
 
@@ -96,7 +114,7 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
     void delButtonClicked(SelectEvent event) {
         MetadataTemplateInfo selectedItem = grid.getSelectionModel().getSelectedItem();
         if (selectedItem != null) {
-            presenter.deleteTemplate(grid.getSelectionModel().getSelectedItem());
+            fireEvent(new DeleteMetadataSelectedEvent(selectedItem));
         }
     }
 
@@ -144,11 +162,6 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
     public void loadTemplates(List<MetadataTemplateInfo> result) {
         store.clear();
         store.addAll(result);
-    }
-
-    @Override
-    public void setPresenter(Presenter p) {
-        this.presenter = p;
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
@@ -86,12 +86,18 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
 
     @UiHandler("editBtn")
     void editButtonClicked(SelectEvent event) {
-        presenter.editTemplate(grid.getSelectionModel().getSelectedItem());
+        MetadataTemplateInfo selectedItem = grid.getSelectionModel().getSelectedItem();
+        if (selectedItem != null) {
+            presenter.editTemplate(grid.getSelectionModel().getSelectedItem());
+        }
     }
 
     @UiHandler("delBtn")
     void delButtonClicked(SelectEvent event) {
-        presenter.deleteTemplate(grid.getSelectionModel().getSelectedItem());
+        MetadataTemplateInfo selectedItem = grid.getSelectionModel().getSelectedItem();
+        if (selectedItem != null) {
+            presenter.deleteTemplate(grid.getSelectionModel().getSelectedItem());
+        }
     }
 
     @UiFactory

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -202,6 +202,7 @@ public interface Belphegor {
         String DELETE_MSG_BOX = "deleteMetadataMsgBox";
         String YES = ".yesBtn";
         String NO = ".noBtn";
+        String TEMPLATE_DESCRIPTION = ".description";
     }
 
     interface PermIds {

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateInfo.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateInfo.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.client.models.diskResources;
 
+import org.iplantc.de.client.models.HasDescription;
 import org.iplantc.de.client.models.HasId;
 
 import com.google.gwt.user.client.ui.HasName;
@@ -7,7 +8,7 @@ import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 
 import java.util.Date;
 
-public interface MetadataTemplateInfo  extends HasId, HasName {
+public interface MetadataTemplateInfo  extends HasId, HasName, HasDescription {
 
     void setId(String id);
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/metadata/DefaultEditMetadataTemplateViewAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/metadata/DefaultEditMetadataTemplateViewAppearance.java
@@ -3,7 +3,6 @@ package org.iplantc.de.theme.base.client.admin.metadata;
 import org.iplantc.de.admin.desktop.client.metadata.view.EditMetadataTemplateView.EditMetadataTemplateViewAppearance;
 import org.iplantc.de.resources.client.IplantResources;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
-import org.iplantc.de.theme.base.client.admin.BelphegorDisplayStrings;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ImageResource;
@@ -61,6 +60,11 @@ public class DefaultEditMetadataTemplateViewAppearance implements EditMetadataTe
     @Override
     public String enumError() {
         return displayStrings.enumError();
+    }
+
+    @Override
+    public int tempNameMaxLength() {
+        return 20;
     }
 
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/metadata/DefaultTemplateListingAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/metadata/DefaultTemplateListingAppearance.java
@@ -97,4 +97,9 @@ public class DefaultTemplateListingAppearance implements TemplateListingAppearan
         return displayStrings.nameColumn();
     }
 
+    @Override
+    public String descriptionColumn() {
+        return displayStrings.descriptionColumn();
+    }
+
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/metadata/MetadataDisplayStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/metadata/MetadataDisplayStrings.java
@@ -42,4 +42,5 @@ public interface MetadataDisplayStrings extends Messages {
 
     public String enumError();
 
+    String descriptionColumn();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/metadata/MetadataDisplayStrings.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/metadata/MetadataDisplayStrings.properties
@@ -17,3 +17,4 @@ lastModified = Last Modified
 lastModBy = Last Modified By
 nameColumn = Name Column
 enumError = Please complete all fields. Only Enum type field supports value(s)!
+descriptionColumn = Description


### PR DESCRIPTION
This PR addresses a request for there to be a limit on how long the name of a metadata template can be (20 chars) and also adds an optional description field.  The metadata template names currently are too long because the description is also being included in the name.

I noticed some NPEs happening when clicking on the Edit and Delete buttons so I patched those up.  Then I noticed that the view was calling presenter methods directly, so I went ahead and refactored the view to fire events instead. 