### PR TITLE
CORE-8126 prep: support fetching groups for a subject with a folder filter in iplant-groups

### DIFF
--- a/services/iplant-groups/src/iplant_groups/clients/grouper.clj
+++ b/services/iplant-groups/src/iplant_groups/clients/grouper.clj
@@ -530,20 +530,33 @@
 ;; Groups for a subject.
 
 (defn- format-groups-for-subject-request
-  [username subject-id]
-  {:WsRestGetGroupsRequest
-   {:actAsSubjectLookup   (act-as-subject-lookup username)
-    :subjectLookups       [(subject-id-lookup subject-id)]}})
+  ([username subject-id]
+   {:WsRestGetGroupsRequest
+    {:actAsSubjectLookup   (act-as-subject-lookup username)
+     :subjectLookups       [(subject-id-lookup subject-id)]}})
+  ([username subject-id folder-name]
+   {:WsRestGetGroupsRequest
+    {:actAsSubjectLookup   (act-as-subject-lookup username)
+     :subjectLookups       [(subject-id-lookup subject-id)]
+     :wsStemLookup {:stemName folder-name}
+     :stemScope "ALL_IN_SUBTREE"}}))
 
-(defn groups-for-subject
-  [username subject-id]
+(defn- groups-for-subject*
+  [request-body]
   (with-trap [default-error-handler]
-    (-> (format-groups-for-subject-request username subject-id)
-        (grouper-post "subjects")
+    (-> (grouper-post request-body "subjects")
         :WsGetGroupsResults
         :results
         first
         :wsGroups)))
+
+(defn groups-for-subject
+  [username subject-id]
+  (groups-for-subject* (format-groups-for-subject-request username subject-id)))
+
+(defn groups-for-subject-folder
+  [username subject-id folder-name]
+  (groups-for-subject* (format-groups-for-subject-request username subject-id folder-name)))
 
 ;; Attribute Definition Name search
 (defn- format-attribute-name-search-request

--- a/services/iplant-groups/src/iplant_groups/routes/schemas/params.clj
+++ b/services/iplant-groups/src/iplant_groups/routes/schemas/params.clj
@@ -24,6 +24,11 @@
     (s/optional-key :folder)
     (describe NonBlankString "The name of the folder to search for.")))
 
+(s/defschema GroupsForSubjectParams
+  (assoc StandardUserQueryParams
+    (s/optional-key :folder)
+    (describe NonBlankString "The name of the folder to limit to results within.")))
+
 (s/defschema AttributeSearchParams
   (assoc SearchParams
     (s/optional-key :exact)

--- a/services/iplant-groups/src/iplant_groups/routes/subjects.clj
+++ b/services/iplant-groups/src/iplant_groups/routes/subjects.clj
@@ -24,7 +24,7 @@
 
   (GET* "/:subject-id/groups" []
         :path-params [subject-id :- SubjectIdPathParam]
-        :query       [params StandardUserQueryParams]
+        :query       [params GroupsForSubjectParams]
         :return      GroupList
         :summary     "List Groups for a Subject"
         :description "This endpoint allows callers to list all groups that a subject belongs to."

--- a/services/iplant-groups/src/iplant_groups/service/subjects.clj
+++ b/services/iplant-groups/src/iplant_groups/service/subjects.clj
@@ -13,5 +13,8 @@
     (fmt/format-subject attribute-names subject)))
 
 (defn groups-for-subject
-  [subject-id {:keys [user]}]
-  {:groups (mapv fmt/format-group (grouper/groups-for-subject user subject-id))})
+  [subject-id {:keys [user folder]}]
+  (let [result (if folder
+                 (grouper/groups-for-subject-folder user subject-id folder)
+                 (grouper/groups-for-subject user subject-id))]
+    {:groups (mapv fmt/format-group result)}))


### PR DESCRIPTION
This is in preparation for fetching groups for a subject when an analysis is submitted -- we want to only fetch groups which are within the folder corresponding to the current environment, then remove the environment-folder part of the name and pass it down to jex-adapter.