### PR TITLE
DE-1133/CORE-8094: handle spaces in paths in anon-files properly

### DIFF
--- a/services/anon-files/project.clj
+++ b/services/anon-files/project.clj
@@ -22,6 +22,7 @@
                  [org.iplantc/service-logging "5.2.8.0"]
                  [org.iplantc/common-cli "5.2.8.0"]
                  [org.iplantc/common-cfg "5.2.8.0"]
+                 [com.cemerick/url "0.1.1"]
                  [medley "0.6.0"]
                  [compojure "1.3.4"]
                  [ring "1.4.0"]]


### PR DESCRIPTION
We weren't URL decoding... well, anything, in anon-files. So this would probably have also failed with other url-unsafe characters that'll end up in the URI as decoded.

Tested this manually and it does work with the test file listed in the ticket.