### PR TITLE
CORE-8102 Fix terrain's Permanent ID Requests metadata parsing

### DIFF
--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -104,14 +104,15 @@
 ;; CREATE
 
 (defn upload-file
-  [user dest-path filename content-type istream]
+  [user dest-path filename content-type istream & {:keys [as] :or {as :stream}}]
   (http/post (str (url/url (cfg/data-info-base) "data"))
              {:query-params {:user user
                              :dest dest-path}
               :multipart [{:part-name "file"
                            :name filename
                            :mime-type content-type
-                           :content istream}]}))
+                           :content istream}]
+              :as as}))
 (defn create-dirs
   "Uses the data-info directories endpoint to create several directories."
   [user paths]
@@ -163,6 +164,12 @@
     [user paths]
     (request :post ["deleter"]
              (mk-req-map user (json/encode {:paths paths}))))
+
+(defn delete-data-item
+  "Uses the data-info delete by data ID endpoint to delete a single data item."
+  [user data-id]
+  (request :delete ["data" data-id]
+           (mk-req-map user)))
 
 (defn delete-contents
     "Uses the data-info delete-children endpoint to delete the contents of a directory."

--- a/services/terrain/test/integration.clj
+++ b/services/terrain/test/integration.clj
@@ -1,0 +1,34 @@
+(ns integration
+  (:use [clojure.test])
+  (:require [terrain.clients.data-info.raw :as data-info-client]
+            [terrain.util.config :as config]))
+
+(defn- integration-test-setup
+  []
+  (config/load-config-from-file (System/getenv "TERRAIN_CONFIG_PATH")))
+
+(defn run-integration-tests
+  [f]
+  (when (System/getenv "RUN_INTEGRATION_TESTS")
+    (integration-test-setup)
+    (f)))
+
+(def test-user "ipctest")
+(def ^:dynamic test-data-item nil)
+
+(defn- create-test-file
+  [user]
+  (let [dest-path (str "/iplant/home/" user)
+        filename  (str "integration-test-file-" (java.util.UUID/randomUUID) ".txt")
+        istream   (java.io.ByteArrayInputStream. (.getBytes "testing" "UTF-8"))]
+    (-> (data-info-client/upload-file user dest-path filename "text/plain" istream :as :json)
+        :body
+        :file)))
+
+(defn with-test-data-item
+  [f]
+  (binding [test-data-item (create-test-file test-user)]
+    (f)
+    ;; Send the delete request twice, so that it's deleted from the Trash
+    (data-info-client/delete-data-item test-user (:id test-data-item))
+    (data-info-client/delete-data-item test-user (:id test-data-item))))

--- a/services/terrain/test/integration/terrain/services/permanent_id_requests.clj
+++ b/services/terrain/test/integration/terrain/services/permanent_id_requests.clj
@@ -2,7 +2,8 @@
   (:use [clojure.test]
         [terrain.services.permanent-id-requests])
   (:require [terrain.clients.data-info :as data-info]
-            [terrain.clients.data-info.raw :as data-info-client]))
+            [terrain.clients.data-info.raw :as data-info-client]
+            [terrain.util.config :as config]))
 
 (use-fixtures :once integration/run-integration-tests integration/with-test-data-item)
 
@@ -10,19 +11,52 @@
 (def parse-valid-ezid-metadata #'terrain.services.permanent-id-requests/parse-valid-ezid-metadata)
 (def ezid-target-attr #'terrain.services.permanent-id-requests/ezid-target-attr)
 
+(defn- get-test-item-metadata
+  []
+  (data-info/get-metadata-json integration/test-user (:id integration/test-data-item)))
+
+(defn- set-test-item-metadata
+  [avus]
+  (data-info-client/set-avus integration/test-user
+                             (:id integration/test-data-item)
+                             {:avus avus
+                              :irods-avus []}))
+
+(defn- add-test-item-metadata
+  [avus]
+  (data-info-client/add-avus integration/test-user
+                             (:id integration/test-data-item)
+                             {:avus avus
+                              :irods-avus []}))
+
+(defn- remove-test-item-metadata
+  []
+  (data-info-client/set-avus integration/test-user
+                             (:id integration/test-data-item)
+                             {:irods-avus []}))
 
 (deftest test-parse-valid-ezid-metadata
-  (testing "parse-valid-ezid-metadata"
-    (data-info-client/set-avus integration/test-user
-                               (:id integration/test-data-item)
-                               {:avus [{:attr  "test-attr-1"
-                                        :value "test-value-1"
-                                        :unit  ""}]
-                                :irods-avus []})
+  (testing "Test parse-valid-ezid-metadata return values and exceptions"
+    (set-test-item-metadata [{:attr  "test-attr-1"
+                              :value "test-value-1"
+                              :unit  "test-unit-1"}])
 
-    (let [data-id       (:id integration/test-data-item)
-          metadata      (data-info/get-metadata-json integration/test-user data-id)
-          ezid-metadata (parse-valid-ezid-metadata integration/test-data-item metadata)]
-      (is (contains? ezid-metadata @ezid-target-attr)))
+    (let [ezid-metadata (parse-valid-ezid-metadata integration/test-data-item (get-test-item-metadata))]
+      (is (contains? ezid-metadata @ezid-target-attr))
+      (is (contains? ezid-metadata (config/permanent-id-date-attr))))
 
-    (data-info-client/set-avus integration/test-user (:id integration/test-data-item) {:irods-avus []})))
+    (add-test-item-metadata [{:attr  (config/permanent-id-identifier-attr)
+                              :value "test-ID"
+                              :unit  "DOI"}])
+
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"already contains a Permanent Identifier"
+                          (parse-valid-ezid-metadata integration/test-data-item
+                                                     (get-test-item-metadata))))
+
+    (remove-test-item-metadata)
+
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"No metadata found"
+                          (parse-valid-ezid-metadata integration/test-data-item
+                                                     (get-test-item-metadata))))))

--- a/services/terrain/test/integration/terrain/services/permanent_id_requests.clj
+++ b/services/terrain/test/integration/terrain/services/permanent_id_requests.clj
@@ -20,9 +20,9 @@
                                         :unit  ""}]
                                 :irods-avus []})
 
-    (let [data-id (:id integration/test-data-item)
-          {:keys [irods-avus metadata]} (data-info/get-metadata-json integration/test-user data-id)
-          ezid-metadata (parse-valid-ezid-metadata integration/test-data-item irods-avus metadata)]
+    (let [data-id       (:id integration/test-data-item)
+          metadata      (data-info/get-metadata-json integration/test-user data-id)
+          ezid-metadata (parse-valid-ezid-metadata integration/test-data-item metadata)]
       (is (contains? ezid-metadata @ezid-target-attr)))
 
     (data-info-client/set-avus integration/test-user (:id integration/test-data-item) {:irods-avus []})))

--- a/services/terrain/test/integration/terrain/services/permanent_id_requests.clj
+++ b/services/terrain/test/integration/terrain/services/permanent_id_requests.clj
@@ -1,0 +1,28 @@
+(ns integration.terrain.services.permanent-id-requests
+  (:use [clojure.test]
+        [terrain.services.permanent-id-requests])
+  (:require [terrain.clients.data-info :as data-info]
+            [terrain.clients.data-info.raw :as data-info-client]))
+
+(use-fixtures :once integration/run-integration-tests integration/with-test-data-item)
+
+;; Re-def private functions so they can be tested in this namespace.
+(def parse-valid-ezid-metadata #'terrain.services.permanent-id-requests/parse-valid-ezid-metadata)
+(def ezid-target-attr #'terrain.services.permanent-id-requests/ezid-target-attr)
+
+
+(deftest test-parse-valid-ezid-metadata
+  (testing "parse-valid-ezid-metadata"
+    (data-info-client/set-avus integration/test-user
+                               (:id integration/test-data-item)
+                               {:avus [{:attr  "test-attr-1"
+                                        :value "test-value-1"
+                                        :unit  ""}]
+                                :irods-avus []})
+
+    (let [data-id (:id integration/test-data-item)
+          {:keys [irods-avus metadata]} (data-info/get-metadata-json integration/test-user data-id)
+          ezid-metadata (parse-valid-ezid-metadata integration/test-data-item irods-avus metadata)]
+      (is (contains? ezid-metadata @ezid-target-attr)))
+
+    (data-info-client/set-avus integration/test-user (:id integration/test-data-item) {:irods-avus []})))


### PR DESCRIPTION
This fixes the terrain permanent-id-requests service's expected format of data-info's metadata endpoint response (the metadata AVUs are no longer nested under a `metadata` key, after one of the last commits of #196).

Initial integration tests have also been added for terrain.services.permanent-id-requests, with more to be added before merging this PR.