### PR TITLE
Create optimized uuid-for-path endpoint in data-info

### DIFF
--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -13,6 +13,7 @@
             [data-info.services.write :as write]
             [data-info.services.page-file :as page-file]
             [data-info.services.page-tabular :as page-tabular]
+            [data-info.services.uuids :as uuids]
             [data-info.util.config :as cfg]
             [tree-urls-client.middleware :refer [wrap-tree-urls-base]]
             [clojure-commons.error-codes :as ce]
@@ -24,6 +25,14 @@
 
   (context* "/data" []
     :tags ["data"]
+
+    (GET* "/uuid" [:as {uri :uri}]
+      :query [params PathToUUIDParams]
+      :return PathToUUIDReturn
+      :summary "Get the UUID for a path"
+      :description (str "Get a UUID for a path provided as a query parameter."
+(get-error-code-block "ERR_DOES_NOT_EXIST, ERR_NOT_READABLE, ERR_NOT_A_USER"))
+      (svc/trap uri uuids/do-simple-uuid-for-path params))
 
     (GET* "/path/:zone/*" [:as {{zone :zone path :*} :params uri :uri}]
       :query [params FolderListingParams]

--- a/services/data-info/src/data_info/routes/schemas/data.clj
+++ b/services/data-info/src/data_info/routes/schemas/data.clj
@@ -9,6 +9,13 @@
         [heuristomancer.core :as info])
   (:require [schema.core :as s]))
 
+(s/defschema PathToUUIDParams
+  (assoc StandardUserQueryParams
+         :path (describe NonBlankString "A path to translate to a UUID")))
+
+(s/defschema PathToUUIDReturn
+  {:id (describe NonBlankString "The UUID for the path queried.")})
+
 (s/defschema FileUploadQueryParams
   (assoc StandardUserQueryParams
          :dest (describe NonBlankString "The destination directory for the uploaded file.")))

--- a/services/data-info/src/data_info/services/uuids.clj
+++ b/services/data-info/src/data_info/services/uuids.clj
@@ -81,6 +81,14 @@
     (valid/all-paths-readable cm user paths)
     (remove nil? (mapv (partial uuid-for-path cm user) paths))))
 
+(defn do-simple-uuid-for-path
+  [{:keys [user path]}]
+  (init/with-jargon (cfg/jargon-cfg) [cm]
+    (valid/user-exists cm user)
+    (valid/path-exists cm path)
+    (valid/path-readable cm user path)
+    {:id (str (irods/lookup-uuid cm path))}))
+
 (defn ^Boolean uuid-accessible?
   "Indicates if a data item is readable by a given user.
 

--- a/services/terrain/src/terrain/clients/data_info.clj
+++ b/services/terrain/src/terrain/clients/data_info.clj
@@ -66,10 +66,10 @@
 
 (defn uuid-for-path
   [^String user ^String path]
-  (-> (raw/collect-stats user :paths [path])
+  (-> (raw/uuid-for-path user path)
       :body
-      json/decode
-      (get-in ["paths" path "id"])))
+      (json/decode true)
+      :id))
 
 (defn ensure-dir-created
   "If a folder doesn't exist, it creates the folder and makes the given user an owner of it.

--- a/services/terrain/src/terrain/clients/data_info/raw.clj
+++ b/services/terrain/src/terrain/clients/data_info/raw.clj
@@ -271,6 +271,12 @@
 
 ;; MISC
 
+(defn uuid-for-path
+  "Uses the data-info uuid-for-path endpoint to resolve a path to a UUID"
+  [user path]
+  (request :get ["data" "uuid"]
+           (mk-req-map user {:path path})))
+
 (defn collect-permissions
   "Uses the data-info permissions-gatherer endpoint to query user permissions for a set of files/folders."
   [user paths]


### PR DESCRIPTION
This endpoint uses more direct methods for getting the UUID, for cases
where a full stat entry isn't needed, just the path. Terrain has also
been updated to use this for the data-info client's uuid-for-path
function, which is used for a lot of terrain's current translating of
paths into uuids.

Ideally, this eventually goes away or nearly away as we move the UI to
use data UUIDs in more/most places, such that terrain doesn't need to be
making these lookups. But, for now, this should trim off a decent amount
off each request it has to make to resolve a UUID.

I've put this up for review since it adds an endpoint, and filed an issue at CORE-8129 to track for QA's sake.