### PR TITLE
Core 8087 - Ansible Elasticsearch host/group refactoring

### DIFF
--- a/ansible/inventories/example.cfg
+++ b/ansible/inventories/example.cfg
@@ -170,10 +170,12 @@ amqp.example.com
 docker-registry.example.com
 
 ###############################################################################
-# elasticsearch
+# data-store-elasticsearch
 ###############################################################################
-[elasticsearch]
+[data-store-elasticsearch]
 elasticsearch.example.com
+[elasticsearch:children]
+data-store-elasticsearch
 
 ###############################################################################
 # irods

--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -259,17 +259,12 @@ iplant_email:
 
 environment_name:
 
-elasticsearch:
-  host: "{{ groups['elasticsearch'][0] }}"
-  port:
-  version: 2.3.0
-  base: "http://{{ groups['elasticsearch'][0] }}"
-  scroll_size: 1000
-  cluster_name: elasticsearch
-  data_index: data
-  heap_size:
-  network_http_port:
-  network_transport_tcp_port:
+data_store:
+  elasticsearch:
+    host: "{{ groups['data-store-elasticsearch'][0] }}"
+    port:
+    scroll_size: 1000
+    data_index: data
 
 exim:
   service_name: exim-sender.service

--- a/ansible/roles/util-cfg-service/templates/dewey.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/dewey.properties.j2
@@ -9,8 +9,8 @@ dewey.amqp.exchange.durable     = {{ amqp_irods_exchange_durable }}
 dewey.amqp.exchange.auto-delete = {{ amqp_irods_exchange_auto_delete }}
 dewey.amqp.qos                  = 100
 
-dewey.es.host                   = {{ elasticsearch.host }}
-dewey.es.port                   = {{ elasticsearch.port }}
+dewey.es.host                   = {{ data_store.elasticsearch.host }}
+dewey.es.port                   = {{ data_store.elasticsearch.port }}
 
 dewey.irods.host                = {{ irods.host }}
 dewey.irods.port                = {{ irods.port }}

--- a/ansible/roles/util-cfg-service/templates/infosquito.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/infosquito.properties.j2
@@ -1,7 +1,7 @@
 # ElasticSearch Settings
-infosquito.es.host        = {{ elasticsearch.host }}
-infosquito.es.port        = {{ elasticsearch.port }}
-infosquito.es.scroll-size = {{ elasticsearch.scroll_size }}
+infosquito.es.host        = {{ data_store.elasticsearch.host }}
+infosquito.es.port        = {{ data_store.elasticsearch.port }}
+infosquito.es.scroll-size = {{ data_store.elasticsearch.scroll_size }}
 
 # ICAT Database Connection Settings
 infosquito.icat.host     = {{ icat.host }}

--- a/ansible/roles/util-cfg-service/templates/monkey.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/monkey.properties.j2
@@ -12,11 +12,11 @@ monkey.amqp.exchange.name        = {{ amqp_de_exchange }}
 monkey.amqp.exchange.durable     = {{ amqp_de_exchange_durable }}
 monkey.amqp.exchange.auto-delete = {{ amqp_de_exchange_auto_delete }}
 
-monkey.es.url            = http://{{ elasticsearch.host }}:{{ elasticsearch.port }}
+monkey.es.url            = http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}
 monkey.es.index          = data
 monkey.es.tag-type       = tag
 monkey.es.batch-size     = 1000
-monkey.es.scroll-size    = {{ elasticsearch.scroll_size }}
+monkey.es.scroll-size    = {{ data_store.elasticsearch.scroll_size }}
 monkey.es.scroll-timeout = 1m
 
 monkey.tags.host       = {{ metadata_db_host }}

--- a/ansible/roles/util-cfg-service/templates/templeton-incremental.yaml.j2
+++ b/ansible/roles/util-cfg-service/templates/templeton-incremental.yaml.j2
@@ -2,8 +2,8 @@ amqp:
   uri: amqp://{{ amqp_broker.user }}:{{ amqp_broker.password }}@{{ amqp_broker.host }}:{{ amqp_broker.port }}/
 
 elasticsearch:
-  base: http://{{ elasticsearch.host }}:{{ elasticsearch.port }}
-  index: data
+  base: http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}
+  index: {{ data_store.elasticsearch.data_index }}
 
 db:
   uri: postgres://{{ metadata_db_user }}:{{ metadata_db_password }}@{{ metadata_db_host }}:{{ metadata_db_port }}/{{ metadata_db_name }}?sslmode=disable

--- a/ansible/roles/util-cfg-service/templates/templeton-periodic.yaml.j2
+++ b/ansible/roles/util-cfg-service/templates/templeton-periodic.yaml.j2
@@ -2,8 +2,8 @@ amqp:
   uri: amqp://{{ amqp_broker.user }}:{{ amqp_broker.password }}@{{ amqp_broker.host }}:{{ amqp_broker.port }}/
 
 elasticsearch:
-  base: http://{{ elasticsearch.host }}:{{ elasticsearch.port }}
-  index: data
+  base: http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}
+  index: {{ data_store.elasticsearch.data_index }}
 
 db:
   uri: postgres://{{ metadata_db_user }}:{{ metadata_db_password }}@{{ metadata_db_host }}:{{ metadata_db_port }}/{{ metadata_db_name }}?sslmode=disable

--- a/ansible/roles/util-cfg-service/templates/terrain.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/terrain.properties.j2
@@ -53,8 +53,8 @@ terrain.jex.base-url = {{ jex.base }}/
 # Tree viewer settings
 terrain.tree-viewer.base-url = {{ tree_parser_base }}
 
-# Elastic Search settings
-terrain.infosquito.es-url = {{ elasticsearch.base }}
+# Data-Store Elastic Search settings
+terrain.infosquito.es-url = http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}
 
 # App execution settings
 terrain.job-exec.default-output-folder = {{ apps.out_dir }}


### PR DESCRIPTION
The current host groups which call out the hosts which host elasticsearch clusters for our data-store- clusters are in the `[elasticsearch]` host groups. 
Currently, the DE only runs one cluster, but we cannot preclude that we might run multiple clusters in the future. 

Therefore, it is desirable to separate variables related to accessing the data-store- clusters from variables related to the installation of elasticsearch.

Variables related to elasticsearch installation are kept in the private ansible repo.