### PR TITLE
CORE-7645 Update Public Submission Form for Ontology Hierarchies

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/SubmitAppForPublicUseView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/SubmitAppForPublicUseView.java
@@ -1,10 +1,10 @@
 package org.iplantc.de.apps.client;
 
 import org.iplantc.de.client.models.apps.App;
-import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.models.apps.AppRefLink;
+import org.iplantc.de.client.models.apps.PublishAppRequest;
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 
-import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -98,11 +98,9 @@ public interface SubmitAppForPublicUseView extends IsWidget {
         void go(HasOneWidget container, App selectedApp, AsyncCallback<String> callback);
     }
 
-    TreeStore<AppCategory> getTreeStore();
+    TreeStore<OntologyHierarchy> getTreeStore();
 
-    void expandAppCategories();
-
-    JSONObject toJson();
+    PublishAppRequest getPublishAppRequest();
 
     App getSelectedApp();
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/submit/SubmitAppForPublicUseView.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/submit/SubmitAppForPublicUseView.ui.xml
@@ -84,8 +84,7 @@
             <cp:ContentPanel ui:field="catPanel"
                              headingHtml="{appearance.publicCategories}"
                              height="200">
-                <tree:Tree ui:field="tree"
-                           autoExpand="true"/>
+                <tree:Tree ui:field="tree"/>
             </cp:ContentPanel>
         </con:child>
         <con:child layoutData="{fileSelLabel}">

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/AppAutoBeanFactory.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/AppAutoBeanFactory.java
@@ -39,4 +39,6 @@ public interface AppAutoBeanFactory extends AutoBeanFactory {
 
     AutoBean<AppUnSharingRequestList> appUnSharingRequestList();
 
+    AutoBean<PublishAppRequest> publishAppRequest();
+
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/PublishAppRequest.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/PublishAppRequest.java
@@ -1,0 +1,42 @@
+package org.iplantc.de.client.models.apps;
+
+import org.iplantc.de.client.models.HasDescription;
+import org.iplantc.de.client.models.HasId;
+import org.iplantc.de.client.models.avu.Avu;
+
+import com.google.gwt.user.client.ui.HasName;
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public interface PublishAppRequest extends HasId, HasName, HasDescription {
+
+    void setId(String id);
+
+    @PropertyName("integration_date")
+    String getIntegrationDate();
+
+    @PropertyName("integration_date")
+    void setIntegrationDate(String date);
+
+    @PropertyName("edited_date")
+    String getEditedDate();
+
+    @PropertyName("edited_date")
+    void setEditedDate(String date);
+
+    String getDocumentation();
+
+    void setDocumentation(String doc);
+
+    List<String> getReferences();
+
+    void setReferences(List<String> references);
+
+    List<Avu> getAvus();
+
+    void setAvus(List<Avu> avus);
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/AppUserServiceFacade.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/AppUserServiceFacade.java
@@ -4,11 +4,11 @@ import org.iplantc.de.client.models.HasId;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppDoc;
 import org.iplantc.de.client.models.apps.AppFeedback;
+import org.iplantc.de.client.models.apps.PublishAppRequest;
 import org.iplantc.de.client.models.apps.integration.AppTemplate;
 import org.iplantc.de.client.models.apps.sharing.AppSharingRequestList;
 import org.iplantc.de.client.models.apps.sharing.AppUnSharingRequestList;
 
-import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import java.util.List;
@@ -66,7 +66,7 @@ public interface AppUserServiceFacade extends AppServiceFacade {
     /**
      * Adds an app to the given public categories.
      */
-    void publishToWorld(JSONObject json, String appId, AsyncCallback<Void> callback);
+    void publishToWorld(PublishAppRequest req, AsyncCallback<Void> callback);
 
     /**
      * Get app details

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/AppUserServiceFacadeImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/AppUserServiceFacadeImpl.java
@@ -11,6 +11,7 @@ import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.models.apps.AppDoc;
 import org.iplantc.de.client.models.apps.AppFeedback;
 import org.iplantc.de.client.models.apps.AppList;
+import org.iplantc.de.client.models.apps.PublishAppRequest;
 import org.iplantc.de.client.models.apps.integration.AppTemplate;
 import org.iplantc.de.client.models.apps.integration.AppTemplateAutoBeanFactory;
 import org.iplantc.de.client.models.apps.proxy.AppListLoadResult;
@@ -139,10 +140,11 @@ public class AppUserServiceFacadeImpl implements AppUserServiceFacade {
     }
 
     @Override
-    public void publishToWorld(JSONObject application, String appId, AsyncCallback<Void> callback) {
-        String address = APPS + "/" + appId + "/publish"; //$NON-NLS-1$
+    public void publishToWorld(PublishAppRequest request, AsyncCallback<Void> callback) {
+        String address = APPS + "/" + request.getId() + "/publish"; //$NON-NLS-1$
 
-        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, application.toString());
+        final Splittable encode = AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(request));
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, encode.getPayload());
 
         deServiceFacade.getServiceData(wrapper, new StringToVoidCallbackConverter(callback));
     }


### PR DESCRIPTION
These are the UI changes that go along with PR #273.  Basically, since we're moving away from app categories, when a user wants to publish an app, they now have the active ontology's hierarchies to choose from to categorize their app.  Those hierarchies then get turned into AVUs for metadata.