### PR TITLE
CORE-8114 Update Apps window to parse ontology attrs from configs

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -494,7 +494,6 @@ apps:
   beta_attr_iri: n2t.net/ark:/99152/h1459
   beta_attr_label: releaseStatus
   beta_value: beta
-  ontology_attrs: "{\"http://edamontology.org/operation.*\":\"rdf:type\",\"http://edamontology.org/topic.*\":\"http://edamontology.org/has_topic\"}"
 
 metadata_db_driver: "{{ db_driver }}"
 metadata_db_vendor: "{{ db_vendor }}"

--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -494,6 +494,7 @@ apps:
   beta_attr_iri: n2t.net/ark:/99152/h1459
   beta_attr_label: releaseStatus
   beta_value: beta
+  ontology_attrs: "{\"http://edamontology.org/operation.*\":\"rdf:type\",\"http://edamontology.org/topic.*\":\"http://edamontology.org/has_topic\"}"
 
 metadata_db_driver: "{{ db_driver }}"
 metadata_db_vendor: "{{ db_vendor }}"

--- a/ansible/roles/util-cfg-service/templates/ui/de.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/ui/de.properties.j2
@@ -130,6 +130,7 @@ org.iplantc.discoveryenvironment.workspace.defaultAppCategories      = {{ apps.u
 org.iplantc.discoveryenvironment.workspace.defaultBetaAppCategoryId  = {{ apps.beta_category }}
 org.iplantc.discoveryenvironment.workspace.defaultHpcAppCategoryId   = {{ apps.hpc_category }}
 org.iplantc.discoveryenvironment.workspace.defaultTrashAppCategoryId = {{ apps.trash_category }}
+org.iplantc.discoveryenvironment.workspace.ontologyAttrs             = {{ apps.ontology_attrs }}
 
 org.iplantc.discoveryenvironment.workspace.metadata.beta.attr.iri       = {{ apps.beta_attr_iri }}
 org.iplantc.discoveryenvironment.workspace.metadata.beta.attr.label     = {{ apps.beta_attr_label }}

--- a/ansible/roles/util-cfg-service/templates/ui/de.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/ui/de.properties.j2
@@ -130,7 +130,7 @@ org.iplantc.discoveryenvironment.workspace.defaultAppCategories      = {{ apps.u
 org.iplantc.discoveryenvironment.workspace.defaultBetaAppCategoryId  = {{ apps.beta_category }}
 org.iplantc.discoveryenvironment.workspace.defaultHpcAppCategoryId   = {{ apps.hpc_category }}
 org.iplantc.discoveryenvironment.workspace.defaultTrashAppCategoryId = {{ apps.trash_category }}
-org.iplantc.discoveryenvironment.workspace.ontologyAttrs             = {{ apps.ontology_attrs }}
+org.iplantc.discoveryenvironment.workspace.ontologyAttrs             = {"http://edamontology.org/operation.*":"rdf:type","http://edamontology.org/topic.*":"http://edamontology.org/has_topic"}
 
 org.iplantc.discoveryenvironment.workspace.metadata.beta.attr.iri       = {{ apps.beta_attr_iri }}
 org.iplantc.discoveryenvironment.workspace.metadata.beta.attr.label     = {{ apps.beta_attr_label }}

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -205,6 +205,8 @@ public interface OntologiesView extends IsWidget,
         String confirmDeleteAppTitle();
 
         String externalAppDND(String appLabels);
+
+        String ontologyAttrMatchingError();
     }
 
     interface Presenter {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -138,6 +138,10 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
             if (result.size() == 0) {
                 view.showEmptyTreePanel();
             } else {
+                boolean isValid = ontologyUtil.createIriToAttrMap(result);
+                if (!isValid) {
+                    ErrorHandler.post(appearance.ontologyAttrMatchingError());
+                }
                 view.maskHierarchyTree();
                 addHierarchies(null, result);
             }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -64,7 +64,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                                                 DeleteHierarchyEvent.DeleteHierarchyEventHandler,
                                                 DeleteAppsSelected.DeleteAppsSelectedHandler {
 
-    private class CategorizeCallback implements AsyncCallback<List<Avu>> {
+    class CategorizeCallback implements AsyncCallback<List<Avu>> {
         private final App selectedApp;
         private final List<OntologyHierarchy> hierarchyRoots;
 
@@ -98,7 +98,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         }
     }
 
-    private class SaveHierarchyAsyncCallback implements AsyncCallback<OntologyHierarchy> {
+    class SaveHierarchyAsyncCallback implements AsyncCallback<OntologyHierarchy> {
         private final String iri;
         private final String ontologyVersion;
 
@@ -125,7 +125,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         }
     }
 
-    private class HierarchiesCallback implements AsyncCallback<List<OntologyHierarchy>> {
+    class HierarchiesCallback implements AsyncCallback<List<OntologyHierarchy>> {
         @Override
         public void onFailure(Throwable caught) {
             ErrorHandler.post(caught);
@@ -140,7 +140,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
             } else {
                 boolean isValid = ontologyUtil.createIriToAttrMap(result);
                 if (!isValid) {
-                    ErrorHandler.post(appearance.ontologyAttrMatchingError());
+                    displayErrorToAdmin();
                 }
                 view.maskHierarchyTree();
                 addHierarchies(null, result);
@@ -393,7 +393,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         serviceFacade.getAppAVUs(selectedApp, new CategorizeCallback(selectedApp, hierarchyRoots));
     }
 
-    private boolean isValidHierarchy(OntologyHierarchy result) {
+    boolean isValidHierarchy(OntologyHierarchy result) {
         // If there are no subclasses, either the hierarchy had no subcategories (which
         // we do not want as a root, or
         // there was an undetected typo in the iri
@@ -530,5 +530,9 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                                           view.unmaskGrids();
                                       }
                                   });
+    }
+
+    void displayErrorToAdmin() {
+        ErrorHandler.post(appearance.ontologyAttrMatchingError());
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
@@ -21,6 +21,8 @@ public interface OntologyHierarchiesView extends IsWidget,
     interface OntologyHierarchiesAppearance extends AppCategoriesView.AppCategoriesAppearance {
 
         String hierarchyLabelName(OntologyHierarchy hierarchy);
+
+        String ontologyAttrMatchingFailure();
     }
 
     interface Presenter extends AppInfoSelectedEvent.AppInfoSelectedEventHandler,

--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
@@ -49,6 +49,8 @@ import com.sencha.gxt.widget.core.client.tree.Tree;
 
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author aramsey
@@ -117,7 +119,7 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
     private OntologyHierarchiesViewFactory viewFactory;
     String baseID;
     List<OntologyHierarchy> unclassifiedHierarchies = Lists.newArrayList();
-
+    Logger LOG = Logger.getLogger("OntologyHierarchiesPresenterImpl");
 
     @Inject
     public OntologyHierarchiesPresenterImpl(OntologyHierarchiesViewFactory viewFactory,
@@ -145,7 +147,13 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
             @Override
             public void onSuccess(List<OntologyHierarchy> result) {
                 if (result != null && result.size() > 0) {
-                    createViewTabs(result);
+                    boolean isValid = ontologyUtil.createIriToAttrMap(result);
+                    if (!isValid) {
+                        announcer.schedule(new ErrorAnnouncementConfig(appearance.ontologyAttrMatchingFailure()));
+                        LOG.log(Level.SEVERE, "ERROR UI's ontology configs do not exist or do not match published ontology!");
+                    } else {
+                        createViewTabs(result);
+                    }
                 }
             }
         });

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/util/OntologyUtil.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/util/OntologyUtil.java
@@ -82,12 +82,13 @@ public class OntologyUtil {
      * @return
      */
     public boolean createIriToAttrMap(List<OntologyHierarchy> result) {
-        if (properties.getOntologyAttrs() == null) {
+        String attrs = properties.getOntologyAttrs();
+        if (attrs == null) {
             return false;
         }
 
         iriToAttrMap.clear();
-        buildIriToAttrMap(properties.getOntologyAttrs());
+        buildIriToAttrMap(attrs);
 
         return isValidIriMap(result);
     }
@@ -110,7 +111,8 @@ public class OntologyUtil {
         JSONObject map = jsonUtil.getObject(ontologyAttr);
 
         for (String key : map.keySet()) {
-            iriToAttrMap.put(key, jsonUtil.getString(map, key));
+            String value = jsonUtil.getString(map, key);
+            iriToAttrMap.put(key, value);
         }
     }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/shared/DEProperties.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/shared/DEProperties.java
@@ -83,6 +83,9 @@ public class DEProperties {
     private static final String DEFAULT_TRASH_CATEGORY_ID =
             WORKSPACE_PREFIX + "defaultTrashAppCategoryId";
 
+    private static final String ONTOLOGY_ATTRS = WORKSPACE_PREFIX + "ontologyAttrs";
+
+
     /**
      * Properties key for the Beta Avu fields
      */
@@ -157,6 +160,8 @@ public class DEProperties {
     private String betaAvuValue;
 
     private String betaAvuUnit;
+
+    private String ontologyAttrs;
 
 
     public String getPathListFileIdentifier() {
@@ -239,6 +244,7 @@ public class DEProperties {
         keys.add(BETA_AVU_LABEL);
         keys.add(BETA_AVU_VALUE);
         keys.add(BETA_AVU_UNIT);
+        keys.add(ONTOLOGY_ATTRS);
         return keys;
     }
 
@@ -267,6 +273,7 @@ public class DEProperties {
         betaAvuLabel = properties.get(BETA_AVU_LABEL);
         betaAvuValue = properties.get(BETA_AVU_VALUE);
         betaAvuUnit = properties.get(BETA_AVU_UNIT);
+        ontologyAttrs = properties.get(ONTOLOGY_ATTRS);
     }
 
     /**
@@ -399,5 +406,9 @@ public class DEProperties {
 
     public String getBetaAvuUnit() {
         return betaAvuUnit;
+    }
+
+    public String getOntologyAttrs() {
+        return ontologyAttrs;
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
@@ -390,4 +390,8 @@ public class OntologiesViewDefaultAppearance implements OntologiesView.Ontologie
     public String externalAppDND(String appLabels) {
         return displayStrings.externalAppDND(appLabels);
     }
+
+    public String ontologyAttrMatchingError() {
+        return displayStrings.ontologyAttrMatchingError();
+    }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
@@ -82,4 +82,6 @@ public interface OntologyDisplayStrings extends Messages{
     String confirmDeleteAppWarning(String name);
 
     String externalAppDND(String appLabels);
+
+    String ontologyAttrMatchingError();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
@@ -35,3 +35,4 @@ confirmDeleteHierarchy = Are you sure you want to delete the `{0}` hierarchy?<BR
 confirmDeleteAppTitle = Delete App
 confirmDeleteAppWarning = Are you sure you want to delete the app `{0}`?
 externalAppDND = External app(s): {0}
+ontologyAttrMatchingError = A hierarchy root you have added does not match or has not been added to the DE configs attribute list.  Please contact the core software dev team to have the configs updated with the attribute values that correspond to the hierarchies you requested.

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
@@ -133,4 +133,6 @@ public interface AppsMessages extends Messages {
     String viewCategoriesHeader();
 
     String betaToolTip();
+
+    String ontologyAttrMatchingFailure();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
@@ -61,3 +61,4 @@ workspaceTab = My Apps
 hpcTab = HPC
 viewCategoriesHeader = Categories
 betaToolTip = This app is currently in the Beta phase and has not yet been reviewed by the CyVerse science team.
+ontologyAttrMatchingFailure = Unable to fetch all app listings.  Please try again later.

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/hierarchies/OntologyHierarchiesDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/hierarchies/OntologyHierarchiesDefaultAppearance.java
@@ -2,20 +2,34 @@ package org.iplantc.de.theme.base.client.apps.hierarchies;
 
 import org.iplantc.de.apps.client.OntologyHierarchiesView;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
+import org.iplantc.de.theme.base.client.apps.AppsMessages;
 import org.iplantc.de.theme.base.client.apps.categories.AppCategoriesViewDefaultAppearance;
+
+import com.google.gwt.core.client.GWT;
 
 /**
  * @author aramsey
  */
 public class OntologyHierarchiesDefaultAppearance extends AppCategoriesViewDefaultAppearance implements OntologyHierarchiesView.OntologyHierarchiesAppearance {
 
+    private AppsMessages displayStrings;
 
     public OntologyHierarchiesDefaultAppearance() {
+        this(GWT.<AppsMessages> create(AppsMessages.class));
+    }
+
+    public OntologyHierarchiesDefaultAppearance(AppsMessages appsMessages) {
+        this.displayStrings = appsMessages;
     }
 
     @Override
     public String hierarchyLabelName(OntologyHierarchy hierarchy) {
         return hierarchy.getLabel();
+    }
+
+    @Override
+    public String ontologyAttrMatchingFailure() {
+        return displayStrings.ontologyAttrMatchingFailure();
     }
 
 }

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
@@ -127,6 +127,7 @@ public class OntologiesPresenterImplTest {
         when(appearanceMock.appAvusCleared(Matchers.<App> any())).thenReturn("success");
         when(appearanceMock.ontologyDeleted(anyString())).thenReturn("success");
         when(appearanceMock.hierarchyDeleted(anyString())).thenReturn("success");
+        when(appearanceMock.ontologyAttrMatchingError()).thenReturn("fail");
         when(oldGridViewMock.getGrid()).thenReturn(oldGridMock);
         when(oldGridPresenterMock.getView()).thenReturn(oldGridViewMock);
         when(newGridPresenterMock.getView()).thenReturn(newGridViewMock);
@@ -346,6 +347,10 @@ public class OntologiesPresenterImplTest {
             @Override
             void addHierarchies(OntologyHierarchy parent, List<OntologyHierarchy> children) {
             }
+
+            @Override
+            void displayErrorToAdmin() {
+            }
         };
 
         /** CALL METHOD UNDER TEST **/
@@ -384,9 +389,19 @@ public class OntologiesPresenterImplTest {
             @Override
             void addHierarchies(OntologyHierarchy parent, List<OntologyHierarchy> children) {
             }
+
+            @Override
+            boolean isValidHierarchy(OntologyHierarchy result) {
+                return true;
+            }
+
+            @Override
+            void displayErrorToAdmin() {
+            }
         };
         uut.properties = propertiesMock;
         uut.announcer = announcerMock;
+        uut.ontologyUtil = utilMock;
 
         /** CALL METHOD UNDER TEST **/
         uut.onSaveOntologyHierarchy(eventMock);
@@ -395,6 +410,16 @@ public class OntologiesPresenterImplTest {
                                                         asyncOntologyHierarchyCaptor.capture());
 
         asyncOntologyHierarchyCaptor.getValue().onSuccess(ontologyHierarchyMock);
+
+        verify(serviceFacadeMock).getOntologyHierarchies(anyString(), asyncOntologyHierarchyListCaptor.capture());
+
+        asyncOntologyHierarchyListCaptor.getValue().onSuccess(ontologyHierarchyListMock);
+
+        verify(viewMock).clearStore();
+        verify(utilMock).createIriToAttrMap(eq(ontologyHierarchyListMock));
+        verify(viewMock, times(3)).maskHierarchyTree();
+        verify(viewMock).unMaskHierarchyTree();
+        verify(viewMock).updateButtonStatus();
 
         verify(viewMock).showTreePanel();
 


### PR DESCRIPTION
This updates the UI so that instead of hard-coding the attribute values for metadata into the UI, the UI can read the mapping between IRIs and the corresponding attribute from the configs.  The value is the attribute and the key is a regex that should match all IRIs that should be associated with that attribute.  Right now the UI needs to know which attributes apply to which hierarchies in order to update any metadata.

[This is a temporary solution until changes can be made so that admins can select which attributes they want associated with which hierarchies, which would be too many changes to make the 2.8 release.]