### PR TITLE
CORE-7755: download zip of blank+guide template CSVs

### DIFF
--- a/services/metadata/project.clj
+++ b/services/metadata/project.clj
@@ -18,6 +18,7 @@
                  [net.sourceforge.owlapi/owlapi-apibinding "3.4.10"]
                  [net.sourceforge.owlapi/owlapi-reasoner "3.3"]
                  [metosin/compojure-api "0.24.5"]
+                 [me.raynes/fs "1.4.6"]
                  [cheshire "5.5.0"]
                  [org.clojure/data.csv "0.1.3"]
                  [com.novemberain/langohr "3.5.1"]
@@ -27,6 +28,7 @@
                  [org.iplantc/common-swagger-api "5.2.8.0"]
                  [org.iplantc/kameleon "5.2.8.0"]
                  [org.iplantc/service-logging "5.2.8.0"]
+                 [sanitize-filename "0.1.0"]
                  [slingshot "0.12.2"]]
   :main metadata.core
   :ring {:handler metadata.core/dev-handler

--- a/services/metadata/src/metadata/services/templates.clj
+++ b/services/metadata/src/metadata/services/templates.clj
@@ -3,6 +3,8 @@
         [korma.db :only [transaction]])
   (:require [clojure-commons.assertions :as ca]
             [clojure.string :as string]
+            [me.raynes.fs.compression :as cmp]
+            [sanitize-filename.core :as sf]
             [metadata.persistence.templates :as tp]
             [metadata.util.csv :as csv]))
 
@@ -16,23 +18,38 @@
       (ca/assert-found "metadata template" template-id)
       (remove-nil-values)))
 
-(defn view-template-csv
-  [template-id]
+(defn- format-template-csv
+  [template-data]
   (csv/csv-string [
-    (->> (view-template template-id)
+    (->> template-data
       :attributes
       (map :name)
       (cons "file name or path"))]))
 
-(defn view-template-guide
+(defn view-template-csv
   [template-id]
+  (format-template-csv (view-template template-id)))
+
+(defn- format-template-guide
+  [template-data]
   (csv/csv-string
-    (->> (view-template template-id)
+    (->> template-data
       :attributes
       (map (juxt :name :description :required :type #(if (:values %) (string/join ", " (map :value (:values %))) "")))
       (cons ["attribute name", "attribute description",
              "required (If you cannot provide,  enter 'not collected', 'not applicable' or 'missing'.)",
              "value type definition", "enum value options (you must enter one of these values)"]))))
+
+(defn view-template-guide
+  [template-id]
+  (format-template-guide (view-template template-id)))
+
+(defn view-template-zip
+  [template-id]
+  (let [template-data (view-template template-id)
+        template-name (sf/sanitize (:name template-data))]
+    (cmp/make-zip-stream [(str template-name "/blank.csv") (format-template-csv template-data)]
+                         [(str template-name "/guide.csv") (format-template-guide template-data)])))
 
 ;; This function alias relies on view-template's error checking to throw an exception if a template
 ;; with the given ID doesn't exist.

--- a/services/terrain/src/terrain/clients/metadata/raw.clj
+++ b/services/terrain/src/terrain/clients/metadata/raw.clj
@@ -162,6 +162,10 @@
   [template-id]
   (http/get (metadata-url "templates" template-id "guide-csv") (get-options)))
 
+(defn get-template-zip
+  [template-id]
+  (http/get (metadata-url "templates" template-id "zip-csv") (get-options)))
+
 (defn get-attribute
   [attr-id]
   (http/get (metadata-url "templates" "attr" attr-id) (get-options)))

--- a/services/terrain/src/terrain/routes/filesystem.clj
+++ b/services/terrain/src/terrain/routes/filesystem.clj
@@ -113,6 +113,9 @@
     (GET "/filesystem/metadata/template/:template-id/guide-csv" [template-id :as req]
       (controller req meta-raw/get-template-guide template-id))
 
+    (GET "/filesystem/metadata/template/:template-id/zip-csv" [template-id :as req]
+      (controller req meta-raw/get-template-zip template-id))
+
     (GET "/filesystem/metadata/template/attr/:attr-id" [attr-id :as req]
       (controller req mt/do-metadata-attribute-view attr-id))
 


### PR DESCRIPTION
Plus, some refactoring. Mostly just making it so we don't hit the database multiple times for this endpoint which does several things with the same template data.

This uses a sanitize-filename library I found to generate the folder name inside the zip file from the template name. It seems to be pretty sane, though it does choose to replace slashes with dollar signs which could be mildly confusing. Still, it should be pretty readable in general. For making zip files, apparently `me.raynes.fs` has tools for this already! Woo!