### PR TITLE
CORE-8112 Add ability to restore apps within App Catalog tab in Belphegor

### DIFF
--- a/ansible/inventories/group_vars/all
+++ b/ansible/inventories/group_vars/all
@@ -488,7 +488,6 @@ apps:
   hpc_category: 00000000-0000-0000-0000-000000000001
   user_root: Workspace
   user_subs: "[\"Apps under development\",\"Favorite Apps\"]"
-  trash_category: Trash
   max_heap: "{{ max_heap.high }}"
   grouper_user:
   beta_attr_iri: n2t.net/ark:/99152/h1459

--- a/ansible/roles/util-cfg-service/templates/ui/de.properties.j2
+++ b/ansible/roles/util-cfg-service/templates/ui/de.properties.j2
@@ -129,7 +129,7 @@ org.iplantc.discoveryenvironment.workspace.rootAppCategory           = {{ apps.u
 org.iplantc.discoveryenvironment.workspace.defaultAppCategories      = {{ apps.user_subs }}
 org.iplantc.discoveryenvironment.workspace.defaultBetaAppCategoryId  = {{ apps.beta_category }}
 org.iplantc.discoveryenvironment.workspace.defaultHpcAppCategoryId   = {{ apps.hpc_category }}
-org.iplantc.discoveryenvironment.workspace.defaultTrashAppCategoryId = {{ apps.trash_category }}
+org.iplantc.discoveryenvironment.workspace.defaultTrashAppCategoryId = ffffffff-ffff-ffff-ffff-ffffffffffff
 org.iplantc.discoveryenvironment.workspace.ontologyAttrs             = {"http://edamontology.org/operation.*":"rdf:type","http://edamontology.org/topic.*":"http://edamontology.org/has_topic"}
 
 org.iplantc.discoveryenvironment.workspace.metadata.beta.attr.iri       = {{ apps.beta_attr_iri }}

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -8,6 +8,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySel
 import org.iplantc.de.admin.desktop.client.ontologies.events.PublishOntologyClickEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshOntologiesEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshPreviewButtonClicked;
+import org.iplantc.de.admin.desktop.client.ontologies.events.RestoreAppButtonClicked;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarchyEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
@@ -46,11 +47,13 @@ public interface OntologiesView extends IsWidget,
                                         DeleteAppsSelected.HasDeleteAppsSelectedHandlers,
                                         BeforeAppSearchEvent.HasBeforeAppSearchEventHandlers,
                                         AppSearchResultLoadEvent.HasAppSearchResultLoadEventHandlers,
-                                        RefreshPreviewButtonClicked.HasRefreshPreviewButtonClickedHandlers {
+                                        RefreshPreviewButtonClicked.HasRefreshPreviewButtonClickedHandlers,
+                                        RestoreAppButtonClicked.HasRestoreAppButtonClickedHandlers {
 
     enum TreeType {
         ALL, EDITOR, PREVIEW
     }
+
 
     void showOntologyVersions(List<Ontology> result);
 
@@ -235,6 +238,16 @@ public interface OntologiesView extends IsWidget,
         String treePanelHeader();
 
         String refresh();
+
+        String restoreApp();
+
+        ImageResource restoreAppIcon();
+
+        String restoreAppFailureMsg(String name);
+
+        String restoreAppSuccessMsgTitle();
+
+        String restoreAppSuccessMsg(String name, String joinedCatNames);
     }
 
     interface Presenter {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/RestoreAppButtonClicked.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/RestoreAppButtonClicked.java
@@ -1,0 +1,40 @@
+package org.iplantc.de.admin.desktop.client.ontologies.events;
+
+import org.iplantc.de.client.models.apps.App;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class RestoreAppButtonClicked
+        extends GwtEvent<RestoreAppButtonClicked.RestoreAppButtonClickedHandler> {
+    public static interface RestoreAppButtonClickedHandler extends EventHandler {
+        void onRestoreAppButtonClicked(RestoreAppButtonClicked event);
+    }
+
+    public interface HasRestoreAppButtonClickedHandlers {
+        HandlerRegistration addRestoreAppButtonClickedHandlers(RestoreAppButtonClickedHandler handler);
+    }
+    public static Type<RestoreAppButtonClickedHandler> TYPE = new Type<RestoreAppButtonClickedHandler>();
+
+    private App app;
+
+    public RestoreAppButtonClicked (App app) {
+        this.app = app;
+    }
+
+    public Type<RestoreAppButtonClickedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(RestoreAppButtonClickedHandler handler) {
+        handler.onRestoreAppButtonClicked(this);
+    }
+
+    public App getApp() {
+        return app;
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -46,7 +46,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.inject.Inject;
@@ -706,8 +705,8 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
             @Override
             public void onFailure(Throwable caught) {
                 view.unmaskGrids();
-                JSONObject obj = JSONParser.parseStrict(caught.getMessage()).isObject();
-                String reason = jsonUtil.trim(obj.get("reason").toString());
+                JSONObject obj = jsonUtil.getObject(caught.getMessage());
+                String reason = jsonUtil.getString(obj, "reason");
                 if (reason.contains("orphaned")) {
                     announcer.schedule(new ErrorAnnouncementConfig(appearance.restoreAppFailureMsg(app.getName())));
                 } else {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -10,6 +10,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySel
 import org.iplantc.de.admin.desktop.client.ontologies.events.PublishOntologyClickEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshOntologiesEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshPreviewButtonClicked;
+import org.iplantc.de.admin.desktop.client.ontologies.events.RestoreAppButtonClicked;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarchyEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.PublishOntologyDialog;
@@ -88,6 +89,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     @UiField TextButton deleteApp;
     @UiField AppSearchField appSearchField;
     @UiField TextButton refreshPreview;
+    @UiField TextButton restoreApp;
     @UiField(provided = true) OntologiesViewAppearance appearance;
     @UiField(provided = true) Tree<OntologyHierarchy, String> editorTree;
     @UiField(provided = true) Tree<OntologyHierarchy, String> previewTree;
@@ -222,6 +224,10 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     @Override
     public HandlerRegistration addRefreshPreviewButtonClickedHandler(RefreshPreviewButtonClicked.RefreshPreviewButtonClickedHandler handler) {
         return addHandler(handler, RefreshPreviewButtonClicked.TYPE);
+    }
+
+    public HandlerRegistration addRestoreAppButtonClickedHandlers(RestoreAppButtonClicked.RestoreAppButtonClickedHandler handler) {
+        return addHandler(handler, RestoreAppButtonClicked.TYPE);
     }
 
     @Override
@@ -451,6 +457,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
         categorize.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
         deleteApp.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
         refreshPreview.setEnabled(selectedOntology != null && editorTreeStore.getRootItems() != null && editorTreeStore.getRootItems().size() > 0);
+        restoreApp.setEnabled(targetApp != null && targetApp.isDeleted());
     }
 
     @Override
@@ -552,6 +559,11 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     @UiHandler("refreshPreview")
     void refreshPreviewButtonClicked(SelectEvent event) {
         fireEvent(new RefreshPreviewButtonClicked(ontologyDropDown.getCurrentValue(), editorTreeStore.getRootItems()));
+    }
+
+    @UiHandler("restoreApp")
+    void restoreAppClicked(SelectEvent event) {
+        fireEvent(new RestoreAppButtonClicked(targetApp));
     }
 
     Tree<OntologyHierarchy, String> createTree(TreeStore<OntologyHierarchy> store) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
@@ -88,6 +88,11 @@
                                        text="{appearance.confirmDeleteAppTitle}"
                                        icon="{appearance.deleteIcon}"/>
                 </toolbar:child>
+                <toolbar:child>
+                    <button:TextButton ui:field="restoreApp"
+                                       text="{appearance.restoreApp}"
+                                       icon="{appearance.restoreAppIcon}"/>
+                </toolbar:child>
                 <toolbar:child layoutData="{boxData}">
                     <appSearch:AppSearchField ui:field="appSearchField"
                                               emptyText="{appearance.emptySearchFieldText}"/>

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/AppServiceFacade.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/AppServiceFacade.java
@@ -34,6 +34,8 @@ public interface AppServiceFacade {
      * @param callback called when the RPC call is complete.*/
     void getApps(HasId appCategory, AsyncCallback<List<App>> callback);
 
+    void getApps(String id, AsyncCallback<List<App>> callback);
+
     /**
      * Retrieves a paged listing of templates in the given group.
      *

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/AppUserServiceFacadeImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/services/impl/AppUserServiceFacadeImpl.java
@@ -110,7 +110,11 @@ public class AppUserServiceFacadeImpl implements AppUserServiceFacade {
 
     @Override
     public void getApps(HasId appCategory, AsyncCallback<List<App>> callback) {
-        String address = CATEGORIES + "/" + appCategory.getId();
+        getApps(appCategory.getId(), callback);
+    }
+
+    public void getApps(String id, AsyncCallback<List<App>> callback) {
+        String address = CATEGORIES + "/" + id;
         ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
         deServiceFacade.getServiceData(wrapper, new AsyncCallbackConverter<String, List<App>>(callback) {
             @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/client/util/OntologyUtil.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/client/util/OntologyUtil.java
@@ -303,4 +303,7 @@ public class OntologyUtil {
         return avuListBean;
     }
 
+    public OntologyHierarchy getHierarchyObject() {
+        return factory.getHierarchy().as();
+    }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
@@ -5,6 +5,7 @@ import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.avu.Avu;
 import org.iplantc.de.resources.client.IplantResources;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
+import org.iplantc.de.theme.base.client.admin.BelphegorErrorStrings;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
@@ -41,25 +42,29 @@ public class OntologiesViewDefaultAppearance implements OntologiesView.Ontologie
     private IplantDisplayStrings iplantDisplayStrings;
     private HelpTemplates helpTemplates;
     private Templates templates;
+    private BelphegorErrorStrings belphegorErrorStrings;
 
     public OntologiesViewDefaultAppearance() {
         this(GWT.<OntologyDisplayStrings>create(OntologyDisplayStrings.class),
              GWT.<IplantResources>create(IplantResources.class),
              GWT.<IplantDisplayStrings>create(IplantDisplayStrings.class),
              GWT.<HelpTemplates>create(HelpTemplates.class),
-             GWT.<Templates>create(Templates.class));
+             GWT.<Templates>create(Templates.class),
+             GWT.<BelphegorErrorStrings>create(BelphegorErrorStrings.class));
     }
 
     OntologiesViewDefaultAppearance(OntologyDisplayStrings displayStrings,
                                     IplantResources iplantResources,
                                     IplantDisplayStrings iplantDisplayStrings,
                                     HelpTemplates helpTemplates,
-                                    Templates templates) {
+                                    Templates templates,
+                                    BelphegorErrorStrings belphegorErrorStrings) {
         this.displayStrings = displayStrings;
         this.iplantResources = iplantResources;
         this.iplantDisplayStrings = iplantDisplayStrings;
         this.helpTemplates = helpTemplates;
         this.templates = templates;
+        this.belphegorErrorStrings = belphegorErrorStrings;
     }
 
     @Override
@@ -422,5 +427,29 @@ public class OntologiesViewDefaultAppearance implements OntologiesView.Ontologie
     @Override
     public String refresh() {
         return displayStrings.refresh();
+    }
+
+    public String restoreApp() {
+        return displayStrings.restoreApp();
+    }
+
+    @Override
+    public ImageResource restoreAppIcon() {
+        return iplantResources.submitForPublic();
+    }
+
+    @Override
+    public String restoreAppFailureMsg(String name) {
+        return belphegorErrorStrings.restoreAppFailureMsg(name);
+    }
+
+    @Override
+    public String restoreAppSuccessMsgTitle() {
+        return displayStrings.restoreAppSuccessMsgTitle();
+    }
+
+    @Override
+    public String restoreAppSuccessMsg(String name, String joinedCatNames) {
+        return displayStrings.restoreAppSuccessMsg(name, joinedCatNames);
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
@@ -92,4 +92,10 @@ public interface OntologyDisplayStrings extends Messages{
     String treePanelHeader();
 
     String refresh();
+
+    String restoreApp();
+
+    String restoreAppSuccessMsgTitle();
+
+    String restoreAppSuccessMsg(String name, String joinedCatNames);
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
@@ -40,3 +40,6 @@ westPanelHeader = Ontology Editor
 eastPanelHeader = DE Preview
 treePanelHeader = Hierarchies
 refresh = Refresh Preview
+restoreApp = Restore App
+restoreAppSuccessMsg = "{0}" is restored into following hierarchy(ies)\: "{1}"
+restoreAppSuccessMsgTitle = App Restored


### PR DESCRIPTION
This PR enables the admin to restore apps that have been deleted in Belphegor.  This is done by adding a fake hierarchy called "Trash".  Clicking on that hierarchy fetches the list of deleted apps.  From there, the admin can select a deleted app and restore the app using the Restore button.