### PR TITLE
CORE-8103 Notify integrator when admin deletes app

### DIFF
--- a/ansible/roles/util-cfg-service/templates/apps.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/apps.properties.j2
@@ -77,3 +77,11 @@ apps.metadata.base-url = http://{{ metadata.host }}:{{ metadata.port }}
 
 # Permissions service connection settings.
 apps.permissions.base-url = {{ permissions_base }}
+
+# iPlant Email service settings.
+apps.email.base-url             = {{ iplant_email.base }}
+apps.email.app-deletion.from    = {{ de_mail_from_addr }}
+apps.email.app-deletion.subject = Your "%s" app has been administratively deprecated
+
+# UI host
+apps.ui.base-url = {{ de.base }}

--- a/services/apps/src/apps/clients/email.clj
+++ b/services/apps/src/apps/clients/email.clj
@@ -1,0 +1,32 @@
+(ns apps.clients.email
+  (:require [apps.util.config :as config]
+            [cemerick.url :as curl]
+            [cheshire.core :as cheshire]
+            [clj-http.client :as client]))
+
+(defn send-email
+  "Sends an e-mail message via the iPlant e-mail service."
+  [& {:keys [to from-addr from-name subject template values]}]
+  (client/post
+    (config/iplant-email-base-url)
+    {:content-type :json
+     :body         (cheshire/encode {:to        to
+                                     :from-addr from-addr
+                                     :from-name from-name
+                                     :subject   subject
+                                     :template  template
+                                     :values    values})}))
+
+(defn send-app-deletion-notification
+  "Sends an app deletion email message to the app integrator."
+  [integrator-name integrator-email app-name app-id]
+  (let [app-link (str (assoc (curl/url (config/ui-base-url)) :query {:type "apps" :app-id app-id}))
+        template-values {:name     integrator-name
+                         :app_name app-name
+                         :app_link app-link}]
+    (send-email
+      :to        integrator-email
+      :from-addr (config/app-deletion-notification-src-addr)
+      :subject   (format (config/app-deletion-notification-subject) app-name)
+      :template  "app_deletion_notification"
+      :values    template-values)))

--- a/services/apps/src/apps/util/config.clj
+++ b/services/apps/src/apps/util/config.clj
@@ -270,6 +270,26 @@
   [props config-valid configs]
   "apps.permissions.base-url")
 
+(cc/defprop-str ui-base-url
+  "The base URL for the email service."
+  [props config-valid configs]
+  "apps.ui.base-url")
+
+(cc/defprop-str iplant-email-base-url
+  "The base URL for the email service."
+  [props config-valid configs]
+  "apps.email.base-url")
+
+(cc/defprop-str app-deletion-notification-src-addr
+  "The source email address of app deletion notification messages."
+  [props config-valid configs]
+  "apps.email.app-deletion.from")
+
+(cc/defprop-str app-deletion-notification-subject
+  "The email subject of app deletion notification messages."
+  [props config-valid configs]
+  "apps.email.app-deletion.subject")
+
 (def get-default-app-categories
   (memoize
    (fn []

--- a/services/iplant-email/conf/app_deletion_notification.st
+++ b/services/iplant-email/conf/app_deletion_notification.st
@@ -1,0 +1,11 @@
+Dear $name$,
+
+Your app, $app_name$, has been administratively deprecated in the Discovery Environment.
+Usually this happens when a newer version of this app is made publicly available in the Discovery Environment.
+This app is still viewable by its direct link, though it can no longer be searched or used within the Discovery Environment:
+$app_link$
+
+If you believe this app should not have been deprecated, please contact support@cyverse.org.
+
+Thank you,
+The CyVerse Team


### PR DESCRIPTION
These changes update the apps service `DELETE /admin/apps/{app-id}` endpoint to send an app deletion notification email to the app integrator.

The email template `app_deletion_notification.st` was added to the iplant-email service for this notification.

The following apps configs were also added:
* apps.email.base-url
* apps.email.app-deletion.from
* apps.email.app-deletion.subject
* apps.ui.base-url