### PR TITLE
CORE-7773 Save AVUS instead of category IDs in apps publish endpoint.

### DIFF
--- a/services/apps/src/apps/persistence/app_metadata.clj
+++ b/services/apps/src/apps/persistence/app_metadata.clj
@@ -331,18 +331,6 @@
    (delete app_references (where {:app_id app-id}))
    (dorun (map (partial add-app-reference app-id) references))))
 
-(defn add-app-suggested-category
-  "Adds an App's suggested category to the database."
-  [app-id category-id]
-  (insert :suggested_groups (values {:app_id app-id, :app_category_id category-id})))
-
-(defn set-app-suggested-categories
-  "Resets the given App's suggested categories with the given category ID list."
-  [app-id category-ids]
-  (transaction
-   (delete :suggested_groups (where {:app_id app-id}))
-   (dorun (map (partial add-app-suggested-category app-id) category-ids))))
-
 (defn add-task
   "Adds a task to the database."
   [task]

--- a/services/apps/src/apps/routes/apps.clj
+++ b/services/apps/src/apps/routes/apps.clj
@@ -1,5 +1,6 @@
 (ns apps.routes.apps
   (:use [common-swagger-api.schema]
+        [apps.routes.middleware :only [wrap-metadata-base-url]]
         [apps.routes.params]
         [apps.routes.schemas.app]
         [apps.routes.schemas.app.rating]
@@ -218,6 +219,7 @@
   (POST* "/:app-id/publish" []
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParamsEmailRequired]
+         :middlewares [wrap-metadata-base-url]
          :body [body (describe PublishAppRequest "The user's Publish App Request.")]
          :summary "Submit an App for Public Use"
          :description "This service can be used to submit a private App for public use. The user supplies

--- a/services/apps/src/apps/routes/schemas/app.clj
+++ b/services/apps/src/apps/routes/schemas/app.clj
@@ -427,8 +427,8 @@
     (assoc OptionalGroupsKey (describe [AppGroupRequest] GroupListDocs)
            (optional-key :is_public) AppPublicParam)))
 
-(defschema AppCategoryIdListing
-  {:categories (describe [UUID] "A listing of App Category IDs")})
+(defschema AppCategoryMetadata
+  {:avus (describe [Any] "A listing of App Category metadata")})
 
 (defschema PublishAppRequest
   (-> AppBase
@@ -437,7 +437,7 @@
     (->optional-param :description)
     (assoc :documentation AppDocParam
            :references AppReferencesParam)
-    (merge AppCategoryIdListing)))
+    (merge AppCategoryMetadata)))
 
 (defschema AdminAppPatchRequest
   (-> AppBase


### PR DESCRIPTION
The `/apps/:id/publish` endpoint now accepts a list of AVUS instead of category IDs, which it will publish immediately to the metadata service.
This means apps published by users are categorized immediately into the ontology hierarchies the user chooses, rather than requiring admins to categorize the apps.

* This also makes the `suggested_groups` table obsolete, and it can be removed in a future db conversion.
* In a following PR, this endpoint will also tag the app with a "Beta" AVU, which will be the indicator to users that the app has not been curated by the admins yet.