### PR TITLE
Use explicit column names in a notificationagent insert statement

### DIFF
--- a/services/NotificationAgent/src/notification_agent/db.clj
+++ b/services/NotificationAgent/src/notification_agent/db.clj
@@ -640,7 +640,9 @@
   "Inserts a new system notification acknowledgment record for a given user and system notification.
    The state is set to acknowledged, and the given time used for the date acknowledged."
   [seen-date user sys-note-uuid]
-  (exec-raw ["INSERT INTO system_notification_acknowledgments VALUES (?, ?, 'acknowledged', ?)"
+  (exec-raw ["INSERT INTO system_notification_acknowledgments
+                  (user_id, system_notification_id, state, date_acknowledged)
+                VALUES (?, ?, 'acknowledged', ?)"
              [(lock-user user)
               (system-notif-id sys-note-uuid)
               (parse-date seen-date)]]))


### PR DESCRIPTION
This happened to be erroring in a QA environment, I think for unrelated reasons, but I think it's better to be explicit about the columns we're inserting into.

So, minor, but may as well be fixed. I'd like a double-check that I've put the right columns in the right order, though.