### PR TITLE
CORE-7934 Update publish endpoint to include beta AVU in app metadata.

### DIFF
--- a/ansible/roles/util-cfg-service/templates/apps.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/apps.properties.j2
@@ -26,8 +26,10 @@ apps.workspace.root-app-category            = {{ apps.user_root }}
 apps.workspace.default-app-categories       = {{ apps.user_subs }}
 apps.workspace.dev-app-category-index       = 0
 apps.workspace.favorites-app-category-index = 1
-apps.workspace.beta-app-category-id         = 5401bd14-6c14-4470-aedd-57b47ea1b979
 apps.workspace.public-id                    = 00000000-0000-0000-0000-000000000000
+apps.workspace.metadata.beta.attr.iri       = n2t.net/ark:/99152/h1459
+apps.workspace.metadata.beta.attr.label     = releaseStatus
+apps.workspace.metadata.beta.value          = beta
 
 # The domain name to append to the user id to get the fully qualified user id.
 apps.uid.domain = {{ cas_uid_domain }}

--- a/services/apps/src/apps/persistence/app_metadata.clj
+++ b/services/apps/src/apps/persistence/app_metadata.clj
@@ -722,16 +722,15 @@
                   :a.id                      [not= app-id]})))
 
 (defn- app-category-id-subselect
-  [app-id beta-app-category-id]
+  [app-id]
   (subselect :app_category_app
              (fields :app_category_id)
-             (where {:app_id          app-id
-                     :app_category_id [not= beta-app-category-id]})))
+             (where {:app_id app-id})))
 
 (defn list-duplicate-apps
   "List apps with the same name that exist in the same category as the new app."
-  [app-name app-id beta-app-category-id category-ids]
+  [app-name app-id category-ids]
   (->> (if (seq category-ids)
-         (remove (partial = beta-app-category-id) category-ids)
-         (app-category-id-subselect app-id beta-app-category-id))
+         category-ids
+         (app-category-id-subselect app-id))
        (list-duplicate-apps* app-name app-id)))

--- a/services/apps/src/apps/service/apps/de/admin.clj
+++ b/services/apps/src/apps/service/apps/de/admin.clj
@@ -2,7 +2,7 @@
   (:use [korma.db :only [transaction]]
         [apps.persistence.app-metadata.relabel :only [update-app-labels]]
         [apps.util.assertions :only [assert-not-nil]]
-        [apps.util.config :only [workspace-public-id workspace-beta-app-category-id]]
+        [apps.util.config :only [workspace-public-id]]
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.tools.logging :as log]
             [kameleon.app-groups :as app-groups]
@@ -93,7 +93,7 @@
   (transaction
    (validate-app-existence app-id)
    (when-not (nil? app-name)
-     (av/validate-app-name app-name app-id (workspace-beta-app-category-id)))
+     (av/validate-app-name app-name app-id))
    (if (empty? (select-keys app [:name :description :wiki_url :references :groups]))
      (update-app-deleted-disabled app)
      (update-app-details app))))

--- a/services/apps/src/apps/service/apps/de/categorization.clj
+++ b/services/apps/src/apps/service/apps/de/categorization.clj
@@ -6,8 +6,7 @@
         [apps.validation]
         [slingshot.slingshot :only [throw+]])
   (:require [apps.persistence.app-metadata :as ap]
-            [apps.service.apps.de.validation :as av]
-            [apps.util.config :as cfg]))
+            [apps.service.apps.de.validation :as av]))
 
 (defn- categorize-app
   "Associates an app with an app category."
@@ -55,7 +54,7 @@
   "Validates the app name to ensure that there are no apps with the same name in any of the
   destination categories."
   [app-id category-ids path]
-  (av/validate-app-name (ap/get-app-name app-id) app-id (cfg/workspace-beta-app-category-id) category-ids path))
+  (av/validate-app-name (ap/get-app-name app-id) app-id category-ids path))
 
 (defn- validate-category
   "Validates each categorized app in the request."

--- a/services/apps/src/apps/service/apps/de/edit.clj
+++ b/services/apps/src/apps/service/apps/de/edit.clj
@@ -9,7 +9,7 @@
         [kameleon.uuids :only [uuidify]]
         [apps.metadata.params :only [format-reference-genome-value]]
         [apps.service.apps.de.validation :only [verify-app-editable verify-app-permission validate-app-name]]
-        [apps.util.config :only [workspace-dev-app-category-index workspace-beta-app-category-id]]
+        [apps.util.config :only [workspace-dev-app-category-index]]
         [apps.util.conversions :only [remove-nil-vals convert-rule-argument]]
         [apps.validation :only [validate-parameter]]
         [apps.workspace :only [get-workspace]]
@@ -350,7 +350,7 @@
   [user {app-id :id app-name :name :keys [references groups] :as app}]
   (verify-app-editable user (persistence/get-app app-id))
   (transaction
-    (validate-app-name app-name app-id (workspace-beta-app-category-id))
+    (validate-app-name app-name app-id)
     (persistence/update-app app)
     (let [tool-id (->> app :tools first :id)
           app-task (->> (get-app-details app-id) :tasks first)
@@ -388,7 +388,7 @@
   [{:keys [username] :as user} {app-name :name :keys [references groups] :as app}]
   (transaction
     (let [cat-id  (get-user-subcategory username (workspace-dev-app-category-index))
-          _       (validate-app-name app-name nil (workspace-beta-app-category-id) [cat-id])
+          _       (validate-app-name app-name nil [cat-id])
           app-id  (:id (persistence/add-app app user))
           tool-id (->> app :tools first :id)
           task-id (-> (assoc app :id app-id :tool_id tool-id)
@@ -466,6 +466,6 @@
     (when-not (user-owns-app? user app)
       (verify-app-permission user app "write")))
   (transaction
-   (validate-app-name app-name app-id (workspace-beta-app-category-id))
+   (validate-app-name app-name app-id)
    (persistence/update-app-labels body))
   (get-app-ui user app-id))

--- a/services/apps/src/apps/service/apps/de/validation.clj
+++ b/services/apps/src/apps/service/apps/de/validation.clj
@@ -151,15 +151,15 @@
 (defn validate-app-name
   "Verifies that an app with the same name doesn't already exist in any of the same app categories. The beta
    category is treated as an exception because it's intended to be a staging area for new apps."
-  ([app-name app-id beta-app-category-id]
-     (validate-app-name app-name app-id beta-app-category-id nil))
-  ([app-name app-id beta-app-category-id category-ids]
-     (when (seq (list-duplicate-apps app-name app-id beta-app-category-id category-ids))
+  ([app-name app-id]
+     (validate-app-name app-name app-id nil))
+  ([app-name app-id category-ids]
+     (when (seq (list-duplicate-apps app-name app-id category-ids))
        (if (seq category-ids)
          (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids)
          (exists duplicate-app-existing-categories-msg :app_name app-name :app_id app-id))))
-  ([app-name app-id beta-app-category-id category-ids path]
-     (when (seq (list-duplicate-apps app-name app-id beta-app-category-id category-ids))
+  ([app-name app-id category-ids path]
+     (when (seq (list-duplicate-apps app-name app-id category-ids))
        (if (seq category-ids)
          (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids :path path)
          (exists duplicate-app-existing-categories-msg :app_name app-name :app_id app-id :path path)))))

--- a/services/apps/src/apps/util/config.clj
+++ b/services/apps/src/apps/util/config.clj
@@ -116,10 +116,20 @@
   [props config-valid configs]
   "apps.workspace.favorites-app-category-index")
 
-(cc/defprop-uuid workspace-beta-app-category-id
-  "The UUID of the default Beta app category."
+(cc/defprop-str workspace-metadata-beta-attr-iri
+  "The attr of the Beta metadata AVU."
   [props config-valid configs]
-  "apps.workspace.beta-app-category-id")
+  "apps.workspace.metadata.beta.attr.iri")
+
+(cc/defprop-str workspace-metadata-beta-attr-label
+  "The label of the Beta metadata AVU attr."
+  [props config-valid configs]
+  "apps.workspace.metadata.beta.attr.label")
+
+(cc/defprop-str workspace-metadata-beta-value
+  "The value of the Beta metadata AVU."
+  [props config-valid configs]
+  "apps.workspace.metadata.beta.value")
 
 (cc/defprop-uuid workspace-public-id
   "The UUID of the default Beta app category."


### PR DESCRIPTION
Since the Beta category is going away with all the old app categories, when an app is made public from now on, it will be "tagged" with a "Beta" AVU, rather than added to the old Beta category.

These changes remove references in the apps service to the old apps.workspace.beta-app-category-id config and add new settings for the beta AVU’s attr, value, and the attr's label.
These new configs are used to automatically add the beta AVU to apps published with the `/apps/:id/publish` endpoint.