### PR TITLE
CORE-7898 Make apps tagged as Beta appear as blue

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/grid/cells/AppNameCell.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/grid/cells/AppNameCell.java
@@ -35,6 +35,10 @@ public class AppNameCell extends AbstractCell<App> {
 
         String appUnavailable();
 
+        String appBeta();
+
+        String appBetaNameClass();
+
         void render(SafeHtmlBuilder sb, App value, String textClassName, String searchPattern,
                     String textToolTip, String debugId);
 
@@ -64,8 +68,13 @@ public class AppNameCell extends AbstractCell<App> {
         favoriteCell.render(context, value, sb);
         String textClassName, textToolTip;
         if (!value.isDisabled()) {
-            textClassName = appearance.appHyperlinkNameClass();
-            textToolTip = appearance.run();
+            if (value.isBeta()) {
+                textClassName = appearance.appBetaNameClass();
+                textToolTip = appearance.appBeta();
+            } else {
+                textClassName = appearance.appHyperlinkNameClass();
+                textToolTip = appearance.run();
+            }
         } else {
             textClassName = appearance.appDisabledClass();
             textToolTip = appearance.appUnavailable();

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/App.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/App.java
@@ -140,4 +140,6 @@ public interface App extends HasId,
     void setPermission(PermissionValue value);
 
     PermissionValue getPermission();
+
+    Boolean isBeta();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/App.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/App.java
@@ -29,7 +29,7 @@ public interface App extends HasId,
     String IS_PUBLIC_KEY = "is_public";
     String PIPELINE_ELIGIBILITY_KEY = "pipeline_eligibility";
     String STEP_COUNT_KEY = "step_count";
-    String SUGGESTED_GROUPS_KEY = "suggested_groups";
+    String SUGGESTED_GROUPS_KEY = "suggested_categories";
     String TOOLS_KEY = "tools";
     String WIKI_URL_KEY = "wiki_url";
     String REFERENCES_KEY = "references";

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/apps/AdminAppNameCellDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/apps/AdminAppNameCellDefaultAppearance.java
@@ -20,12 +20,21 @@ public class AdminAppNameCellDefaultAppearance extends AppNameCellDefaultAppeara
                        final App value,
                        final String searchPattern) {
         if(!value.isDisabled()){
-            super.render(sb,
-                         value,
-                         resources.css().appName(),
-                         searchPattern,
-                         displayStrings.editApp(),
-                         null);
+            if (value.isBeta()) {
+                super.render(sb,
+                             value,
+                             resources.css().appBeta(),
+                             searchPattern,
+                             displayStrings.editApp(),
+                             null);
+            } else {
+                super.render(sb,
+                             value,
+                             resources.css().appName(),
+                             searchPattern,
+                             displayStrings.editApp(),
+                             null);
+            }
         } else {
             super.render(sb,
                          value,

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
@@ -131,4 +131,6 @@ public interface AppsMessages extends Messages {
     String hpcTab();
 
     String viewCategoriesHeader();
+
+    String betaToolTip();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
@@ -60,3 +60,4 @@ sharePublic = Make Public...
 workspaceTab = My Apps
 hpcTab = HPC
 viewCategoriesHeader = Categories
+betaToolTip = This app is currently in the Beta phase and has not yet been reviewed by the CyVerse science team.

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCell.css
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCell.css
@@ -30,10 +30,14 @@
 }
 
 .appBeta {
+    color: blue;
+}
+
+.appBetaHyperlink {
     cursor: pointer;
     color: blue;
 }
 
-.appBeta:hover {
+.appBetaHyperlink:hover {
     text-decoration: underline;
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCell.css
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCell.css
@@ -28,3 +28,12 @@
     padding-top: 2px;
     padding-bottom: 2px;
 }
+
+.appBeta {
+    cursor: pointer;
+    color: blue;
+}
+
+.appBeta:hover {
+    text-decoration: underline;
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCellDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCellDefaultAppearance.java
@@ -27,6 +27,8 @@ public class AppNameCellDefaultAppearance implements AppNameCell.AppNameCellAppe
         String appName();
 
         String appDisabled();
+
+        String appBeta();
     }
 
     public interface Resources extends ClientBundle {
@@ -83,6 +85,16 @@ public class AppNameCellDefaultAppearance implements AppNameCell.AppNameCellAppe
     @Override
     public String appUnavailable() {
         return iplantDisplayStrings.appUnavailable();
+    }
+
+    @Override
+    public String appBeta() {
+        return appsMessages.betaToolTip();
+    }
+
+    @Override
+    public String appBetaNameClass() {
+        return resources.css().appBeta();
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCellDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCellDefaultAppearance.java
@@ -29,6 +29,8 @@ public class AppNameCellDefaultAppearance implements AppNameCell.AppNameCellAppe
         String appDisabled();
 
         String appBeta();
+
+        String appBetaHyperlink();
     }
 
     public interface Resources extends ClientBundle {
@@ -94,7 +96,7 @@ public class AppNameCellDefaultAppearance implements AppNameCell.AppNameCellAppe
 
     @Override
     public String appBetaNameClass() {
-        return resources.css().appBeta();
+        return resources.css().appBetaHyperlink();
     }
 
     @Override


### PR DESCRIPTION
This applies to both Belphegor and the DE.  Belphegor just doesn't have the underlined hyperlink app names.