### PR TITLE
CORE-8126: put user groups into the jex submission in apps

### DIFF
--- a/services/apps/src/apps/service/apps/de/jobs/common.clj
+++ b/services/apps/src/apps/service/apps/de/jobs/common.clj
@@ -9,6 +9,7 @@
         [apps.util.conversions :only [remove-nil-vals]])
   (:require [clojure.string :as string]
             [apps.containers :as c]
+            [apps.clients.iplant-groups :as ipg]
             [apps.service.apps.de.jobs.params :as params]
             [apps.service.apps.de.jobs.util :as util]))
 
@@ -133,6 +134,7 @@
    :steps                (.buildSteps request-builder)
    :username             (:shortUsername user)
    :user_id              (get-user-id (:username user))
+   :user_groups          (map (comp ipg/remove-environment-from-group :name) (:groups (ipg/lookup-subject-groups (:shortUsername user))))
    :uuid                 (or (:uuid submission) (uuid))
    :wiki_url             (:wiki_url app)
    :skip-parent-meta     (:skip-parent-meta submission)


### PR DESCRIPTION
This time actually fixing the ticket! This:

* adds a client function for fetching a subject's groups
* adds a client function for trimming off the environment name
* uses them to add information to the submission that will be sent to the jex in the format I was told to

I've tried this against our dev environment with the newly-deployed jex-adapter and the `+IpcUserGroups` entry I'd expect (`{"users:de-users"}` only -- I'm not in anything else) appeared.