### PR TITLE
CORE-8091 Switch to tree paths in AppDetails view

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/AppDetailsView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/AppDetailsView.java
@@ -5,15 +5,20 @@ import org.iplantc.de.apps.client.events.selection.AppDetailsDocSelected;
 import org.iplantc.de.apps.client.events.selection.AppFavoriteSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppRatingDeselected;
 import org.iplantc.de.apps.client.events.selection.AppRatingSelected;
+import org.iplantc.de.apps.client.events.selection.DetailsHierarchyClicked;
 import org.iplantc.de.apps.client.events.selection.SaveMarkdownSelected;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppDoc;
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 
 import com.google.gwt.editor.client.Editor;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.gwt.user.client.ui.IsWidget;
+
+import com.sencha.gxt.data.shared.TreeStore;
+import com.sencha.gxt.widget.core.client.tree.TreeStyle;
 
 import java.util.List;
 
@@ -28,7 +33,8 @@ public interface AppDetailsView extends IsWidget,
                                         AppDetailsDocSelected.HasAppDetailsDocSelectedHandlers,
                                         SaveMarkdownSelected.HasSaveMarkdownSelectedHandlers,
                                         AppRatingDeselected.HasAppRatingDeselectedHandlers,
-                                        AppRatingSelected.HasAppRatingSelectedEventHandlers {
+                                        AppRatingSelected.HasAppRatingSelectedEventHandlers,
+                                        DetailsHierarchyClicked.HasDetailsHierarchyClickedHandlers {
 
     interface AppDetailsAppearance {
         interface AppDetailsStyle extends CssResource {
@@ -91,16 +97,19 @@ public interface AppDetailsView extends IsWidget,
         String appUrl();
 
         String copyAppUrl();
+
+        void setTreeIcons(TreeStyle style);
     }
 
     interface Presenter extends AppFavoriteSelectedEvent.HasAppFavoriteSelectedEventHandlers,
                                 AppRatingDeselected.HasAppRatingDeselectedHandlers,
-                                AppRatingSelected.HasAppRatingSelectedEventHandlers {
+                                AppRatingSelected.HasAppRatingSelectedEventHandlers,
+                                DetailsHierarchyClicked.HasDetailsHierarchyClickedHandlers {
 
         void go(HasOneWidget widget,
                 App app,
                 String searchRegexPattern,
-                List<List<String>> appGroupHierarchies);
+                TreeStore<OntologyHierarchy> hierarchyTreeStore);
     }
 
     /**

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/AppDetailsView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/AppDetailsView.java
@@ -5,9 +5,11 @@ import org.iplantc.de.apps.client.events.selection.AppDetailsDocSelected;
 import org.iplantc.de.apps.client.events.selection.AppFavoriteSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppRatingDeselected;
 import org.iplantc.de.apps.client.events.selection.AppRatingSelected;
+import org.iplantc.de.apps.client.events.selection.DetailsCategoryClicked;
 import org.iplantc.de.apps.client.events.selection.DetailsHierarchyClicked;
 import org.iplantc.de.apps.client.events.selection.SaveMarkdownSelected;
 import org.iplantc.de.client.models.apps.App;
+import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.models.apps.AppDoc;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 
@@ -34,7 +36,8 @@ public interface AppDetailsView extends IsWidget,
                                         SaveMarkdownSelected.HasSaveMarkdownSelectedHandlers,
                                         AppRatingDeselected.HasAppRatingDeselectedHandlers,
                                         AppRatingSelected.HasAppRatingSelectedEventHandlers,
-                                        DetailsHierarchyClicked.HasDetailsHierarchyClickedHandlers {
+                                        DetailsHierarchyClicked.HasDetailsHierarchyClickedHandlers,
+                                        DetailsCategoryClicked.HasDetailsCategoryClickedHandlers {
 
     interface AppDetailsAppearance {
         interface AppDetailsStyle extends CssResource {
@@ -104,12 +107,14 @@ public interface AppDetailsView extends IsWidget,
     interface Presenter extends AppFavoriteSelectedEvent.HasAppFavoriteSelectedEventHandlers,
                                 AppRatingDeselected.HasAppRatingDeselectedHandlers,
                                 AppRatingSelected.HasAppRatingSelectedEventHandlers,
-                                DetailsHierarchyClicked.HasDetailsHierarchyClickedHandlers {
+                                DetailsHierarchyClicked.HasDetailsHierarchyClickedHandlers,
+                                DetailsCategoryClicked.HasDetailsCategoryClickedHandlers{
 
         void go(HasOneWidget widget,
                 App app,
                 String searchRegexPattern,
-                TreeStore<OntologyHierarchy> hierarchyTreeStore);
+                TreeStore<OntologyHierarchy> hierarchyTreeStore,
+                TreeStore<AppCategory> categoryTreeStore);
     }
 
     /**

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/DetailsCategoryClicked.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/DetailsCategoryClicked.java
@@ -1,0 +1,41 @@
+package org.iplantc.de.apps.client.events.selection;
+
+
+import org.iplantc.de.client.models.apps.AppCategory;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class DetailsCategoryClicked
+        extends GwtEvent<DetailsCategoryClicked.DetailsCategoryClickedHandler> {
+    public static interface DetailsCategoryClickedHandler extends EventHandler {
+        void onDetailsCategoryClicked(DetailsCategoryClicked event);
+    }
+
+    public interface HasDetailsCategoryClickedHandlers {
+        HandlerRegistration addDetailsCategoryClickedHandler(DetailsCategoryClickedHandler handler);
+    }
+    public static Type<DetailsCategoryClickedHandler> TYPE = new Type<DetailsCategoryClickedHandler>();
+
+    private AppCategory Category;
+
+    public DetailsCategoryClicked(AppCategory Category) {
+        this.Category = Category;
+    }
+
+    public Type<DetailsCategoryClickedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(DetailsCategoryClickedHandler handler) {
+        handler.onDetailsCategoryClicked(this);
+    }
+
+    public AppCategory getCategory() {
+        return Category;
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/DetailsHierarchyClicked.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/DetailsHierarchyClicked.java
@@ -1,0 +1,40 @@
+package org.iplantc.de.apps.client.events.selection;
+
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class DetailsHierarchyClicked
+        extends GwtEvent<DetailsHierarchyClicked.DetailsHierarchyClickedHandler> {
+    public static interface DetailsHierarchyClickedHandler extends EventHandler {
+        void onDetailsHierarchyClicked(DetailsHierarchyClicked event);
+    }
+
+    public interface HasDetailsHierarchyClickedHandlers {
+        HandlerRegistration addDetailsHierarchyClickedHandler(DetailsHierarchyClickedHandler handler);
+    }
+    public static Type<DetailsHierarchyClickedHandler> TYPE = new Type<DetailsHierarchyClickedHandler>();
+
+    private OntologyHierarchy hierarchy;
+
+    public DetailsHierarchyClicked(OntologyHierarchy hierarchy) {
+        this.hierarchy = hierarchy;
+    }
+
+    public Type<DetailsHierarchyClickedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(DetailsHierarchyClickedHandler handler) {
+        handler.onDetailsHierarchyClicked(this);
+    }
+
+    public OntologyHierarchy getHierarchy() {
+        return hierarchy;
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/gin/factory/AppDetailsViewFactory.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/gin/factory/AppDetailsViewFactory.java
@@ -2,8 +2,9 @@ package org.iplantc.de.apps.client.gin.factory;
 
 import org.iplantc.de.apps.client.AppDetailsView;
 import org.iplantc.de.client.models.apps.App;
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 
-import java.util.List;
+import com.sencha.gxt.data.shared.TreeStore;
 
 /**
  * Created by jstroot on 3/4/15.
@@ -12,5 +13,5 @@ import java.util.List;
 public interface AppDetailsViewFactory {
     AppDetailsView create(App app,
                           String searchRegex,
-                          List<List<String>> appGroupHierarchies);
+                          TreeStore<OntologyHierarchy> hierarchyTreeStore);
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/gin/factory/AppDetailsViewFactory.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/gin/factory/AppDetailsViewFactory.java
@@ -2,6 +2,7 @@ package org.iplantc.de.apps.client.gin.factory;
 
 import org.iplantc.de.apps.client.AppDetailsView;
 import org.iplantc.de.client.models.apps.App;
+import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 
 import com.sencha.gxt.data.shared.TreeStore;
@@ -13,5 +14,6 @@ import com.sencha.gxt.data.shared.TreeStore;
 public interface AppDetailsViewFactory {
     AppDetailsView create(App app,
                           String searchRegex,
-                          TreeStore<OntologyHierarchy> hierarchyTreeStore);
+                          TreeStore<OntologyHierarchy> hierarchyTreeStore,
+                          TreeStore<AppCategory> categoryTreeStore);
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/details/AppDetailsViewPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/details/AppDetailsViewPresenterImpl.java
@@ -6,11 +6,13 @@ import org.iplantc.de.apps.client.events.selection.AppDetailsDocSelected;
 import org.iplantc.de.apps.client.events.selection.AppFavoriteSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppRatingDeselected;
 import org.iplantc.de.apps.client.events.selection.AppRatingSelected;
+import org.iplantc.de.apps.client.events.selection.DetailsHierarchyClicked;
 import org.iplantc.de.apps.client.events.selection.SaveMarkdownSelected;
 import org.iplantc.de.apps.client.gin.factory.AppDetailsViewFactory;
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppDoc;
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 import org.iplantc.de.client.services.AppUserServiceFacade;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
@@ -25,7 +27,7 @@ import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
-import java.util.List;
+import com.sencha.gxt.data.shared.TreeStore;
 
 /**
  * @author jstroot
@@ -72,13 +74,21 @@ public class AppDetailsViewPresenterImpl implements AppDetailsView.Presenter,
     }
 
     @Override
+    public HandlerRegistration addDetailsHierarchyClickedHandler(DetailsHierarchyClicked.DetailsHierarchyClickedHandler handler) {
+        if(view == null){
+            throw new IllegalStateException("You must call 'go(..)' before calling this method");
+        }
+        return view.addDetailsHierarchyClickedHandler(handler);
+    }
+
+    @Override
     public void go(final HasOneWidget widget,
                    final App app,
                    final String searchRegexPattern,
-                   final List<List<String>> appGroupHierarchies) {
+                   TreeStore<OntologyHierarchy> hierarchyTreeStore) {
         Preconditions.checkState(view == null, "Cannot call go(..) more than once");
 
-        view = viewFactoryProvider.get().create(app, searchRegexPattern, appGroupHierarchies);
+        view = viewFactoryProvider.get().create(app, searchRegexPattern, hierarchyTreeStore);
         view.addAppDetailsDocSelectedHandler(AppDetailsViewPresenterImpl.this);
         view.addSaveMarkdownSelectedHandler(AppDetailsViewPresenterImpl.this);
         widget.setWidget(view);

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/details/AppDetailsViewPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/details/AppDetailsViewPresenterImpl.java
@@ -6,11 +6,13 @@ import org.iplantc.de.apps.client.events.selection.AppDetailsDocSelected;
 import org.iplantc.de.apps.client.events.selection.AppFavoriteSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppRatingDeselected;
 import org.iplantc.de.apps.client.events.selection.AppRatingSelected;
+import org.iplantc.de.apps.client.events.selection.DetailsCategoryClicked;
 import org.iplantc.de.apps.client.events.selection.DetailsHierarchyClicked;
 import org.iplantc.de.apps.client.events.selection.SaveMarkdownSelected;
 import org.iplantc.de.apps.client.gin.factory.AppDetailsViewFactory;
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.apps.App;
+import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.models.apps.AppDoc;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 import org.iplantc.de.client.services.AppUserServiceFacade;
@@ -82,13 +84,22 @@ public class AppDetailsViewPresenterImpl implements AppDetailsView.Presenter,
     }
 
     @Override
+    public HandlerRegistration addDetailsCategoryClickedHandler(DetailsCategoryClicked.DetailsCategoryClickedHandler handler) {
+        if(view == null){
+            throw new IllegalStateException("You must call 'go(..)' before calling this method");
+        }
+        return view.addDetailsCategoryClickedHandler(handler);
+    }
+
+    @Override
     public void go(final HasOneWidget widget,
                    final App app,
                    final String searchRegexPattern,
-                   TreeStore<OntologyHierarchy> hierarchyTreeStore) {
+                   TreeStore<OntologyHierarchy> hierarchyTreeStore,
+                   TreeStore<AppCategory> categoryTreeStore) {
         Preconditions.checkState(view == null, "Cannot call go(..) more than once");
 
-        view = viewFactoryProvider.get().create(app, searchRegexPattern, hierarchyTreeStore);
+        view = viewFactoryProvider.get().create(app, searchRegexPattern, hierarchyTreeStore, categoryTreeStore);
         view.addAppDetailsDocSelectedHandler(AppDetailsViewPresenterImpl.this);
         view.addSaveMarkdownSelectedHandler(AppDetailsViewPresenterImpl.this);
         widget.setWidget(view);

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
@@ -1,5 +1,7 @@
 package org.iplantc.de.apps.client.presenter.hierarchies;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.iplantc.de.apps.client.OntologyHierarchiesView;
 import org.iplantc.de.apps.client.events.AppFavoritedEvent;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
@@ -310,17 +312,17 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
     @Override
     public void onDetailsHierarchyClicked(DetailsHierarchyClicked event) {
         OntologyHierarchy hierarchy = event.getHierarchy();
-        if (hierarchy != null) {
-            String id = ontologyUtil.getOrCreateHierarchyPathTag(hierarchy);
-            for (int i = 0 ; i < viewTabPanel.getWidgetCount() ; i++) {
-                Tree<OntologyHierarchy, String> tree = ((Tree)viewTabPanel.getWidget(i));
-                OntologyHierarchy selectedHierarchy = tree.getStore().findModelWithKey(id);
-                if (selectedHierarchy != null) {
-                    viewTabPanel.setActiveWidget(tree);
-                    tree.scrollIntoView(selectedHierarchy);
-                    tree.getSelectionModel().select(selectedHierarchy, true);
-                    break;
-                }
+        checkNotNull(hierarchy);
+
+        String id = ontologyUtil.getOrCreateHierarchyPathTag(hierarchy);
+        for (int i = 0; i < viewTabPanel.getWidgetCount(); i++) {
+            Tree<OntologyHierarchy, String> tree = ((Tree)viewTabPanel.getWidget(i));
+            OntologyHierarchy selectedHierarchy = tree.getStore().findModelWithKey(id);
+            if (selectedHierarchy != null) {
+                viewTabPanel.setActiveWidget(tree);
+                tree.scrollIntoView(selectedHierarchy);
+                tree.getSelectionModel().select(selectedHierarchy, true);
+                break;
             }
         }
     }
@@ -328,16 +330,16 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
     @Override
     public void onDetailsCategoryClicked(DetailsCategoryClicked event) {
         AppCategory category = event.getCategory();
-        if (category != null) {
-            for (int i = 0 ; i < viewTabPanel.getWidgetCount() ; i++) {
-                Tree<AppCategory, String> tree = ((Tree)viewTabPanel.getWidget(i));
-                AppCategory selectedCategory = tree.getStore().findModelWithKey(category.getId());
-                if (selectedCategory != null) {
-                    viewTabPanel.setActiveWidget(tree);
-                    tree.scrollIntoView(selectedCategory);
-                    tree.getSelectionModel().select(selectedCategory, true);
-                    break;
-                }
+        checkNotNull(category);
+
+        for (int i = 0 ; i < viewTabPanel.getWidgetCount() ; i++) {
+            Tree<AppCategory, String> tree = ((Tree)viewTabPanel.getWidget(i));
+            AppCategory selectedCategory = tree.getStore().findModelWithKey(category.getId());
+            if (selectedCategory != null) {
+                viewTabPanel.setActiveWidget(tree);
+                tree.scrollIntoView(selectedCategory);
+                tree.getSelectionModel().select(selectedCategory, true);
+                break;
             }
         }
     }

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/AppDetailsViewImpl.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/AppDetailsViewImpl.ui.xml
@@ -17,7 +17,9 @@
 		type="com.sencha.gxt.widget.core.client.TabItemConfig">
 		<ui:attributes text="{appearance.toolInformationTabLabel}" />
 	</ui:with>
-	<ui:with field="treeStore"
+	<ui:with field="hierarchyTreeStore"
+			 type="com.sencha.gxt.data.shared.TreeStore"/>
+	<ui:with field="categoryTreeStore"
 			 type="com.sencha.gxt.data.shared.TreeStore"/>
 
 	<tabs:TabPanel ui:field="tabPanel" bodyBorder="false"
@@ -99,7 +101,8 @@
 							<ui:text from="{appearance.categoriesLabel}" />
 						</td>
 						<td>
-							<tree:Tree ui:field="categories" store="{treeStore}"/>
+							<tree:Tree ui:field="categoryTree" store="{categoryTreeStore}"/>
+							<tree:Tree ui:field="hierarchyTree" store="{hierarchyTreeStore}"/>
 						</td>
 					</tr>
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/AppDetailsViewImpl.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/AppDetailsViewImpl.ui.xml
@@ -1,8 +1,10 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-	xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
-	xmlns:tabs="urn:import:com.sencha.gxt.widget.core.client"
-	xmlns:appWidgets="urn:import:org.iplantc.de.apps.client.views.grid.cells">
+			 xmlns:g="urn:import:com.google.gwt.user.client.ui"
+			 xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
+			 xmlns:tabs="urn:import:com.sencha.gxt.widget.core.client"
+			 xmlns:tree="urn:import:com.sencha.gxt.widget.core.client.tree"
+			 xmlns:appWidgets="urn:import:org.iplantc.de.apps.client.views.grid.cells">
 
 	<ui:with field="appearance"
 		type="org.iplantc.de.apps.client.AppDetailsView.AppDetailsAppearance" />
@@ -15,6 +17,8 @@
 		type="com.sencha.gxt.widget.core.client.TabItemConfig">
 		<ui:attributes text="{appearance.toolInformationTabLabel}" />
 	</ui:with>
+	<ui:with field="treeStore"
+			 type="com.sencha.gxt.data.shared.TreeStore"/>
 
 	<tabs:TabPanel ui:field="tabPanel" bodyBorder="false"
 		borders="false" styleName="{appearance.css.tabPanel}">
@@ -84,18 +88,18 @@
 					</tr>
 					<tr>
 						<td class="{appearance.css.label}">
-							<ui:text from="{appearance.categoriesLabel}" />
+							<ui:text from="{appearance.url}" />
 						</td>
-						<td>
-							<div ui:field="categories" />
+						<td class="{appearance.css.value}">
+							<g:Anchor ui:field="url" styleName="{appearance.css.hyperlink}"/>
 						</td>
 					</tr>
 					<tr>
-					<td class="{appearance.css.label}">
-                                <ui:text from="{appearance.url}" />
-                        </td>
-						<td class="{appearance.css.value}">
-							<g:Anchor ui:field="url" styleName="{appearance.css.hyperlink}"/>
+						<td class="{appearance.css.label}">
+							<ui:text from="{appearance.categoriesLabel}" />
+						</td>
+						<td>
+							<tree:Tree ui:field="categories" store="{treeStore}"/>
 						</td>
 					</tr>
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/dialogs/AppDetailsDialog.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/dialogs/AppDetailsDialog.java
@@ -4,7 +4,9 @@ import org.iplantc.de.apps.client.AppDetailsView;
 import org.iplantc.de.apps.client.events.selection.AppFavoriteSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppRatingDeselected;
 import org.iplantc.de.apps.client.events.selection.AppRatingSelected;
+import org.iplantc.de.apps.client.events.selection.DetailsHierarchyClicked;
 import org.iplantc.de.client.models.apps.App;
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 import org.iplantc.de.shared.AsyncProviderWrapper;
@@ -12,7 +14,7 @@ import org.iplantc.de.shared.AsyncProviderWrapper;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
-import java.util.List;
+import com.sencha.gxt.data.shared.TreeStore;
 
 /**
  * @author jstroot
@@ -31,10 +33,12 @@ public class AppDetailsDialog extends IPlantDialog {
 
     public void show(final App app,
                      final String searchRegexPattern,
-                     final List<List<String>> appGroupHierarchies,
+                     final TreeStore<OntologyHierarchy> hierarchyTreeStore,
                      final AppFavoriteSelectedEvent.AppFavoriteSelectedEventHandler favoriteSelectedHandler,
                      final AppRatingSelected.AppRatingSelectedHandler ratingSelectedHandler,
-                     final AppRatingDeselected.AppRatingDeselectedHandler ratingDeselectedHandler) {
+                     final AppRatingDeselected.AppRatingDeselectedHandler ratingDeselectedHandler,
+                     final DetailsHierarchyClicked.DetailsHierarchyClickedHandler hierarchySelectionHandler) {
+
         setHeadingText(app.getName());
         presenterProvider.get(new AsyncCallback<AppDetailsView.Presenter>() {
             @Override
@@ -44,7 +48,7 @@ public class AppDetailsDialog extends IPlantDialog {
 
             @Override
             public void onSuccess(final AppDetailsView.Presenter result) {
-                result.go(AppDetailsDialog.this, app, searchRegexPattern, appGroupHierarchies);
+                result.go(AppDetailsDialog.this, app, searchRegexPattern, hierarchyTreeStore);
                 if(favoriteSelectedHandler != null){
                     result.addAppFavoriteSelectedEventHandlers(favoriteSelectedHandler);
                 }
@@ -53,6 +57,9 @@ public class AppDetailsDialog extends IPlantDialog {
                 }
                 if(ratingDeselectedHandler != null){
                     result.addAppRatingDeselectedHandler(ratingDeselectedHandler);
+                }
+                if (hierarchySelectionHandler != null) {
+                    result.addDetailsHierarchyClickedHandler(hierarchySelectionHandler);
                 }
             }
         });

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/dialogs/AppDetailsDialog.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/dialogs/AppDetailsDialog.java
@@ -4,8 +4,10 @@ import org.iplantc.de.apps.client.AppDetailsView;
 import org.iplantc.de.apps.client.events.selection.AppFavoriteSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppRatingDeselected;
 import org.iplantc.de.apps.client.events.selection.AppRatingSelected;
+import org.iplantc.de.apps.client.events.selection.DetailsCategoryClicked;
 import org.iplantc.de.apps.client.events.selection.DetailsHierarchyClicked;
 import org.iplantc.de.client.models.apps.App;
+import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
@@ -34,10 +36,12 @@ public class AppDetailsDialog extends IPlantDialog {
     public void show(final App app,
                      final String searchRegexPattern,
                      final TreeStore<OntologyHierarchy> hierarchyTreeStore,
+                     final TreeStore<AppCategory> categoryTreeStore,
                      final AppFavoriteSelectedEvent.AppFavoriteSelectedEventHandler favoriteSelectedHandler,
                      final AppRatingSelected.AppRatingSelectedHandler ratingSelectedHandler,
                      final AppRatingDeselected.AppRatingDeselectedHandler ratingDeselectedHandler,
-                     final DetailsHierarchyClicked.DetailsHierarchyClickedHandler hierarchySelectionHandler) {
+                     final DetailsHierarchyClicked.DetailsHierarchyClickedHandler hierarchySelectionHandler,
+                     final DetailsCategoryClicked.DetailsCategoryClickedHandler categoryClickedHandler) {
 
         setHeadingText(app.getName());
         presenterProvider.get(new AsyncCallback<AppDetailsView.Presenter>() {
@@ -48,7 +52,7 @@ public class AppDetailsDialog extends IPlantDialog {
 
             @Override
             public void onSuccess(final AppDetailsView.Presenter result) {
-                result.go(AppDetailsDialog.this, app, searchRegexPattern, hierarchyTreeStore);
+                result.go(AppDetailsDialog.this, app, searchRegexPattern, hierarchyTreeStore, categoryTreeStore);
                 if(favoriteSelectedHandler != null){
                     result.addAppFavoriteSelectedEventHandlers(favoriteSelectedHandler);
                 }
@@ -60,6 +64,9 @@ public class AppDetailsDialog extends IPlantDialog {
                 }
                 if (hierarchySelectionHandler != null) {
                     result.addDetailsHierarchyClickedHandler(hierarchySelectionHandler);
+                }
+                if (categoryClickedHandler != null) {
+                    result.addDetailsCategoryClickedHandler(categoryClickedHandler);
                 }
             }
         });

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/App.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/models/apps/App.java
@@ -3,6 +3,7 @@ package org.iplantc.de.client.models.apps;
 import org.iplantc.de.client.models.HasDescription;
 import org.iplantc.de.client.models.HasId;
 import org.iplantc.de.client.models.diskResources.PermissionValue;
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 import org.iplantc.de.client.models.tool.Tool;
 
 import com.google.gwt.user.client.ui.HasName;
@@ -142,4 +143,8 @@ public interface App extends HasId,
     PermissionValue getPermission();
 
     Boolean isBeta();
+
+    List<OntologyHierarchy> getHierarchies();
+
+    void setHierarchies(List<OntologyHierarchy> hierarchies);
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/util/OntologyUtil.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/util/OntologyUtil.java
@@ -66,11 +66,12 @@ public class OntologyUtil {
         }
     }
 
-    public void addUnclassifiedChild(OntologyHierarchy child) {
+    public OntologyHierarchy addUnclassifiedChild(OntologyHierarchy child) {
         OntologyHierarchy unclassified = factory.getHierarchy().as();
         unclassified.setLabel(UNCLASSIFIED_LABEL);
         unclassified.setIri(child.getIri() + UNCLASSIFIED_IRI_APPEND);
         child.getSubclasses().add(unclassified);
+        return unclassified;
     }
 
     public boolean isUnclassified(OntologyHierarchy hierarchy) {
@@ -199,5 +200,4 @@ public class OntologyUtil {
     AutoBean<OntologyHierarchy> getHierarchyAutoBean(OntologyHierarchy hierarchy) {
         return AutoBeanUtils.getAutoBean(hierarchy);
     }
-
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/details/AppDetailsDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/details/AppDetailsDefaultAppearance.java
@@ -4,13 +4,15 @@ import org.iplantc.de.apps.client.AppDetailsView;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 import org.iplantc.de.theme.base.client.apps.AppSearchHighlightAppearance;
 import org.iplantc.de.theme.base.client.apps.AppsMessages;
+import org.iplantc.de.theme.base.client.apps.categories.AppCategoriesViewDefaultAppearance;
 
 import com.google.common.base.Joiner;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+
+import com.sencha.gxt.widget.core.client.tree.TreeStyle;
 
 import java.util.List;
 
@@ -19,7 +21,7 @@ import java.util.List;
  */
 public class AppDetailsDefaultAppearance implements AppDetailsView.AppDetailsAppearance {
 
-    public interface AppDetailsAppearanceResources extends ClientBundle {
+    public interface AppDetailsAppearanceResources extends AppCategoriesViewDefaultAppearance.AppCategoryViewResources {
         @Source("AppDetailsStyle.css")
         AppDetailsStyle css();
     }
@@ -167,5 +169,12 @@ public class AppDetailsDefaultAppearance implements AppDetailsView.AppDetailsApp
     @Override
     public String copyAppUrl() {
         return appsMessages.copyAppUrl();
+    }
+
+    @Override
+    public void setTreeIcons(TreeStyle style) {
+        style.setNodeCloseIcon(resources.category());
+        style.setNodeOpenIcon(resources.categoryOpen());
+        style.setLeafIcon(resources.subCategory());
     }
 }


### PR DESCRIPTION
Since we're moving to hierarchies in 2.8, the app details window has become cluttered with the list of all the paths where an app can be found.  Instead of having a textual path in the app details window, we will have a slimmed down tree to show only the hierarchies where the app resides.

If the app is an HPC app, the details window will show a tree that only has the HPC category.
If the app has not been tagged with any hierarchies, only the Unclassified hierarchies will be listed.

Additionally, clicking on any node in the tree will open up that hierarchy in the Apps window automatically.
