### PR TITLE
CORE-7261: update iplant-groups exception handling to match other services

### DIFF
--- a/services/iplant-groups/src/iplant_groups/clients/grouper.clj
+++ b/services/iplant-groups/src/iplant_groups/clients/grouper.clj
@@ -416,7 +416,7 @@
     {:WsRestGetGrouperPrivilegesLiteRequest
      {:actAsSubjectId username
       name-key group-or-folder-name}}
-    (throw+ {:error_code ce/ERR_BAD_REQUEST :entity-type entity-type})))
+    (throw+ {:type :clojure-commons.exception/bad-request :entity-type entity-type})))
 
 (defn- get-group-folder-privileges
   [entity-type username group-or-folder-name]
@@ -609,10 +609,6 @@
 
 ;; Permission assignment
 ;; search/lookup
-(defn- uuid-lookups
-  [uuids]
-  (when-not (every? nil? uuids)
-    (mapv uuid-lookup (remove nil? uuids))))
 
 (defn- format-attribute-def-lookup
   [{:keys [attribute_def_id attribute_def]}]

--- a/services/iplant-groups/src/iplant_groups/service/format.clj
+++ b/services/iplant-groups/src/iplant_groups/service/format.clj
@@ -24,7 +24,7 @@
       "f"     false
       "no"    false
       "n"     false
-      (throw+ {:error_code    ce/ERR_ILLEGAL_ARGUMENT
+      (throw+ {:type          :clojure-commons.exception/illegal-argument
                :boolean_value s}))))
 
 (defn string-to-integer
@@ -34,7 +34,7 @@
 
 (defn- not-found
   [response]
-  (throw+ {:error_code          ce/ERR_NOT_FOUND
+  (throw+ {:type                :clojure-commons.exception/not-found
            :grouper_result_code (:resultCode response)
            :id                  (:id response)}))
 

--- a/services/iplant-groups/src/iplant_groups/util/config.clj
+++ b/services/iplant-groups/src/iplant_groups/util/config.clj
@@ -55,7 +55,7 @@
   "Validates the configuration settings after they've been loaded."
   []
   (when-not (cc/validate-config configs config-valid)
-    (throw+ {:error_code ce/ERR_CONFIG_INVALID})))
+    (throw+ {:type :clojure-commons.exception/invalid-cfg})))
 
 (defn load-config-from-file
   "Loads the configuration settings from a file."

--- a/services/iplant-groups/src/iplant_groups/util/service.clj
+++ b/services/iplant-groups/src/iplant_groups/util/service.clj
@@ -5,13 +5,13 @@
 
 (defn not-found
   [desc id]
-  (throw+ {:error_code  ce/ERR_NOT_FOUND
+  (throw+ {:type        :clojure-commons.exception/not-found
            :description desc
            :id          id}))
 
 (defn forbidden
   [desc id]
-  (throw+ {:error_code  ce/ERR_FORBIDDEN
+  (throw+ {:type        :clojure-commons.exception/forbidden
            :description desc
            :id          id}))
 


### PR DESCRIPTION
This should just be consistent with other such exception handling updates.