### PR TITLE
CORE-7935 Update apps listing endpoints to include a beta flag.

### DIFF
--- a/services/apps/src/apps/routes/apps.clj
+++ b/services/apps/src/apps/routes/apps.clj
@@ -14,6 +14,7 @@
 (defroutes* apps
   (GET* "/" []
         :query [params AppSearchParams]
+        :middlewares [wrap-metadata-base-url]
         :summary "Search Apps"
         :return AppListing
         :description "This service allows users to search for Apps based on a part of the App name or

--- a/services/apps/src/apps/routes/apps/categories.clj
+++ b/services/apps/src/apps/routes/apps/categories.clj
@@ -26,6 +26,7 @@
   (GET* "/:category-id" []
         :path-params [category-id :- AppCategoryIdPathParam]
         :query [params AppListingPagingParams]
+        :middlewares [wrap-metadata-base-url]
         :return AppCategoryAppListing
         :summary "List Apps in a Category"
         :description "This service lists all of the apps within an app category or any of its

--- a/services/apps/src/apps/routes/schemas/app.clj
+++ b/services/apps/src/apps/routes/schemas/app.clj
@@ -357,6 +357,9 @@
      :is_public
      AppPublicParam
 
+     (optional-key :beta)
+     (describe Boolean "Whether the App has been marked as `beta` release status")
+
      :pipeline_eligibility
      (describe PipelineEligibility "Whether the App can be used in a Pipeline")
 


### PR DESCRIPTION
The `/apps/`, `/apps/categories/:id`, and `/apps/hierarchies/:iri/apps` endpoints now include a `beta` flag for each app, which is `true` for apps that have the `beta` metadata AVU attached.