### PR TITLE
CORE-7927 Disable actions in App Catalog for external apps

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -203,6 +203,8 @@ public interface OntologiesView extends IsWidget,
         String confirmDeleteAppWarning(String name);
 
         String confirmDeleteAppTitle();
+
+        String externalAppDND(String appLabels);
     }
 
     interface Presenter {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/AppToOntologyHierarchyDND.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/AppToOntologyHierarchyDND.java
@@ -143,6 +143,20 @@ public class AppToOntologyHierarchyDND implements DndDragStartEvent.DndDragStart
             return false;
         }
 
+        // Verify no external apps are selected
+        List<App> agaveApps = Lists.newArrayList();
+        for (App app : apps) {
+            if (app.getAppType().equalsIgnoreCase(App.EXTERNAL_APP)) {
+                agaveApps.add(app);
+            }
+        }
+
+        if (agaveApps.size() > 0) {
+            status.setStatus(false);
+            status.update(appearance.externalAppDND(getAppLabels(agaveApps)));
+            return false;
+        }
+
         String appList = getAppLabels(apps);
 
         // Verify we have a drop target.

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -301,8 +301,8 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
         saveHierarchy.setEnabled(selectedOntology != null);
         deleteButton.setEnabled(selectedOntology != null && selectedOntology != activeOntology);
         deleteHierarchy.setEnabled(selectedOntology != null && tree.getSelectionModel().getSelectedItem() != null);
-        categorize.setEnabled(selectedOntology != null && targetApp != null);
-        deleteApp.setEnabled(selectedOntology != null && targetApp != null);
+        categorize.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
+        deleteApp.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologyHierarchyToAppDND.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologyHierarchyToAppDND.java
@@ -130,7 +130,14 @@ public class OntologyHierarchyToAppDND implements DndDragStartEvent.DndDragStart
         // Verify we have a drop target.
         if (targetApp == null) {
             status.setStatus(false);
-            status.update(hierarchy.getLabel());
+            status.update("");
+            return false;
+        }
+
+        // Verify the target is not an external app
+        if (targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP)) {
+            status.setStatus(false);
+            status.update(appearance.externalAppDND(targetApp.getName()));
             return false;
         }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
@@ -385,4 +385,9 @@ public class OntologiesViewDefaultAppearance implements OntologiesView.Ontologie
     public String confirmDeleteAppTitle() {
         return displayStrings.confirmDeleteAppTitle();
     }
+
+    @Override
+    public String externalAppDND(String appLabels) {
+        return displayStrings.externalAppDND(appLabels);
+    }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
@@ -80,4 +80,6 @@ public interface OntologyDisplayStrings extends Messages{
     String confirmDeleteAppTitle();
 
     String confirmDeleteAppWarning(String name);
+
+    String externalAppDND(String appLabels);
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
@@ -34,3 +34,4 @@ hierarchyColumnLabel = Root(s)
 confirmDeleteHierarchy = Are you sure you want to delete the `{0}` hierarchy?<BR><BR>NOTE: You can always add it back by re-saving any root hierarchy to which it is a child.
 confirmDeleteAppTitle = Delete App
 confirmDeleteAppWarning = Are you sure you want to delete the app `{0}`?
+externalAppDND = External app(s): {0}


### PR DESCRIPTION
Once Agave apps are tagged with EDAM ontology terms, agave apps will get listed in the admin App Catalog tab mixed in with DE apps.  This PR makes sure that app categorization is disabled for the admins on any of those external apps.