### PR TITLE
CORE-8090: Update apps details endpoint to include an app's category hierarchy

### DIFF
--- a/ansible/roles/util-cfg-service/templates/apps.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/apps.properties.j2
@@ -27,6 +27,7 @@ apps.workspace.default-app-categories       = {{ apps.user_subs }}
 apps.workspace.dev-app-category-index       = 0
 apps.workspace.favorites-app-category-index = 1
 apps.workspace.public-id                    = 00000000-0000-0000-0000-000000000000
+apps.workspace.metadata.category.attrs      = rdf:type, http://edamontology.org/has_topic
 apps.workspace.metadata.beta.attr.iri       = n2t.net/ark:/99152/h1459
 apps.workspace.metadata.beta.attr.label     = releaseStatus
 apps.workspace.metadata.beta.value          = beta

--- a/libs/metadata-client/src/metadata_client/core.clj
+++ b/libs/metadata-client/src/metadata_client/core.clj
@@ -54,6 +54,14 @@
   (http/get (metadata-url-encoded "ontologies" ontology-version)
             (get-options {:user username})))
 
+(defn filter-hierarchies
+  [username ontology-version attrs target-type target-id]
+  (->> (http/post (metadata-url-encoded "ontologies" ontology-version "filter")
+                  (post-options (json/encode {:attrs attrs :type target-type :id target-id})
+                                {:user username}
+                                :as :json))
+       :body))
+
 (defn filter-hierarchy
   [username ontology-version root-iri attr target-types target-ids]
   (http/post (metadata-url-encoded "ontologies" ontology-version root-iri "filter")

--- a/services/apps/src/apps/routes/apps.clj
+++ b/services/apps/src/apps/routes/apps.clj
@@ -1,5 +1,6 @@
 (ns apps.routes.apps
-  (:use [common-swagger-api.schema]
+  (:use [common-swagger-api.routes]
+        [common-swagger-api.schema]
         [apps.routes.middleware :only [wrap-metadata-base-url]]
         [apps.routes.params]
         [apps.routes.schemas.app]
@@ -166,8 +167,14 @@
         :path-params [app-id :- AppIdJobViewPathParam]
         :query [params SecuredQueryParams]
         :return AppDetails
+        :middlewares [wrap-metadata-base-url]
         :summary "Get App Details"
-        :description "This service is used by the DE to obtain high-level details about a single App"
+        :description (str
+"This service is used by the DE to obtain high-level details about a single App."
+(get-endpoint-delegate-block
+  "metadata"
+  "POST /ontologies/{ontology-version}/filter")
+"Please see the metadata service documentation for information about the `hierarchies` response field.")
         (ok (coerce! AppDetails
                  (apps/get-app-details current-user app-id))))
 

--- a/services/apps/src/apps/routes/schemas/app.clj
+++ b/services/apps/src/apps/routes/schemas/app.clj
@@ -281,6 +281,10 @@
           :references
           AppReferencesParam
 
+          (optional-key :hierarchies)
+          (describe Any
+            "The ontology hierarchies associated with the App")
+
           :categories
           (describe [AppDetailCategory]
             "The list of Categories associated with the App")

--- a/services/apps/src/apps/service/apps/de/listings.clj
+++ b/services/apps/src/apps/service/apps/de/listings.clj
@@ -388,7 +388,7 @@
 
 (defn- format-app-details
   "Formats information for the get-app-details service."
-  [details tools]
+  [username details tools]
   (let [app-id (:id details)]
     (-> details
       (select-keys [:id :integration_date :edited_date :deleted :disabled :wiki_url
@@ -399,6 +399,11 @@
              :tools                (map remove-nil-vals tools)
              :categories           (get-groups-for-app app-id)
              :suggested_categories (get-suggested-groups-for-app app-id))
+      (merge (metadata-client/filter-hierarchies username
+                                                 (get-active-hierarchy-version)
+                                                 (workspace-metadata-category-attrs)
+                                                 "app"
+                                                 app-id))
       format-wiki-url)))
 
 ;; FIXME: remove the code to bypass the permission checks for admin users when we have a better
@@ -412,7 +417,7 @@
         tools   (get-app-tools app-id)]
     (when (empty? tools)
       (throw  (IllegalArgumentException. (str "no tools associated with app, " app-id))))
-    (->> (format-app-details details tools)
+    (->> (format-app-details username details tools)
          (remove-nil-vals))))
 
 (defn load-app-ids

--- a/services/apps/src/apps/util/config.clj
+++ b/services/apps/src/apps/util/config.clj
@@ -136,6 +136,11 @@
   [props config-valid configs]
   "apps.workspace.public-id")
 
+(cc/defprop-vec workspace-metadata-category-attrs
+  "The attrs used for an app's category metadata AVUs."
+  [props config-valid configs]
+  "apps.workspace.metadata.category.attrs")
+
 (cc/defprop-str uid-domain
   "The domain name to append to the user identifier to get the fully qualified
    user identifier."

--- a/services/metadata/src/metadata/persistence/avu.clj
+++ b/services/metadata/src/metadata/persistence/avu.clj
@@ -38,11 +38,11 @@
   [target-type target-id]
   (select :avus (target-where-clause target-type target-id)))
 
-(defn get-avus-by-attr
+(defn get-avus-by-attrs
   "Finds all existing AVUs by the given targets and the given set of attributes."
-  [target-types target-ids attribute]
+  [target-types target-ids attributes]
   (select :avus
-          (where {:attribute   attribute
+          (where {:attribute   [in attributes]
                   :target_id   [in target-ids]
                   :target_type [in (map db/->enum-val target-types)]})))
 

--- a/services/metadata/src/metadata/routes/ontologies.clj
+++ b/services/metadata/src/metadata/routes/ontologies.clj
@@ -25,6 +25,17 @@
           :description "List Ontology Hierarchies saved for the given `ontology-version`."
           (ok (service/list-hierarchies ontology-version)))
 
+    (POST* "/:ontology-version/filter" []
+           :path-params [ontology-version :- OntologyVersionParam]
+           :query [{:keys [user]} StandardUserQueryParams]
+           :body [{:keys [type id attrs]} TargetHierarchyFilterRequest]
+           :return OntologyHierarchyList
+           :summary "Filter Target's Ontology Hierarchies"
+           :description
+           "Filters Ontology Hierarchies saved for the given `ontology-version`,
+            returning only the hierarchy's leaf-classes that are associated with the given target."
+           (ok (service/filter-target-hierarchies ontology-version attrs type id)))
+
     (POST* "/:ontology-version/:root-iri/filter" []
            :path-params [ontology-version :- OntologyVersionParam
                          root-iri :- OntologyClassIRIParam]

--- a/services/metadata/src/metadata/routes/schemas/ontologies.clj
+++ b/services/metadata/src/metadata/routes/schemas/ontologies.clj
@@ -31,3 +31,8 @@
 
 (s/defschema OntologyHierarchyList
   {:hierarchies (describe [OntologyClassHierarchy] "A list of Ontology Class hierarchies")})
+
+(s/defschema TargetHierarchyFilterRequest
+  (merge TargetItem
+         {:attrs
+          (describe [String] "The metadata attributes that store class IRIs for the given ontology")}))


### PR DESCRIPTION
These changes update the `/apps/:id/details` endpoint to include a `hierarchies` field, populated by a new metadata service `POST /ontologies/{ontology-version}/filter` endpoint, which returns all hierarchies the given target is tagged under.