### PR TITLE
CORE-7677: upgrade jargon version and return to using AVU query code

### DIFF
--- a/libs/clj-jargon/project.clj
+++ b/libs/clj-jargon/project.clj
@@ -6,14 +6,14 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [ch.qos.logback/logback-classic "1.1.3"]
-                 [org.irods.jargon/jargon-core "4.0.2.4-RELEASE"
+                 [org.irods.jargon/jargon-core "4.0.2.6-RELEASE"
                   :exclusions [[org.jglobus/JGlobus-Core]
                                [org.slf4j/slf4j-api]
                                [org.slf4j/slf4j-log4j12]]]
-                 [org.irods.jargon/jargon-data-utils "4.0.2.4-RELEASE"
+                 [org.irods.jargon/jargon-data-utils "4.0.2.6-RELEASE"
                   :exclusions [[org.slf4j/slf4j-api]
                                [org.slf4j/slf4j-log4j12]]]
-                 [org.irods.jargon/jargon-ticket "4.0.2.4-RELEASE"
+                 [org.irods.jargon/jargon-ticket "4.0.2.6-RELEASE"
                   :exclusions [[org.slf4j/slf4j-api]
                                [org.slf4j/slf4j-log4j12]]]
                  [slingshot "0.12.2"]
@@ -21,6 +21,4 @@
   :repositories [["dice.repository"
                   {:url "https://raw.github.com/DICE-UNC/DICE-Maven/master/releases"}]
                  ["renci-snapshot.repository"
-                  {:url "http://ci-dev.renci.org/nexus/content/repositories/renci-snapshot/"}]
-                 ["iplant.repository"
-                  {:url "https://everdene.iplantcollaborative.org/archiva/repository/internal/"}]])
+                  {:url "http://ci-dev.renci.org/nexus/content/repositories/renci-snapshot/"}]])

--- a/libs/clj-jargon/src/clj_jargon/metadata.clj
+++ b/libs/clj-jargon/src/clj_jargon/metadata.clj
@@ -42,53 +42,39 @@
       (.findMetadataValuesForCollection collection-ao dir-path)
       (.findMetadataValuesForDataObject data-ao dir-path))))
 
-; use again when jargon doesn't trim the values
-;(defn- get-metadata-by-query
-;  [{^DataObjectAO data-ao :dataObjectAO
-;    ^CollectionAO collection-ao :collectionAO
-;    :as cm} path query]
-;  (validate-path-lengths path)
-;  (mapv avu2map
-;    (if (is-dir? cm path)
-;      (.findMetadataValuesByMetadataQueryForCollection collection-ao query path)
-;      (.findMetadataValuesForDataObjectUsingAVUQuery data-ao query path))))
+(defn- get-metadata-by-query
+  [{^DataObjectAO data-ao :dataObjectAO
+    ^CollectionAO collection-ao :collectionAO
+    :as cm} path query]
+  (validate-path-lengths path)
+  (mapv avu2map
+    (if (is-dir? cm path)
+      (.findMetadataValuesByMetadataQueryForCollection collection-ao query path)
+      (.findMetadataValuesForDataObjectUsingAVUQuery data-ao query path))))
 
 (defn get-attribute
   "Returns a list of avu maps for a specific attribute associated with dir-path"
   [{^DataObjectAO data-ao :dataObjectAO
     ^CollectionAO collection-ao :collectionAO
     :as cm} dir-path attr]
-  (validate-path-lengths dir-path)
-  (filter
-    #(= (:attr %1) attr)
-    (get-metadata cm dir-path)))
-
-; go back to this once jargon doesn't trim the values
-;  (let [query [(AVUQueryElement/instanceForValueQuery
-;                AVUQueryElement$AVUQueryPart/ATTRIBUTE
-;                AVUQueryOperatorEnum/EQUAL
-;                attr)]]
-;    (get-metadata-by-query cm dir-path query)))
+  (let [query [(AVUQueryElement/instanceForValueQuery
+                AVUQueryElement$AVUQueryPart/ATTRIBUTE
+                AVUQueryOperatorEnum/EQUAL
+                attr)]]
+    (get-metadata-by-query cm dir-path query)))
 
 (defn get-attribute-value
   [{^DataObjectAO data-ao :dataObjectAO
     ^CollectionAO collection-ao :collectionAO
     :as cm} apath attr val]
-  (validate-path-lengths apath)
-  (filter
-    #(and (= (:attr %1) attr)
-          (= (:value %1) val))
-    (get-metadata cm apath)))
-
-; use this once jargon doesn't trim the values
-;  (let [query [(AVUQueryElement/instanceForValueQuery
-;                AVUQueryElement$AVUQueryPart/ATTRIBUTE
-;                AVUQueryOperatorEnum/EQUAL
-;                attr) (AVUQueryElement/instanceForValueQuery
-;                AVUQueryElement$AVUQueryPart/VALUE
-;                AVUQueryOperatorEnum/EQUAL
-;                (str val))]]
-;    (get-metadata-by-query cm apath query)))
+  (let [query [(AVUQueryElement/instanceForValueQuery
+                AVUQueryElement$AVUQueryPart/ATTRIBUTE
+                AVUQueryOperatorEnum/EQUAL
+                attr) (AVUQueryElement/instanceForValueQuery
+                AVUQueryElement$AVUQueryPart/VALUE
+                AVUQueryOperatorEnum/EQUAL
+                (str val))]]
+    (get-metadata-by-query cm apath query)))
 
 (defn attribute?
   "Returns true if the path has the associated attribute."


### PR DESCRIPTION
Jargon 4.0.2.6 has been released, which includes my fixes for the AVU query code, so we can now return to the code I'd previously written for AVU lookups by specific attributes and values, which is more efficient.