### PR TITLE
CORE-7752: switched to Clojure 1.8

### DIFF
--- a/lein-plugins/lein-iplant-cmdtar/project.clj
+++ b/lein-plugins/lein-iplant-cmdtar/project.clj
@@ -4,5 +4,5 @@
   :url "https://github.com/iPlantCollaborativeOpenSource/DE"
   :license {:name "BSD"
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [fleet "0.9.5"]])

--- a/libs/authy/project.clj
+++ b/libs/authy/project.clj
@@ -3,7 +3,7 @@
   :url "http://www.iplantcollaborative.org"
   :license {:name "BSD Standard License"
             :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [clj-http "1.0.0"]
+                 [clj-http "2.2.0"]
                  [slingshot "0.10.3"]])

--- a/libs/clj-icat-direct/project.clj
+++ b/libs/clj-icat-direct/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/iPlantCollaborativeOpenSource/DE"
   :license {:name "BSD Standard License"
             :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.mchange/c3p0 "0.9.5.1"]
                  [korma "0.4.2"
                   :exclusions [c3p0]]

--- a/libs/clj-jargon/project.clj
+++ b/libs/clj-jargon/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/iPlantCollaborativeOpenSource/DE"
   :license {:name "BSD"
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [ch.qos.logback/logback-classic "1.1.3"]
                  [org.irods.jargon/jargon-core "4.0.2.4-RELEASE"

--- a/libs/common-cfg/project.clj
+++ b/libs/common-cfg/project.clj
@@ -2,7 +2,7 @@
   :description "DE services code for managing configurations."
   :url "https://github.com/iPlantCollaborativeOpenSource/DE"
   :license {:name "BSD"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [com.fasterxml.jackson.core/jackson-core "2.5.1"]
                  [com.fasterxml.jackson.core/jackson-databind "2.5.1"]

--- a/libs/common-cli/project.clj
+++ b/libs/common-cli/project.clj
@@ -2,6 +2,6 @@
   :description "Common CLI functions for the DE backend services and tools"
   :url "http://github.com/iPlantCollaborativeOpenSource/DiscoveryEnvironmentBackend/"
   :license {:name "BSD"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.2"]
                  [trptcolin/versioneer "0.1.0"]])

--- a/libs/common-swagger-api/project.clj
+++ b/libs/common-swagger-api/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/iPlantCollaborativeOpenSource/DE"
   :license {:name "BSD"
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [cheshire "5.5.0"
                   :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]

--- a/libs/debug-utils/project.clj
+++ b/libs/debug-utils/project.clj
@@ -3,5 +3,5 @@
   :url "https://github.com/cyverse/DE"
   :license {:name "BSD"
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]])

--- a/libs/heuristomancer/project.clj
+++ b/libs/heuristomancer/project.clj
@@ -4,7 +4,7 @@
   :license {:name "BSD Standard License"
             :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :profiles {:dev {:resource-paths ["test-data"]}}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.2"]
                  [org.clojure/tools.logging "0.3.1"]
                  [instaparse "1.4.1"]]

--- a/libs/iplant-clojure-commons/project.clj
+++ b/libs/iplant-clojure-commons/project.clj
@@ -4,13 +4,13 @@
   :license {:name "BSD"
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :plugins [[test2junit "1.1.3"]]
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [buddy/buddy-sign "0.7.0"]
                  [metosin/ring-http-response "0.6.5"]
                  [metosin/compojure-api "0.24.5"]
                  [cheshire "5.5.0"]
-                 [clj-http "2.0.0"]
+                 [clj-http "2.2.0"]
                  [clj-time "0.11.0"]
                  [com.cemerick/url "0.1.1"]
                  [commons-configuration "1.10"    ; provides org.apache.commons.configuration

--- a/libs/kameleon/project.clj
+++ b/libs/kameleon/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/iPlantCollaborativeOpenSource/DE"
   :license {:name "BSD"
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [clj-time "0.11.0"]
                  [com.mchange/c3p0 "0.9.5.1"]

--- a/libs/mescal/project.clj
+++ b/libs/mescal/project.clj
@@ -3,9 +3,9 @@
   :url "https://github.com/iPlantCollaborativeOpenSource/DE"
   :license {:name "BSD Standard License"
             :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [cheshire "5.5.0"]
-                 [clj-http "1.0.0"]
+                 [clj-http "2.2.0"]
                  [clj-time "0.7.0"]
                  [com.cemerick/url "0.1.1"]
                  [medley "0.5.3"]

--- a/libs/metadata-client/project.clj
+++ b/libs/metadata-client/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/cyverse/DE"
   :license {:name "BSD"
             :url "http://cyverse.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [clj-http "2.0.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-http "2.2.0"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
                  [cheshire "5.5.0"]
                  [org.iplantc/kameleon "5.2.8.0"]])

--- a/libs/permissions-client/project.clj
+++ b/libs/permissions-client/project.clj
@@ -7,5 +7,5 @@
                  [clj-http "2.2.0"]
                  [com.cemerick/url "0.1.1"]
                  [medley "0.8.2"]
-                 [org.clojure/clojure "1.7.0"]]
+                 [org.clojure/clojure "1.8.0"]]
   :profiles {:test {:dependencies [[clj-http-fake "1.0.2"]]}})

--- a/libs/service-logging/project.clj
+++ b/libs/service-logging/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/iPlantCollaborativeOpenSource/DE"
   :license {:name "BSD"
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]       ; exported
                  [cheshire "5.5.0"]
                  [slingshot "0.12.2"]

--- a/libs/tree-urls-client/project.clj
+++ b/libs/tree-urls-client/project.clj
@@ -1,9 +1,9 @@
 (defproject org.iplantc/tree-urls-client "5.2.8.0"
   :description "Client for the tree-urls service"
   :url "https://github.com/cyverse/DE"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.iplantc/clojure-commons "5.2.8.0" :exclusions [buddy/buddy-sign metosin/compojure-api metosin/ring-http-response ring]]
                  [slingshot "0.12.2"]
-                 [clj-http "2.0.0"]
+                 [clj-http "2.2.0"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
                  [cheshire "5.5.0"]])

--- a/services/Infosquito/project.clj
+++ b/services/Infosquito/project.clj
@@ -16,7 +16,7 @@
   :uberjar-name "infosquito-standalone.jar"
   :aot [infosquito.core]
   :main infosquito.core
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [postgresql "9.1-901-1.jdbc4"]
                  [org.clojure/java.jdbc "0.3.5"]
                  [cheshire "5.5.0"
@@ -25,7 +25,7 @@
                                [com.fasterxml.jackson.core/jackson-annotations]
                                [com.fasterxml.jackson.core/jackson-databind]
                                [com.fasterxml.jackson.core/jackson-core]]]
-                 [clojurewerkz/elastisch "2.0.0"]
+                 [clojurewerkz/elastisch "2.2.1"]
                  [com.novemberain/langohr "3.5.1"]
                  [slingshot "0.10.3"]
                  [me.raynes/fs "1.4.6"]

--- a/services/NotificationAgent/project.clj
+++ b/services/NotificationAgent/project.clj
@@ -14,7 +14,7 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "notificationagent-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [cheshire "5.5.0"
                   :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]
@@ -27,7 +27,7 @@
                  [org.iplantc/common-cli "5.2.8.0"]
                  [org.iplantc/service-logging "5.2.8.0"]
                  [me.raynes/fs "1.4.6"]
-                 [clj-http "2.1.0"]
+                 [clj-http "2.2.0"]
                  [clj-time "0.11.0"]
                  [slingshot "0.12.2"]
                  [clojurewerkz/quartzite "2.0.0"]

--- a/services/anon-files/project.clj
+++ b/services/anon-files/project.clj
@@ -15,7 +15,7 @@
   :uberjar-name "anon-files-standalone.jar"
   :main ^:skip-aot anon-files.core
   :profiles {:uberjar {:aot :all}}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.iplantc/clj-jargon "5.2.8.0"
                   :exclusions [[org.slf4j/slf4j-log4j12]
                                [log4j]]]

--- a/services/apps/project.clj
+++ b/services/apps/project.clj
@@ -14,8 +14,8 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "apps-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [clj-http "2.0.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-http "2.2.0"]
                  [com.cemerick/url "0.1.1"]
                  [com.google.guava/guava "18.0"]
                  [de.ubercode.clostache/clostache "1.4.0"]

--- a/services/clockwork/project.clj
+++ b/services/clockwork/project.clj
@@ -14,7 +14,7 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "clockwork-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.jdbc "0.2.3"]
                  [cheshire "5.5.0"
                    :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
@@ -22,7 +22,7 @@
                                 [com.fasterxml.jackson.core/jackson-annotations]
                                 [com.fasterxml.jackson.core/jackson-databind]
                                 [com.fasterxml.jackson.core/jackson-core]]]
-                 [clj-http "0.6.5"]
+                 [clj-http "2.2.0"]
                  [clj-time "0.4.5"]
                  [clojurewerkz/quartzite "1.0.1"
                    :exclusions [c3p0]]

--- a/services/data-info/project.clj
+++ b/services/data-info/project.clj
@@ -11,7 +11,7 @@
   :description "provides the data information HTTP API"
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "data-info-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.codec "0.1.0"]
                  [org.clojure/tools.nrepl "0.2.10"]
                  [cheshire "5.5.0"

--- a/services/dewey/project.clj
+++ b/services/dewey/project.clj
@@ -16,7 +16,7 @@
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "dewey-standalone.jar"
   :main ^:skip-aot dewey.core
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.1"]
                  [cheshire "5.5.0"
                    :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
@@ -24,7 +24,7 @@
                                 [com.fasterxml.jackson.core/jackson-annotations]
                                 [com.fasterxml.jackson.core/jackson-databind]
                                 [com.fasterxml.jackson.core/jackson-core]]]
-                 [clojurewerkz/elastisch "2.0.0"]
+                 [clojurewerkz/elastisch "2.2.1"]
                  [com.novemberain/langohr "3.5.1"]
                  [liberator "0.11.1"]
                  [compojure "1.1.8"]

--- a/services/info-typer/project.clj
+++ b/services/info-typer/project.clj
@@ -14,7 +14,7 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "info-typer-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.novemberain/langohr "3.5.1"]
                  [me.raynes/fs "1.4.6"]
                  [org.iplantc/clj-jargon "5.2.8.0"

--- a/services/iplant-email/project.clj
+++ b/services/iplant-email/project.clj
@@ -14,7 +14,7 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "iplant-email-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.iplantc/clojure-commons "5.2.8.0"]
                  [org.iplantc/service-logging "5.2.8.0"]
                  [cheshire "5.5.0"

--- a/services/iplant-groups/project.clj
+++ b/services/iplant-groups/project.clj
@@ -14,9 +14,9 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "iplant-groups-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [cheshire "5.5.0"]
-                 [clj-http "2.0.0"]
+                 [clj-http "2.2.0"]
                  [clj-time "0.10.0"]
                  [com.cemerick/url "0.1.1"]
                  [medley "0.7.0"]

--- a/services/kifshare/project.clj
+++ b/services/kifshare/project.clj
@@ -17,7 +17,7 @@
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "kifshare-standalone.jar"
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [medley "0.5.5"]
                  [org.iplantc/clj-jargon "5.2.8.0"

--- a/services/metadata/project.clj
+++ b/services/metadata/project.clj
@@ -13,7 +13,7 @@
   :license {:name "BSD Standard License"
             :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [net.sourceforge.owlapi/owlapi-api "3.5.0"]
                  [net.sourceforge.owlapi/owlapi-apibinding "3.4.10"]
                  [net.sourceforge.owlapi/owlapi-reasoner "3.3"]

--- a/services/monkey/project.clj
+++ b/services/monkey/project.clj
@@ -17,10 +17,10 @@
   :aot [monkey.index monkey.tags monkey.core]
   :main monkey.core
   :uberjar-name "monkey-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [postgresql "9.1-901-1.jdbc4"]
                  [org.clojure/java.jdbc "0.3.5"]
-                 [clojurewerkz/elastisch "2.0.0"]
+                 [clojurewerkz/elastisch "2.2.1"]
                  [com.novemberain/langohr "3.5.1"]
                  [me.raynes/fs "1.4.6"]
                  [slingshot "0.10.3"]

--- a/services/terrain/project.clj
+++ b/services/terrain/project.clj
@@ -14,10 +14,10 @@
             :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "terrain-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.nrepl "0.2.12"]
                  [cheshire "5.5.0"]
-                 [clj-http "2.0.0"]
+                 [clj-http "2.2.0"]
                  [clj-time "0.11.0"]
                  [clojurewerkz/elastisch "2.2.0"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]

--- a/tools/facepalm/project.clj
+++ b/tools/facepalm/project.clj
@@ -18,7 +18,7 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "facepalm-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.1"]
                  [org.clojure/tools.logging "0.3.0"]
                  [cheshire "5.5.0"]
@@ -33,7 +33,7 @@
                  [org.iplantc/kameleon "5.2.8.0"]
                  [postgresql "9.1-901-1.jdbc4"]
                  [slingshot "0.10.3"]
-                 [clj-http "2.0.0"]]
+                 [clj-http "2.2.0"]]
   :plugins [[lein-marginalia "0.7.1"]]
   :aot :all
   :main facepalm.core)

--- a/tools/filetool/project.clj
+++ b/tools/filetool/project.clj
@@ -16,7 +16,7 @@
   :main ^:skip-aot porklock.core
   :profiles {:uberjar {:aot :all}}
   :uberjar-name "porklock-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.1"]
                  [org.clojure/tools.logging "0.3.1"]
                  [commons-io/commons-io "2.4"]

--- a/tools/job-preserver/project.clj
+++ b/tools/job-preserver/project.clj
@@ -7,7 +7,7 @@
                  [clj-time "0.8.0"]
                  [com.novemberain/monger "1.5.0"]
                  [korma "0.3.2"]
-                 [org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.1"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.iplantc/kameleon "5.2.8.0"]]

--- a/tools/sharkbait/project.clj
+++ b/tools/sharkbait/project.clj
@@ -18,7 +18,7 @@
                  [honeysql "0.6.2"]
                  [korma "0.4.2"]
                  [net.sf.ehcache/ehcache "2.10.1"]
-                 [org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.hibernate/hibernate-core "3.6.10.Final"]
                  [org.hibernate/hibernate-ehcache "3.6.10.Final"]

--- a/tools/template-mover/project.clj
+++ b/tools/template-mover/project.clj
@@ -15,7 +15,7 @@
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "template-mover-standalone.jar"
   :dependencies [[honeysql "0.6.0"]
-                 [org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojure "1.8.0"]
                  [org.clojure/java.jdbc "0.3.7"]
                  [org.clojure/tools.cli "0.3.1"]
                  [org.clojure/tools.logging "0.3.1"]


### PR DESCRIPTION
This one should be short and sweet. The obvious change was to update the Clojure dependencies. The `clj-http` dependencies were updated because ancient versions relied on a version of `potemkin` that was incompatible with Clojure 1.8. The `elastisch` dependencies were updated because they relied on an ancient version of `clj-http`.
