### PR TITLE
CORE-8084 Add duplicate app name validation for ontology hierarchies

### DIFF
--- a/libs/metadata-client/src/metadata_client/core.clj
+++ b/libs/metadata-client/src/metadata_client/core.clj
@@ -68,13 +68,13 @@
              (post-options (json/encode {:target-types target-types :target-ids target-ids})
                            {:user username :attr attr})))
 
-(defn filter-by-attr-value
-  [username attr value target-types target-ids]
+(defn filter-by-avus
+  [username target-types target-ids avus]
   (->> (http/post (metadata-url-encoded "avus" "filter-targets")
-                  (post-options (json/encode {:target-types target-types :target-ids target-ids})
-                                {:user  username
-                                 :attr  attr
-                                 :value value}
+                  (post-options (json/encode {:target-types target-types
+                                              :target-ids   target-ids
+                                              :avus         avus})
+                                {:user username}
                                 :as :json))
        :body
        :target-ids

--- a/services/apps/src/apps/metadata/avus.clj
+++ b/services/apps/src/apps/metadata/avus.clj
@@ -1,6 +1,9 @@
 (ns apps.metadata.avus
   (:require [apps.persistence.app-metadata :as app-db]
+            [apps.service.apps.de.categorization :as categorization]
             [apps.service.apps.de.validation :as validation]
+            [apps.util.service :as service]
+            [cheshire.core :as json]
             [metadata-client.core :as metadata-client]))
 
 (defn list-avus
@@ -11,12 +14,16 @@
 
 (defn set-avus
   [{username :shortUsername :as user} app-id body admin?]
-  (let [app (app-db/get-app app-id)]
+  (let [{app-name :name :as app} (app-db/get-app app-id)
+        request (service/parse-json body)]
     (validation/verify-app-permission user app "write" admin?)
-    (metadata-client/set-avus username "app" app-id body)))
+    (categorization/validate-app-name-in-hierarchy-avus username app-id app-name (:avus request))
+    (metadata-client/set-avus username "app" app-id (json/encode request))))
 
 (defn update-avus
   [{username :shortUsername :as user} app-id body admin?]
-  (let [app (app-db/get-app app-id)]
+  (let [{app-name :name :as app} (app-db/get-app app-id)
+        request (service/parse-json body)]
     (validation/verify-app-permission user app "write" admin?)
-    (metadata-client/update-avus username "app" app-id body)))
+    (categorization/validate-app-name-in-hierarchy-avus username app-id app-name (:avus request))
+    (metadata-client/update-avus username "app" app-id (json/encode request))))

--- a/services/apps/src/apps/persistence/app_metadata.clj
+++ b/services/apps/src/apps/persistence/app_metadata.clj
@@ -851,6 +851,14 @@
                        {:aca.app_id (uuidify app-id)
                         :l.id       [not= (user-favorite-subselect :w.root_category_id faves-idx)]})))))
 
+(defn list-duplicate-apps-by-id
+  [app-name app-id-set]
+  (select :apps
+          (fields :id :name :description)
+          (where {(normalize-string :name) (normalize-string app-name)
+                  :deleted                 false
+                  :id                      [in app-id-set]})))
+
 (defn- list-duplicate-apps*
   [app-name app-id category-id-set]
   (select [:apps :a]

--- a/services/apps/src/apps/routes/apps.clj
+++ b/services/apps/src/apps/routes/apps.clj
@@ -126,6 +126,7 @@
           :query [params SecuredQueryParamsEmailRequired]
           :body [body (describe App "The App to update.")]
           :return App
+          :middlewares [wrap-metadata-base-url]
           :summary "Update App Labels"
           :description "This service is capable of updating just the labels within a single-step app, and
           it allows apps that have already been made available for public use to be updated, which
@@ -142,6 +143,7 @@
         :query [params SecuredQueryParamsEmailRequired]
         :body [body (describe AppRequest "The App to update.")]
         :return App
+        :middlewares [wrap-metadata-base-url]
         :summary "Update an App"
         :description "This service updates a single-step App in the database, as long as the App has not
         been submitted for public use."

--- a/services/apps/src/apps/service/apps/de.clj
+++ b/services/apps/src/apps/service/apps/de.clj
@@ -1,7 +1,6 @@
 (ns apps.service.apps.de
   (:use [kameleon.uuids :only [uuidify]])
   (:require [clojure.string :as string]
-            [clojure.tools.logging :as log]
             [apps.clients.jex :as jex]
             [apps.persistence.app-metadata :as ap]
             [apps.persistence.jobs :as jp]
@@ -202,7 +201,7 @@
     (app-admin/delete-app app-id))
 
   (adminUpdateApp [_ body]
-    (app-admin/update-app body))
+    (app-admin/update-app user body))
 
   (getAdminAppCategories [_ params]
     (listings/get-admin-app-groups user params))

--- a/services/apps/src/apps/service/apps/de/admin.clj
+++ b/services/apps/src/apps/service/apps/de/admin.clj
@@ -8,6 +8,7 @@
             [kameleon.app-groups :as app-groups]
             [apps.persistence.app-metadata :as persistence]
             [apps.persistence.categories :as db-categories]
+            [apps.service.apps.de.categorization :as categorization]
             [apps.service.apps.de.validation :as av]
             [clojure-commons.exception-util :as ex-util]
             [metadata-client.core :as metadata-client]))
@@ -89,10 +90,11 @@
 (defn update-app
   "This service updates high-level details and labels in an App, and can mark or unmark the app as
    deleted or disabled in the database."
-  [{app-name :name app-id :id :as app}]
+  [{username :shortUsername} {app-name :name app-id :id :as app}]
   (transaction
    (validate-app-existence app-id)
    (when-not (nil? app-name)
+     (categorization/validate-app-name-in-current-hierarchy username app-id app-name)
      (av/validate-app-name app-name app-id))
    (if (empty? (select-keys app [:name :description :wiki_url :references :groups]))
      (update-app-deleted-disabled app)

--- a/services/apps/src/apps/service/apps/de/edit.clj
+++ b/services/apps/src/apps/service/apps/de/edit.clj
@@ -16,7 +16,8 @@
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.set :as set]
             [apps.clients.permissions :as permissions]
-            [apps.persistence.app-metadata :as persistence]))
+            [apps.persistence.app-metadata :as persistence]
+            [apps.service.apps.de.categorization :as categorization]))
 
 (def ^:private copy-prefix "Copy of ")
 (def ^:private max-app-name-len 255)
@@ -350,6 +351,7 @@
   [user {app-id :id app-name :name :keys [references groups] :as app}]
   (verify-app-editable user (persistence/get-app app-id))
   (transaction
+    (categorization/validate-app-name-in-current-hierarchy (:shortUsername user) app-id app-name)
     (validate-app-name app-name app-id)
     (persistence/update-app app)
     (let [tool-id (->> app :tools first :id)
@@ -466,6 +468,7 @@
     (when-not (user-owns-app? user app)
       (verify-app-permission user app "write")))
   (transaction
+   (categorization/validate-app-name-in-current-hierarchy (:shortUsername user) app-id app-name)
    (validate-app-name app-name app-id)
    (persistence/update-app-labels body))
   (get-app-ui user app-id))

--- a/services/apps/src/apps/service/apps/de/listings.clj
+++ b/services/apps/src/apps/service/apps/de/listings.clj
@@ -267,11 +267,9 @@
 (defn- app-ids->beta-ids-set
   "Filters the given list of app-ids into a set containing the ids of apps marked as `beta`"
   [username app-ids]
-  (set (metadata-client/filter-by-attr-value username
-                                             (workspace-metadata-beta-attr-iri)
-                                             (workspace-metadata-beta-value)
-                                             ["app"]
-                                             app-ids)))
+  (let [beta-avu {:attr (workspace-metadata-beta-attr-iri)
+                  :value (workspace-metadata-beta-value)}]
+    (set (metadata-client/filter-by-avus username ["app"] app-ids [beta-avu]))))
 
 (defn- apps-listing-with-metadata-filter
   [{:keys [username shortUsername]} params metadata-filter]

--- a/services/apps/src/apps/service/apps/de/listings.clj
+++ b/services/apps/src/apps/service/apps/de/listings.clj
@@ -14,7 +14,7 @@
         [apps.workspace])
   (:require [apps.clients.permissions :as perms-client]
             [apps.persistence.app-metadata :refer [get-app get-app-tools] :as amp]
-            [apps.persistence.categories :as db-categories]
+            [apps.service.apps.de.categorization :as categorization]
             [apps.service.apps.de.permissions :as perms]
             [cemerick.url :as curl]
             [metadata-client.core :as metadata-client]))
@@ -40,17 +40,9 @@
   ([params short-username]
    (augment-listing-params params short-username (perms-client/load-app-permissions short-username))))
 
-(defn- get-active-hierarchy-version
-  []
-  (let [version (db-categories/get-active-hierarchy-version)]
-    (when-not version
-      (throw+ {:type  :clojure-commons.exception/not-found
-               :error "An app hierarchy version has not been set."}))
-    version))
-
 (defn list-hierarchies
   [{:keys [username]}]
-  (metadata-client/list-hierarchies username (get-active-hierarchy-version)))
+  (metadata-client/list-hierarchies username (categorization/get-active-hierarchy-version)))
 
 (defn- fix-sort-params
   [params]
@@ -178,7 +170,7 @@
 
 (defn get-app-hierarchy
   ([user root-iri attr]
-   (get-app-hierarchy user (get-active-hierarchy-version) root-iri attr))
+   (get-app-hierarchy user (categorization/get-active-hierarchy-version) root-iri attr))
   ([{:keys [username shortUsername]} ontology-version root-iri attr]
    (let [app-ids (get-visible-app-ids shortUsername)]
      (metadata-client/filter-hierarchy username ontology-version root-iri attr ["app"] app-ids))))
@@ -286,14 +278,14 @@
 
 (defn list-apps-under-hierarchy
   ([user root-iri attr params]
-   (list-apps-under-hierarchy user (get-active-hierarchy-version) root-iri attr params))
+   (list-apps-under-hierarchy user (categorization/get-active-hierarchy-version) root-iri attr params))
   ([{:keys [username] :as user} ontology-version root-iri attr params]
    (let [metadata-filter (partial metadata-client/filter-hierarchy-targets username ontology-version root-iri attr ["app"])]
      (apps-listing-with-metadata-filter user params metadata-filter))))
 
 (defn get-unclassified-app-listing
   ([user root-iri attr params]
-   (get-unclassified-app-listing user (get-active-hierarchy-version) root-iri attr params))
+   (get-unclassified-app-listing user (categorization/get-active-hierarchy-version) root-iri attr params))
   ([{:keys [username] :as user} ontology-version root-iri attr params]
    (let [metadata-filter (partial metadata-client/filter-unclassified username ontology-version root-iri attr ["app"])]
      (apps-listing-with-metadata-filter user params metadata-filter))))
@@ -400,7 +392,7 @@
              :categories           (get-groups-for-app app-id)
              :suggested_categories (get-suggested-groups-for-app app-id))
       (merge (metadata-client/filter-hierarchies username
-                                                 (get-active-hierarchy-version)
+                                                 (categorization/get-active-hierarchy-version)
                                                  (workspace-metadata-category-attrs)
                                                  "app"
                                                  app-id))

--- a/services/apps/src/apps/service/apps/de/validation.clj
+++ b/services/apps/src/apps/service/apps/de/validation.clj
@@ -5,7 +5,7 @@
         [kameleon.core]
         [kameleon.entities]
         [kameleon.queries :only [parameter-types-for-tool-type]]
-        [apps.persistence.app-metadata :only [get-app list-duplicate-apps]])
+        [apps.persistence.app-metadata :only [get-app list-duplicate-apps list-duplicate-apps-by-id]])
   (:require [apps.clients.permissions :as perms-client]
             [apps.service.apps.de.permissions :as perms]
             [clojure.string :as string]))
@@ -152,8 +152,7 @@
   "An app with the same name already exists in one of the same categories.")
 
 (defn validate-app-name
-  "Verifies that an app with the same name doesn't already exist in any of the same app categories. The beta
-   category is treated as an exception because it's intended to be a staging area for new apps."
+  "Verifies that an app with the same name doesn't already exist in any of the same app categories."
   ([app-name app-id]
      (validate-app-name app-name app-id nil))
   ([app-name app-id category-ids]
@@ -166,3 +165,9 @@
        (if (seq category-ids)
          (exists duplicate-app-selected-categories-msg :app_name app-name :category_ids category-ids :path path)
          (exists duplicate-app-existing-categories-msg :app_name app-name :app_id app-id :path path)))))
+
+(defn validate-app-name-in-hierarchy
+  [app-name app-ids]
+  (let [duplicate-apps (list-duplicate-apps-by-id app-name app-ids)]
+    (when-not (empty? duplicate-apps)
+      (exists duplicate-app-existing-categories-msg :app_name app-name :apps duplicate-apps))))

--- a/services/metadata/src/metadata/routes/avus.clj
+++ b/services/metadata/src/metadata/routes/avus.clj
@@ -10,14 +10,14 @@
     :tags ["avus"]
 
     (POST* "/filter-targets" []
-           :query [{:keys [attr value user]} FilterByAvuParams]
-           :body [{:keys [target-types target-ids]} TargetFilterRequest]
+           :query [{:keys [user]} StandardUserQueryParams]
+           :body [{:keys [target-types target-ids avus]} FilterByAvusRequest]
            :return TargetIDList
            :summary "Filter Targets by AVU"
            :description
            "Filters the given target IDs by returning a list of any that have metadata with the given
-            `attr` and `value`."
-           (ok (avus/filter-targets-by-attr-value attr value target-types target-ids)))
+            `attrs` and `values`."
+           (ok (avus/filter-targets-by-avus target-types target-ids avus)))
 
     (GET* "/:target-type/:target-id" []
           :path-params [target-id :- TargetIdPathParam

--- a/services/metadata/src/metadata/routes/schemas/avus.clj
+++ b/services/metadata/src/metadata/routes/schemas/avus.clj
@@ -10,11 +10,6 @@
 (def AvuIdPathParam (describe UUID "The AVU's UUID"))
 (def AvuIdParam AvuIdPathParam)
 
-(s/defschema FilterByAvuParams
-  (merge StandardUserQueryParams
-         {:attr  (describe NonBlankString "The Attribute's name")
-          :value (describe NonBlankString "The Attribute's value")}))
-
 (s/defschema Avu
   {:id AvuIdParam
    :attr (describe String "The Attribute's name")
@@ -47,3 +42,10 @@
 
 (s/defschema SetAvuRequest
   (->optional-param AvuListRequest :avus))
+
+(s/defschema AvuFilterRequest
+  (select-keys Avu [:attr :value]))
+
+(s/defschema FilterByAvusRequest
+  (merge TargetFilterRequest
+         {:avus (describe [AvuFilterRequest] "The AVUs to use to filter the given targets")}))

--- a/services/metadata/src/metadata/services/avus.clj
+++ b/services/metadata/src/metadata/services/avus.clj
@@ -6,11 +6,16 @@
             [metadata.amqp :as amqp]
             [metadata.persistence.avu :as persistence]))
 
-(defn filter-targets-by-attr-value
-  "Filters the given target IDs by returning a list of any that have the given attr and value applied."
-  [attr value target-types target-ids]
-  {:target-ids (map :target_id
-                    (persistence/filter-targets-by-attr-values target-types target-ids attr [value]))})
+(defn- filter-targets-by-attr-values
+  [target-types target-ids [attr avus]]
+  (persistence/filter-targets-by-attr-values target-types target-ids attr (map :value avus)))
+
+(defn filter-targets-by-avus
+  "Filters the given target IDs by returning a list of any that have the given attrs and values applied."
+  [target-types target-ids avus]
+  (let [found-targets (mapcat (partial filter-targets-by-attr-values target-types target-ids)
+                              (group-by :attr avus))]
+    {:target-ids (seq (set (map :target_id found-targets)))}))
 
 (defn- format-avu
   "Formats the given AVU for adding or updating."


### PR DESCRIPTION
These changes update the apps service to validate duplicate app names under ontology hierarchies.

The metadata `POST /avus/filter-targets` endpoint now accepts a list of AVUs (just attr/value pairs for now) rather than a single `attr` and `value`.

The following app edit endpoints now validate duplicate app names in the app's current ontology hierarchy:
* PATCH /admin/apps/:app-id
* PATCH /apps/:app-id
* PUT /apps/:app-id

The following app metadata endpoints now validate duplicate app names in ontology hierarchy AVUs given in the request:
* POST /apps/:app-id/metadata
* PUT /apps/:app-id/metadata