### PR TITLE
CORE-8110: add a wrapping macro to catch IOExceptions thrown as JargonExceptions in data-info

### DIFF
--- a/services/data-info/src/data_info/services/create.clj
+++ b/services/data-info/src/data_info/services/create.clj
@@ -8,6 +8,7 @@
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [clj-jargon.item-info :as item]
             [clj-jargon.item-ops :as ops]
+            [data-info.util.irods :as irods]
             [data-info.util.config :as cfg]
             [data-info.util.logging :as dul]
             [data-info.util.validators :as validators]))
@@ -34,23 +35,24 @@
    new directories."
   [user paths]
   (log/debug (str "create " user " " paths))
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/validate-num-paths paths)
-    (validators/user-exists cm user)
-    (let [paths (set (map ft/rm-last-slash paths))
-          sorted-paths (map (partial sort-existing cm) paths)
-          target-dirs (set (map first sorted-paths))
-          set-own-paths (set (map (comp last second) sorted-paths))
-          paths-to-mk (sort (set (mapcat second sorted-paths)))]
-      (doseq [target-dir target-dirs]
-        (validators/path-writeable cm user target-dir))
-      (doseq [path paths]
-        ;; Don't attempt to create the parent of a dir that was already created in this request.
-        (when-not (item/exists? cm path)
-          (ops/mkdirs cm path)))
-      (doseq [new-parent-dir set-own-paths]
-        (set-owner cm new-parent-dir user))
-      {:paths paths-to-mk})))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/validate-num-paths paths)
+      (validators/user-exists cm user)
+      (let [paths (set (map ft/rm-last-slash paths))
+            sorted-paths (map (partial sort-existing cm) paths)
+            target-dirs (set (map first sorted-paths))
+            set-own-paths (set (map (comp last second) sorted-paths))
+            paths-to-mk (sort (set (mapcat second sorted-paths)))]
+        (doseq [target-dir target-dirs]
+          (validators/path-writeable cm user target-dir))
+        (doseq [path paths]
+          ;; Don't attempt to create the parent of a dir that was already created in this request.
+          (when-not (item/exists? cm path)
+            (ops/mkdirs cm path)))
+        (doseq [new-parent-dir set-own-paths]
+          (set-owner cm new-parent-dir user))
+        {:paths paths-to-mk}))))
 
 (defn do-create
   "Entrypoint for the API that calls (create)."

--- a/services/data-info/src/data_info/services/directory.clj
+++ b/services/data-info/src/data_info/services/directory.clj
@@ -52,15 +52,16 @@
 (defn- list-directories
   "Lists the directories contained under path."
   [user path]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (validators/path-exists cm path)
-    (validators/path-readable cm user path)
-    (validators/path-is-dir cm path)
-    (-> (stat/path-stat cm user path)
-        (select-keys [:id :label :path :date-created :date-modified :permission])
-        (assoc :folders (map (partial fmt-folder user)
-                             (icat/list-folders-in-folder user (cfg/irods-zone) path))))))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/user-exists cm user)
+      (validators/path-exists cm path)
+      (validators/path-readable cm user path)
+      (validators/path-is-dir cm path)
+      (-> (stat/path-stat cm user path)
+          (select-keys [:id :label :path :date-created :date-modified :permission])
+          (assoc :folders (map (partial fmt-folder user)
+                               (icat/list-folders-in-folder user (cfg/irods-zone) path)))))))
 
 
 (defn do-directory

--- a/services/data-info/src/data_info/services/directory.clj
+++ b/services/data-info/src/data_info/services/directory.clj
@@ -1,7 +1,6 @@
 (ns data-info.services.directory
   (:require [dire.core :refer [with-pre-hook! with-post-hook!]]
             [clj-icat-direct.icat :as icat]
-            [clj-jargon.init :refer [with-jargon]]
             [clj-jargon.permissions :as perm]
             [data-info.services.stat :as stat]
             [data-info.util.config :as cfg]
@@ -52,16 +51,15 @@
 (defn- list-directories
   "Lists the directories contained under path."
   [user path]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (validators/path-exists cm path)
-      (validators/path-readable cm user path)
-      (validators/path-is-dir cm path)
-      (-> (stat/path-stat cm user path)
-          (select-keys [:id :label :path :date-created :date-modified :permission])
-          (assoc :folders (map (partial fmt-folder user)
-                               (icat/list-folders-in-folder user (cfg/irods-zone) path)))))))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (validators/path-exists cm path)
+    (validators/path-readable cm user path)
+    (validators/path-is-dir cm path)
+    (-> (stat/path-stat cm user path)
+        (select-keys [:id :label :path :date-created :date-modified :permission])
+        (assoc :folders (map (partial fmt-folder user)
+                             (icat/list-folders-in-folder user (cfg/irods-zone) path))))))
 
 
 (defn do-directory

--- a/services/data-info/src/data_info/services/entry.clj
+++ b/services/data-info/src/data_info/services/entry.clj
@@ -4,7 +4,6 @@
   (:require [me.raynes.fs :as fs]
             [clj-icat-direct.icat :as icat]
             [clj-jargon.by-uuid :as uuid]
-            [clj-jargon.init :as init]
             [clj-jargon.item-info :as item]
             [clj-jargon.item-ops :as ops]
             [clj-jargon.permissions :as perm]
@@ -24,15 +23,14 @@
 (defn id-entry
   [url-id user]
   (try
-    (irods/catch-jargon-io-exceptions
-      (init/with-jargon (cfg/jargon-cfg) [cm]
-        (if-not (user/user-exists? cm user)
-          (http-response/unprocessable-entity)
-          (if-let [path (uuid/get-path cm url-id)]
-            (if (perm/is-readable? cm user path)
-              (http-response/ok)
-              (http-response/forbidden))
-            (http-response/not-found)))))
+    (irods/with-jargon-exceptions [cm]
+      (if-not (user/user-exists? cm user)
+        (http-response/unprocessable-entity)
+        (if-let [path (uuid/get-path cm url-id)]
+          (if (perm/is-readable? cm user path)
+            (http-response/ok)
+            (http-response/forbidden))
+          (http-response/not-found))))
     (catch IllegalArgumentException _
       (http-response/unprocessable-entity))))
 
@@ -40,11 +38,10 @@
 ;; file specific
 
 (defn- get-file
-  [path]
-  (init/with-jargon (cfg/jargon-cfg) [irods]
-    (if (zero? (item/file-size irods path))
-      ""
-      (ops/input-stream irods path))))
+  [irods path]
+  (if (zero? (item/file-size irods path))
+    ""
+    (ops/input-stream irods path)))
 
 (defn- file-entry
   [cm path {:keys [attachment]}]
@@ -53,7 +50,7 @@
                       (str "attachment; filename=" filename)
                       (str "filename=" filename))
         media-type  (irods/detect-media-type cm path)]
-    (assoc (http-response/ok (get-file path))
+    (assoc (http-response/ok (get-file cm path))
            :headers {"Content-Type"        media-type
                      "Content-Disposition" disposition})))
 
@@ -251,9 +248,8 @@
 
 (defn dispatch-path-to-resource
   [zone path-in-zone {:keys [user] :as params}]
-  (irods/catch-jargon-io-exceptions
-    (init/with-jargon (cfg/jargon-cfg) [cm]
-      (let [{:keys [path is-dir?]} (get-path-attrs cm zone path-in-zone user)]
-        (if is-dir?
-          (folder-entry cm path params)
-          (file-entry cm path params))))))
+  (irods/with-jargon-exceptions [cm]
+    (let [{:keys [path is-dir?]} (get-path-attrs cm zone path-in-zone user)]
+      (if is-dir?
+        (folder-entry cm path params)
+        (file-entry cm path params)))))

--- a/services/data-info/src/data_info/services/exists.clj
+++ b/services/data-info/src/data_info/services/exists.clj
@@ -5,6 +5,7 @@
             [clj-jargon.permissions :as perm]
             [clojure-commons.file-utils :as ft]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.logging :as log]
             [data-info.util.validators :as duv]))
 
@@ -16,9 +17,10 @@
 
 (defn do-exists
   [{user :user} {paths :paths}]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (duv/user-exists cm user)
-    {:paths (into {} (map (juxt keyword (partial path-exists-for-user? cm user)) (set paths)))}))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (duv/user-exists cm user)
+      {:paths (into {} (map (juxt keyword (partial path-exists-for-user? cm user)) (set paths)))})))
 
 (with-pre-hook! #'do-exists
   (fn [params body]

--- a/services/data-info/src/data_info/services/exists.clj
+++ b/services/data-info/src/data_info/services/exists.clj
@@ -1,10 +1,8 @@
 (ns data-info.services.exists
   (:require [dire.core :refer [with-pre-hook! with-post-hook!]]
-            [clj-jargon.init :refer [with-jargon]]
             [clj-jargon.item-info :as item]
             [clj-jargon.permissions :as perm]
             [clojure-commons.file-utils :as ft]
-            [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.logging :as log]
             [data-info.util.validators :as duv]))
@@ -17,10 +15,9 @@
 
 (defn do-exists
   [{user :user} {paths :paths}]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (duv/user-exists cm user)
-      {:paths (into {} (map (juxt keyword (partial path-exists-for-user? cm user)) (set paths)))})))
+  (irods/with-jargon-exceptions [cm]
+    (duv/user-exists cm user)
+    {:paths (into {} (map (juxt keyword (partial path-exists-for-user? cm user)) (set paths)))}))
 
 (with-pre-hook! #'do-exists
   (fn [params body]

--- a/services/data-info/src/data_info/services/filetypes.clj
+++ b/services/data-info/src/data_info/services/filetypes.clj
@@ -1,6 +1,5 @@
 (ns data-info.services.filetypes
-  (:use [clj-jargon.init :only [with-jargon]]
-        [clj-jargon.metadata])
+  (:use [clj-jargon.metadata])
   (:require [heuristomancer.core :as hm]
             [clojure.string :as string]
             [data-info.util.config :as cfg]
@@ -20,33 +19,31 @@
 (defn- add-type
   "Adds the type to a file in iRODS at path for the specified user."
   [user path type]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/path-exists cm path)
-      (validators/user-exists cm user)
-      (validators/user-owns-path cm user path)
-      (validators/path-is-file cm path)
+  (irods/with-jargon-exceptions [cm]
+    (validators/path-exists cm path)
+    (validators/user-exists cm user)
+    (validators/user-owns-path cm user path)
+    (validators/path-is-file cm path)
 
-      (set-metadata cm path (cfg/type-detect-type-attribute) type "")
-      {:path path
-       :type type
-       :user user})))
+    (set-metadata cm path (cfg/type-detect-type-attribute) type "")
+    {:path path
+     :type type
+     :user user}))
 
 (defn- unset-types
   "Removes all info-type associations from a path."
   [user path]
 
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/path-exists cm path)
-      (validators/user-exists cm user)
-      (validators/user-owns-path cm user path)
+  (irods/with-jargon-exceptions [cm]
+    (validators/path-exists cm path)
+    (validators/user-exists cm user)
+    (validators/user-owns-path cm user path)
 
-      (if (attribute? cm path (cfg/type-detect-type-attribute))
-        (delete-metadata cm path (cfg/type-detect-type-attribute)))
-      {:path path
-       :type ""
-       :user user})))
+    (if (attribute? cm path (cfg/type-detect-type-attribute))
+      (delete-metadata cm path (cfg/type-detect-type-attribute)))
+    {:path path
+     :type ""
+     :user user}))
 
 (defn- add-type-path
   [user path type]

--- a/services/data-info/src/data_info/services/filetypes.clj
+++ b/services/data-info/src/data_info/services/filetypes.clj
@@ -4,6 +4,7 @@
   (:require [heuristomancer.core :as hm]
             [clojure.string :as string]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.logging :as dul]
             [data-info.util.validators :as validators]
             [clojure-commons.file-utils :as ft]
@@ -19,31 +20,33 @@
 (defn- add-type
   "Adds the type to a file in iRODS at path for the specified user."
   [user path type]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/path-exists cm path)
-    (validators/user-exists cm user)
-    (validators/user-owns-path cm user path)
-    (validators/path-is-file cm path)
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/path-exists cm path)
+      (validators/user-exists cm user)
+      (validators/user-owns-path cm user path)
+      (validators/path-is-file cm path)
 
-    (set-metadata cm path (cfg/type-detect-type-attribute) type "")
-    {:path path
-     :type type
-     :user user}))
+      (set-metadata cm path (cfg/type-detect-type-attribute) type "")
+      {:path path
+       :type type
+       :user user})))
 
 (defn- unset-types
   "Removes all info-type associations from a path."
   [user path]
 
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/path-exists cm path)
-    (validators/user-exists cm user)
-    (validators/user-owns-path cm user path)
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/path-exists cm path)
+      (validators/user-exists cm user)
+      (validators/user-owns-path cm user path)
 
-    (if (attribute? cm path (cfg/type-detect-type-attribute))
-      (delete-metadata cm path (cfg/type-detect-type-attribute)))
-    {:path path
-     :type ""
-     :user user}))
+      (if (attribute? cm path (cfg/type-detect-type-attribute))
+        (delete-metadata cm path (cfg/type-detect-type-attribute)))
+      {:path path
+       :type ""
+       :user user})))
 
 (defn- add-type-path
   [user path type]

--- a/services/data-info/src/data_info/services/home.clj
+++ b/services/data-info/src/data_info/services/home.clj
@@ -13,12 +13,13 @@
 (defn- user-home-path
   [user]
   (let [user-home (path/user-home-dir user)]
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (when-not (exists? cm user-home)
-        (mkdirs cm user-home))
-      (-> (stat/path-stat cm user user-home)
-          (select-keys [:id :label :path :date-created :date-modified :permission])))))
+    (irods/catch-jargon-io-exceptions
+      (with-jargon (cfg/jargon-cfg) [cm]
+        (validators/user-exists cm user)
+        (when-not (exists? cm user-home)
+          (mkdirs cm user-home))
+        (-> (stat/path-stat cm user user-home)
+            (select-keys [:id :label :path :date-created :date-modified :permission]))))))
 
 (defn do-homedir
   [{user :user}]

--- a/services/data-info/src/data_info/services/home.clj
+++ b/services/data-info/src/data_info/services/home.clj
@@ -1,10 +1,8 @@
 (ns data-info.services.home
   (:require [dire.core :refer [with-pre-hook! with-post-hook!]]
-            [clj-jargon.init :refer [with-jargon]]
             [clj-jargon.item-info :refer [exists?]]
             [clj-jargon.item-ops :refer [mkdirs]]
             [data-info.services.stat :as stat]
-            [data-info.util.config :as cfg]
             [data-info.util.logging :as log]
             [data-info.util.irods :as irods]
             [data-info.util.validators :as validators]
@@ -13,13 +11,12 @@
 (defn- user-home-path
   [user]
   (let [user-home (path/user-home-dir user)]
-    (irods/catch-jargon-io-exceptions
-      (with-jargon (cfg/jargon-cfg) [cm]
-        (validators/user-exists cm user)
-        (when-not (exists? cm user-home)
-          (mkdirs cm user-home))
-        (-> (stat/path-stat cm user user-home)
-            (select-keys [:id :label :path :date-created :date-modified :permission]))))))
+    (irods/with-jargon-exceptions [cm]
+      (validators/user-exists cm user)
+      (when-not (exists? cm user-home)
+        (mkdirs cm user-home))
+      (-> (stat/path-stat cm user user-home)
+          (select-keys [:id :label :path :date-created :date-modified :permission])))))
 
 (defn do-homedir
   [{user :user}]

--- a/services/data-info/src/data_info/services/manifest.clj
+++ b/services/data-info/src/data_info/services/manifest.clj
@@ -68,9 +68,10 @@
 
 (defn do-manifest-uuid
   [user data-id]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (let [file (uuids/path-stat-for-uuid cm user data-id)]
-      (manifest cm user file))))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (let [file (uuids/path-stat-for-uuid cm user data-id)]
+        (manifest cm user file)))))
 
 (with-pre-hook! #'do-manifest-uuid
   (fn [user data-id]

--- a/services/data-info/src/data_info/services/manifest.clj
+++ b/services/data-info/src/data_info/services/manifest.clj
@@ -1,6 +1,5 @@
 (ns data-info.services.manifest
   (:use [data-info.services.sharing :only [anon-file-url anon-readable?]]
-        [clj-jargon.init :only [with-jargon]]
         [clj-jargon.metadata :only [get-attribute attribute?]]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [clojure.tools.logging :as log]
@@ -68,10 +67,9 @@
 
 (defn do-manifest-uuid
   [user data-id]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (let [file (uuids/path-stat-for-uuid cm user data-id)]
-        (manifest cm user file)))))
+  (irods/with-jargon-exceptions [cm]
+    (let [file (uuids/path-stat-for-uuid cm user data-id)]
+      (manifest cm user file))))
 
 (with-pre-hook! #'do-manifest-uuid
   (fn [user data-id]

--- a/services/data-info/src/data_info/services/metadata.clj
+++ b/services/data-info/src/data_info/services/metadata.clj
@@ -1,7 +1,6 @@
 (ns data-info.services.metadata
   (:use [clojure-commons.error-codes]
         [clojure-commons.validators]
-        [clj-jargon.init :only [with-jargon]]
         [clj-jargon.item-ops :only [copy-stream input-stream]]
         [clj-jargon.metadata]
         [kameleon.uuids :only [uuidify]]
@@ -81,14 +80,13 @@
    if :system true is not passed to it, and replaces
    units set to ipc-reserved with an empty string."
   [user data-id & {:keys [system] :or {system false}}]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (let [{:keys [path type]} (get-readable-data-item cm user data-id)
-            metadata-response   (metadata/list-avus user (resolve-data-type type) data-id :as :json)]
-        (merge (:body metadata-response)
-               {:irods-avus (list-path-metadata cm path :system system)
-                :path       path})))))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (let [{:keys [path type]} (get-readable-data-item cm user data-id)
+          metadata-response   (metadata/list-avus user (resolve-data-type type) data-id :as :json)]
+      (merge (:body metadata-response)
+             {:irods-avus (list-path-metadata cm path :system system)
+              :path       path}))))
 
 (defn admin-metadata-get
   "Lists metadata for a path, showing all AVUs."
@@ -150,20 +148,19 @@
    in addition to the 'irods-avus' key.
    Pass :system true to ignore restrictions on AVUs which may be added."
   [user data-id {:keys [irods-avus] :as metadata} & {:keys [system] :or {system false}}]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (let [{:keys [path type]} (get-readable-data-item cm user data-id)
-            path (ft/rm-last-slash path)
-            metadata (dissoc metadata :irods-avus)]
-        (validators/path-writeable cm user path)
-        (when-not system (authorized-avus irods-avus))
-        (when-not (empty? metadata)
-          (metadata/update-avus user (resolve-data-type type) data-id (json/encode metadata)))
-        (doseq [avu-map irods-avus]
-          (common-metadata-add cm path avu-map))
-        {:path path
-         :user user}))))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (let [{:keys [path type]} (get-readable-data-item cm user data-id)
+          path (ft/rm-last-slash path)
+          metadata (dissoc metadata :irods-avus)]
+      (validators/path-writeable cm user path)
+      (when-not system (authorized-avus irods-avus))
+      (when-not (empty? metadata)
+        (metadata/update-avus user (resolve-data-type type) data-id (json/encode metadata)))
+      (doseq [avu-map irods-avus]
+        (common-metadata-add cm path avu-map))
+      {:path path
+       :user user})))
 
 (defn admin-metadata-add
   "Adds AVUs to path, bypassing user permission checks. See (metadata-add)
@@ -177,25 +174,24 @@
    The 'metadata' parameter should be in a format expected by the metadata service set AVUs endpoint,
    with an 'irods-avus' key following the format used for (metadata-add)."
   [user data-id {:keys [irods-avus] :as metadata}]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (let [{:keys [path type]} (uuids/path-stat-for-uuid cm user data-id)
-            irods-avus (set (map #(select-keys % [:attr :value :unit]) irods-avus))
-            current-avus (set (list-path-metadata cm path :system false))
-            delete-irods-avus (s/difference current-avus irods-avus)
-            metadata-request (json/encode (dissoc metadata :irods-avus))]
-        (validators/path-writeable cm user path)
-        (authorized-avus irods-avus)
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (let [{:keys [path type]} (uuids/path-stat-for-uuid cm user data-id)
+          irods-avus (set (map #(select-keys % [:attr :value :unit]) irods-avus))
+          current-avus (set (list-path-metadata cm path :system false))
+          delete-irods-avus (s/difference current-avus irods-avus)
+          metadata-request (json/encode (dissoc metadata :irods-avus))]
+      (validators/path-writeable cm user path)
+      (authorized-avus irods-avus)
 
-        (metadata/set-avus user (resolve-data-type type) data-id metadata-request)
-        (doseq [del-avu delete-irods-avus]
-          (common-metadata-delete cm path del-avu))
-        (doseq [avu irods-avus]
-          (common-metadata-add cm path avu))
+      (metadata/set-avus user (resolve-data-type type) data-id metadata-request)
+      (doseq [del-avu delete-irods-avus]
+        (common-metadata-delete cm path del-avu))
+      (doseq [avu irods-avus]
+        (common-metadata-add cm path avu))
 
-        {:path path
-         :user user}))))
+      {:path path
+       :user user})))
 
 (defn- format-copy-dest-item
   [{:keys [id type]}]
@@ -215,23 +211,22 @@
    src-id to the items with dest-ids. When the 'force?' parameter is false or not set, additional
    validation is performed."
   [user src-id dest-ids]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (let [{:keys [path type]} (get-readable-data-item cm user src-id)
-            dest-items (get-writable-data-items cm user dest-ids)
-            dest-paths (map :path dest-items)
-            dest-ids (map :id dest-items)
-            irods-avus (list-path-metadata cm path)]
-        (metadata/copy-metadata-avus user
-                                     (resolve-data-type type)
-                                     src-id
-                                     (map format-copy-dest-item dest-items))
-        (doseq [dest-id dest-ids]
-          (metadata-add user dest-id {:irods-avus irods-avus}))
-        {:user  user
-         :src   path
-         :paths dest-paths}))))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (let [{:keys [path type]} (get-readable-data-item cm user src-id)
+          dest-items (get-writable-data-items cm user dest-ids)
+          dest-paths (map :path dest-items)
+          dest-ids (map :id dest-items)
+          irods-avus (list-path-metadata cm path)]
+      (metadata/copy-metadata-avus user
+                                   (resolve-data-type type)
+                                   src-id
+                                   (map format-copy-dest-item dest-items))
+      (doseq [dest-id dest-ids]
+        (metadata-add user dest-id {:irods-avus irods-avus}))
+      {:user  user
+       :src   path
+       :paths dest-paths})))
 
 (defn- stat-is-dir?
   [{:keys [type]}]
@@ -272,21 +267,20 @@
   "Allows a user to export metadata from a file or folder with the given data-id to a file specified
    by dest."
   [user data-id dest recursive?]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (let [dest-dir (ft/dirname dest)
-            src-data (uuids/path-stat-for-uuid cm user data-id)
-            src-path (:path src-data)]
-        (validators/path-readable cm user src-path)
-        (validators/path-exists cm dest-dir)
-        (validators/path-writeable cm user dest-dir)
-        (validators/path-not-exists cm dest)
-        (when recursive?
-          (validators/validate-num-paths-under-folder user src-path))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (let [dest-dir (ft/dirname dest)
+          src-data (uuids/path-stat-for-uuid cm user data-id)
+          src-path (:path src-data)]
+      (validators/path-readable cm user src-path)
+      (validators/path-exists cm dest-dir)
+      (validators/path-writeable cm user dest-dir)
+      (validators/path-not-exists cm dest)
+      (when recursive?
+        (validators/validate-num-paths-under-folder user src-path))
 
-        (with-in-str (build-metadata-for-save cm user src-data recursive?)
-          {:file (stat/decorate-stat cm user (copy-stream cm *in* user dest))})))))
+      (with-in-str (build-metadata-for-save cm user src-data recursive?)
+        {:file (stat/decorate-stat cm user (copy-stream cm *in* user dest))}))))
 
 (defn do-metadata-save
   "Entrypoint for the API. Calls (metadata-save)."
@@ -328,15 +322,14 @@
 (defn- parse-metadata-csv
   "Parses paths and metadata to apply from a source CSV file in the data store"
   [user dest-id ^String separator src-path]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (let [dest-dir (:path (get-readable-data-item cm user dest-id))
-            csv (get-csv cm src-path separator)
-            attrs (set (-> csv first rest))
-            csv-path-values (rest csv)]
-        {:path-metadata
-         (bulk-add-avus cm user dest-dir attrs csv-path-values)}))))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (let [dest-dir (:path (get-readable-data-item cm user dest-id))
+          csv (get-csv cm src-path separator)
+          attrs (set (-> csv first rest))
+          csv-path-values (rest csv)]
+      {:path-metadata
+       (bulk-add-avus cm user dest-dir attrs csv-path-values)})))
 
 (defn parse-metadata-csv-file
   "Parses paths and metadata to apply from a source CSV file in the data store"

--- a/services/data-info/src/data_info/services/page_file.clj
+++ b/services/data-info/src/data_info/services/page_file.clj
@@ -8,23 +8,25 @@
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [data-info.services.uuids :as uuids]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.logging :as dul]
             [data-info.util.validators :as validators]))
 
 (defn- read-file-chunk
   "Reads a chunk of a file starting at 'position' and reading a chunk of length 'chunk-size'."
   [user path position chunk-size]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (validators/path-exists cm path)
-    (validators/path-is-file cm path)
-    (validators/path-readable cm user path)
-    {:path       path
-     :user       user
-     :start      (str position)
-     :chunk-size (str chunk-size)
-     :file-size  (str (file-size cm path))
-     :chunk      (read-at-position cm path position chunk-size)}))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/user-exists cm user)
+      (validators/path-exists cm path)
+      (validators/path-is-file cm path)
+      (validators/path-readable cm user path)
+      {:path       path
+       :user       user
+       :start      (str position)
+       :chunk-size (str chunk-size)
+       :file-size  (str (file-size cm path))
+       :chunk      (read-at-position cm path position chunk-size)})))
 
 (defn do-read-chunk
   [{user :user position :position chunk-size :size} data-id]

--- a/services/data-info/src/data_info/services/page_file.clj
+++ b/services/data-info/src/data_info/services/page_file.clj
@@ -1,13 +1,11 @@
 (ns data-info.services.page-file
-  (:use [clj-jargon.init :only [with-jargon]]
-        [clj-jargon.item-info]
+  (:use [clj-jargon.item-info]
         [clj-jargon.paging]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [clojure.tools.logging :as log]
             [clojure-commons.file-utils :as ft]
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [data-info.services.uuids :as uuids]
-            [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.logging :as dul]
             [data-info.util.validators :as validators]))
@@ -15,18 +13,17 @@
 (defn- read-file-chunk
   "Reads a chunk of a file starting at 'position' and reading a chunk of length 'chunk-size'."
   [user path position chunk-size]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (validators/path-exists cm path)
-      (validators/path-is-file cm path)
-      (validators/path-readable cm user path)
-      {:path       path
-       :user       user
-       :start      (str position)
-       :chunk-size (str chunk-size)
-       :file-size  (str (file-size cm path))
-       :chunk      (read-at-position cm path position chunk-size)})))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (validators/path-exists cm path)
+    (validators/path-is-file cm path)
+    (validators/path-readable cm user path)
+    {:path       path
+     :user       user
+     :start      (str position)
+     :chunk-size (str chunk-size)
+     :file-size  (str (file-size cm path))
+     :chunk      (read-at-position cm path position chunk-size)}))
 
 (defn do-read-chunk
   [{user :user position :position chunk-size :size} data-id]

--- a/services/data-info/src/data_info/services/page_tabular.clj
+++ b/services/data-info/src/data_info/services/page_tabular.clj
@@ -13,6 +13,7 @@
             [data-info.services.uuids :as uuids]
             [data-info.util.logging :as dul]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.validators :as validators])
   (:import [au.com.bytecode.opencsv CSVReader]
            [java.io InputStream]))
@@ -88,38 +89,39 @@
    we shouldn't try to parse partial rows. We scan forward from the starting position to find the first
    line-ending and then scan backwards from the last position for the last line-ending."
   [user path page chunk-size separator]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (log/warn "[read-csv-chunk]" user path page chunk-size separator)
-    (validators/user-exists cm user)
-    (validators/path-exists cm path)
-    (validators/path-is-file cm path)
-    (validators/path-readable cm user path)
-    (let [page            (dec page)
-          start-pg        (if (= page 0) 0 (dec page))
-          full-chunk-size (calc-chunk-size page chunk-size)
-          fsize           (file-size cm path)
-          pages           (num-pages chunk-size fsize)
-          position        (start-pos page chunk-size)
-          load-pos        (start-pos start-pg chunk-size)]
-      (log/debug "reading from" load-pos "for" full-chunk-size)
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (log/warn "[read-csv-chunk]" user path page chunk-size separator)
+      (validators/user-exists cm user)
+      (validators/path-exists cm path)
+      (validators/path-is-file cm path)
+      (validators/path-readable cm user path)
+      (let [page            (dec page)
+            start-pg        (if (= page 0) 0 (dec page))
+            full-chunk-size (calc-chunk-size page chunk-size)
+            fsize           (file-size cm path)
+            pages           (num-pages chunk-size fsize)
+            position        (start-pos page chunk-size)
+            load-pos        (start-pos start-pg chunk-size)]
+        (log/debug "reading from" load-pos "for" full-chunk-size)
 
-      (when-not (<= page pages)
-        (throw+ {:error_code   "ERR_INVALID_PAGE"
-                 :page         (str page)
-                 :number-pages (str pages)}))
+        (when-not (<= page pages)
+          (throw+ {:error_code   "ERR_INVALID_PAGE"
+                   :page         (str page)
+                   :number-pages (str pages)}))
 
-      (let [^String chunk   (trim-chunk (read-at-position cm path load-pos full-chunk-size) chunk-size page pages)
-                    the-csv (read-csv chunk separator)]
-        (log/debug "trimmed chunk for page" (inc page) ":" chunk)
-        (log/debug "parsed csv" the-csv)
-        {:path         path
-         :page         (str (inc page))
-         :number-pages (str pages)
-         :user         user
-         :max-cols     (str (reduce #(if (>= %1 %2) %1 %2) (map count the-csv)))
-         :chunk-size   (str (count (.getBytes chunk)))
-         :file-size    (str fsize)
-         :csv          the-csv}))))
+        (let [^String chunk   (trim-chunk (read-at-position cm path load-pos full-chunk-size) chunk-size page pages)
+                      the-csv (read-csv chunk separator)]
+          (log/debug "trimmed chunk for page" (inc page) ":" chunk)
+          (log/debug "parsed csv" the-csv)
+          {:path         path
+           :page         (str (inc page))
+           :number-pages (str pages)
+           :user         user
+           :max-cols     (str (reduce #(if (>= %1 %2) %1 %2) (map count the-csv)))
+           :chunk-size   (str (count (.getBytes chunk)))
+           :file-size    (str fsize)
+           :csv          the-csv})))))
 
 (with-pre-hook! #'read-csv-chunk
   (fn [user path page chunk-size separator]

--- a/services/data-info/src/data_info/services/permissions.clj
+++ b/services/data-info/src/data_info/services/permissions.clj
@@ -1,5 +1,4 @@
 (ns data-info.services.permissions
-  (:use [clj-jargon.init :only [with-jargon]])
   (:require [clojure.tools.logging :as log]
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [clj-jargon.permissions :as perm]
@@ -24,12 +23,11 @@
 
 (defn list-permissions
   [{:keys [user]} data-id]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
-        (validators/user-exists cm user)
-        (validators/path-readable cm user path)
-        (list-permissions* cm user path)))))
+  (irods/with-jargon-exceptions [cm]
+    (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
+      (validators/user-exists cm user)
+      (validators/path-readable cm user path)
+      (list-permissions* cm user path))))
 
 (with-pre-hook! #'list-permissions
   (fn [params data-id]
@@ -39,14 +37,13 @@
 
 (defn add-permission
   [{:keys [user]} data-id share-with permission]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
-        (validators/user-exists cm user)
-        (validators/user-owns-path cm user path)
-        (validators/user-exists cm share-with)
-        (sharing/share-path cm user share-with path permission)
-        (list-permissions* cm user path)))))
+  (irods/with-jargon-exceptions [cm]
+    (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
+      (validators/user-exists cm user)
+      (validators/user-owns-path cm user path)
+      (validators/user-exists cm share-with)
+      (sharing/share-path cm user share-with path permission)
+      (list-permissions* cm user path))))
 
 (with-pre-hook! #'add-permission
   (fn [params data-id share-with permission]
@@ -56,14 +53,13 @@
 
 (defn remove-permission
   [{:keys [user]} data-id unshare-with]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
-        (validators/user-exists cm user)
-        (validators/user-owns-path cm user path)
-        (validators/user-exists cm unshare-with)
-        (sharing/unshare-path cm user unshare-with path)
-        (list-permissions* cm user path)))))
+  (irods/with-jargon-exceptions [cm]
+    (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
+      (validators/user-exists cm user)
+      (validators/user-owns-path cm user path)
+      (validators/user-exists cm unshare-with)
+      (sharing/unshare-path cm user unshare-with path)
+      (list-permissions* cm user path))))
 
 (with-pre-hook! #'remove-permission
   (fn [params data-id unshare-with]

--- a/services/data-info/src/data_info/services/permissions.clj
+++ b/services/data-info/src/data_info/services/permissions.clj
@@ -7,6 +7,7 @@
             [data-info.services.sharing :as sharing]
             [data-info.services.uuids :as uuids]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.logging :as dul]
             [data-info.util.validators :as validators]))
 
@@ -23,11 +24,12 @@
 
 (defn list-permissions
   [{:keys [user]} data-id]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
-      (validators/user-exists cm user)
-      (validators/path-readable cm user path)
-      (list-permissions* cm user path))))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
+        (validators/user-exists cm user)
+        (validators/path-readable cm user path)
+        (list-permissions* cm user path)))))
 
 (with-pre-hook! #'list-permissions
   (fn [params data-id]
@@ -37,13 +39,14 @@
 
 (defn add-permission
   [{:keys [user]} data-id share-with permission]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
-      (validators/user-exists cm user)
-      (validators/user-owns-path cm user path)
-      (validators/user-exists cm share-with)
-      (sharing/share-path cm user share-with path permission)
-      (list-permissions* cm user path))))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
+        (validators/user-exists cm user)
+        (validators/user-owns-path cm user path)
+        (validators/user-exists cm share-with)
+        (sharing/share-path cm user share-with path permission)
+        (list-permissions* cm user path)))))
 
 (with-pre-hook! #'add-permission
   (fn [params data-id share-with permission]
@@ -53,13 +56,14 @@
 
 (defn remove-permission
   [{:keys [user]} data-id unshare-with]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
-      (validators/user-exists cm user)
-      (validators/user-owns-path cm user path)
-      (validators/user-exists cm unshare-with)
-      (sharing/unshare-path cm user unshare-with path)
-      (list-permissions* cm user path))))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (let [path (ft/rm-last-slash (uuids/path-for-uuid user data-id))]
+        (validators/user-exists cm user)
+        (validators/user-owns-path cm user path)
+        (validators/user-exists cm unshare-with)
+        (sharing/unshare-path cm user unshare-with path)
+        (list-permissions* cm user path)))))
 
 (with-pre-hook! #'remove-permission
   (fn [params data-id unshare-with]

--- a/services/data-info/src/data_info/services/rename.clj
+++ b/services/data-info/src/data_info/services/rename.clj
@@ -9,6 +9,7 @@
             [data-info.services.uuids :as uuids]
             [data-info.services.directory :as directory]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.logging :as dul]
             [data-info.util.validators :as validators]))
 
@@ -19,48 +20,50 @@
 (defn- move-paths
   "As 'user', moves directories listed in 'sources' into the directory listed in 'dest'."
   [user sources dest]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (let [all-paths  (apply merge (mapv #(hash-map (source->dest %1 dest) %1) sources))
-          dest-paths (keys all-paths)
-          sources    (mapv ft/rm-last-slash sources)
-          dest       (ft/rm-last-slash dest)]
-      (validators/user-exists cm user)
-      (validators/all-paths-exist cm sources)
-      (validators/all-paths-exist cm [dest])
-      (validators/path-is-dir cm dest)
-      (validators/user-owns-paths cm user sources)
-      (validators/path-writeable cm user dest)
-      (validators/no-paths-exist cm dest-paths)
-      (move-all cm sources dest :user user :admin-users (cfg/irods-admins))
-      {:user user :sources sources :dest dest})))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (let [all-paths  (apply merge (mapv #(hash-map (source->dest %1 dest) %1) sources))
+            dest-paths (keys all-paths)
+            sources    (mapv ft/rm-last-slash sources)
+            dest       (ft/rm-last-slash dest)]
+        (validators/user-exists cm user)
+        (validators/all-paths-exist cm sources)
+        (validators/all-paths-exist cm [dest])
+        (validators/path-is-dir cm dest)
+        (validators/user-owns-paths cm user sources)
+        (validators/path-writeable cm user dest)
+        (validators/no-paths-exist cm dest-paths)
+        (move-all cm sources dest :user user :admin-users (cfg/irods-admins))
+        {:user user :sources sources :dest dest}))))
 
 (defn- rename-path
   "Data item renaming. As 'user', move 'source' to 'dest'.
 
    If the data item is remaining in the same directory, do not validate if it's writeable."
   [user source dest]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (let [source    (ft/rm-last-slash source)
-          dest      (ft/rm-last-slash dest)
-          src-base  (ft/basename source)
-          dest-base (ft/basename dest)]
-      (if (= source dest)
-        {:source source :dest dest :user user}
-        (do
-          (validators/user-exists cm user)
-          (validators/all-paths-exist cm [source (ft/dirname dest)])
-          (validators/path-is-dir cm (ft/dirname dest))
-          (validators/user-owns-path cm user source)
-          (if-not (= (ft/dirname source) (ft/dirname dest))
-            (validators/path-writeable cm user (ft/dirname dest)))
-          (validators/path-not-exists cm dest)
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (let [source    (ft/rm-last-slash source)
+            dest      (ft/rm-last-slash dest)
+            src-base  (ft/basename source)
+            dest-base (ft/basename dest)]
+        (if (= source dest)
+          {:source source :dest dest :user user}
+          (do
+            (validators/user-exists cm user)
+            (validators/all-paths-exist cm [source (ft/dirname dest)])
+            (validators/path-is-dir cm (ft/dirname dest))
+            (validators/user-owns-path cm user source)
+            (if-not (= (ft/dirname source) (ft/dirname dest))
+              (validators/path-writeable cm user (ft/dirname dest)))
+            (validators/path-not-exists cm dest)
 
-          (let [result (move cm source dest :user user :admin-users (cfg/irods-admins))]
-            (when-not (nil? result)
-              (throw+ {:error_code ERR_INCOMPLETE_RENAME
-                       :paths result
-                       :user user}))
-            {:source source :dest dest :user user}))))))
+            (let [result (move cm source dest :user user :admin-users (cfg/irods-admins))]
+              (when-not (nil? result)
+                (throw+ {:error_code ERR_INCOMPLETE_RENAME
+                         :paths result
+                         :user user}))
+              {:source source :dest dest :user user})))))))
 
 (defn- rename-uuid
   "Rename by UUID: given a user, a source file UUID, and a new name, rename within the same folder."
@@ -96,8 +99,9 @@
   "Rename by UUID: given a user, a source directory UUID, and a new directory, move the directory contents, retaining the filename."
   [user source-uuid dest-dir]
   (let [source (ft/rm-last-slash (uuids/path-for-uuid user source-uuid))]
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/path-is-dir cm source))
+    (irods/catch-jargon-io-exceptions
+      (with-jargon (cfg/jargon-cfg) [cm]
+        (validators/path-is-dir cm source)))
     (let [sources (directory/get-paths-in-folder user source)]
       (move-paths user sources dest-dir))))
 

--- a/services/data-info/src/data_info/services/root.clj
+++ b/services/data-info/src/data_info/services/root.clj
@@ -8,6 +8,7 @@
             [clojure-commons.file-utils :as ft]
             [data-info.services.stat :as stat]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.logging :as dul]
             [data-info.util.paths :as paths]
             [data-info.util.validators :as validators]
@@ -38,13 +39,14 @@
         community-data (ft/rm-last-slash (cfg/community-data))
         irods-home     (ft/rm-last-slash (cfg/irods-home))]
     (log/debug "[root-listing]" "for" user)
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      {:roots (remove nil?
-                [(get-root cm user uhome)
-                 (get-root cm user community-data)
-                 (get-root cm user irods-home)
-                 (make-root cm user utrash)])})))
+    (irods/catch-jargon-io-exceptions
+      (with-jargon (cfg/jargon-cfg) [cm]
+        (validators/user-exists cm user)
+        {:roots (remove nil?
+                  [(get-root cm user uhome)
+                   (get-root cm user community-data)
+                   (get-root cm user irods-home)
+                   (make-root cm user utrash)])}))))
 
 (defn do-root-listing
   [user]

--- a/services/data-info/src/data_info/services/root.clj
+++ b/services/data-info/src/data_info/services/root.clj
@@ -1,6 +1,5 @@
 (ns data-info.services.root
-  (:use [clj-jargon.init :only [with-jargon]]
-        [clj-jargon.item-info :only [exists?]]
+  (:use [clj-jargon.item-info :only [exists?]]
         [clj-jargon.permissions :only [set-permission owns?]])
   (:require [clojure.tools.logging :as log]
             [clj-jargon.item-info :as item]
@@ -39,14 +38,13 @@
         community-data (ft/rm-last-slash (cfg/community-data))
         irods-home     (ft/rm-last-slash (cfg/irods-home))]
     (log/debug "[root-listing]" "for" user)
-    (irods/catch-jargon-io-exceptions
-      (with-jargon (cfg/jargon-cfg) [cm]
-        (validators/user-exists cm user)
-        {:roots (remove nil?
-                  [(get-root cm user uhome)
-                   (get-root cm user community-data)
-                   (get-root cm user irods-home)
-                   (make-root cm user utrash)])}))))
+    (irods/with-jargon-exceptions [cm]
+      (validators/user-exists cm user)
+      {:roots (remove nil?
+                [(get-root cm user uhome)
+                 (get-root cm user community-data)
+                 (get-root cm user irods-home)
+                 (make-root cm user utrash)])})))
 
 (defn do-root-listing
   [user]

--- a/services/data-info/src/data_info/services/sharing.clj
+++ b/services/data-info/src/data_info/services/sharing.clj
@@ -11,6 +11,7 @@
             [data-info.util.logging :as dul]
             [data-info.util.paths :as paths]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.validators :as validators]))
 
 (defn- shared?
@@ -156,14 +157,15 @@
 
 (defn- anon-files
   [user paths]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (validators/all-paths-exist cm paths)
-    (validators/paths-are-files cm paths)
-    (validators/user-owns-paths cm user paths)
-    (log/warn "Giving read access to" (cfg/anon-user) "on:" (string/join " " paths))
-    (share cm user [(cfg/anon-user)] paths :read)
-    {:user user :paths (anon-files-urls paths)}))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/user-exists cm user)
+      (validators/all-paths-exist cm paths)
+      (validators/paths-are-files cm paths)
+      (validators/user-owns-paths cm user paths)
+      (log/warn "Giving read access to" (cfg/anon-user) "on:" (string/join " " paths))
+      (share cm user [(cfg/anon-user)] paths :read)
+      {:user user :paths (anon-files-urls paths)})))
 
 (defn do-anon-files
   [{:keys [user]} {:keys [paths]}]

--- a/services/data-info/src/data_info/services/sharing.clj
+++ b/services/data-info/src/data_info/services/sharing.clj
@@ -1,6 +1,5 @@
 (ns data-info.services.sharing
-  (:use [clj-jargon.init :only [with-jargon]]
-        [clj-jargon.item-info :only [trash-base-dir is-dir?]]
+  (:use [clj-jargon.item-info :only [trash-base-dir is-dir?]]
         [clj-jargon.permissions]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [clojure.tools.logging :as log]
@@ -157,15 +156,14 @@
 
 (defn- anon-files
   [user paths]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (validators/all-paths-exist cm paths)
-      (validators/paths-are-files cm paths)
-      (validators/user-owns-paths cm user paths)
-      (log/warn "Giving read access to" (cfg/anon-user) "on:" (string/join " " paths))
-      (share cm user [(cfg/anon-user)] paths :read)
-      {:user user :paths (anon-files-urls paths)})))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (validators/all-paths-exist cm paths)
+    (validators/paths-are-files cm paths)
+    (validators/user-owns-paths cm user paths)
+    (log/warn "Giving read access to" (cfg/anon-user) "on:" (string/join " " paths))
+    (share cm user [(cfg/anon-user)] paths :read)
+    {:user user :paths (anon-files-urls paths)}))
 
 (defn do-anon-files
   [{:keys [user]} {:keys [paths]}]

--- a/services/data-info/src/data_info/services/stat.clj
+++ b/services/data-info/src/data_info/services/stat.clj
@@ -96,19 +96,20 @@
 
 (defn do-stat
   [{user :user validation :validation-behavior} {paths :paths uuids :ids}]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (validators/all-uuids-exist cm uuids)
-    (let [uuid-paths (map (juxt (comp keyword str) (partial uuid/get-path cm)) uuids)
-          all-paths (into paths (map second uuid-paths))]
-      (validators/all-paths-exist cm all-paths)
-      (case (keyword validation)
-            :own (validators/user-owns-paths cm user all-paths)
-            :write (validators/all-paths-writeable cm user all-paths)
-            :read (validators/all-paths-readable cm user all-paths)
-            (validators/all-paths-readable cm user all-paths))
-      {:paths (into {} (map (juxt keyword (partial path-stat cm user)) paths))
-       :ids (into {} (map (juxt first #(path-stat cm user (second %))) uuid-paths))})))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/user-exists cm user)
+      (validators/all-uuids-exist cm uuids)
+      (let [uuid-paths (map (juxt (comp keyword str) (partial uuid/get-path cm)) uuids)
+            all-paths (into paths (map second uuid-paths))]
+        (validators/all-paths-exist cm all-paths)
+        (case (keyword validation)
+              :own (validators/user-owns-paths cm user all-paths)
+              :write (validators/all-paths-writeable cm user all-paths)
+              :read (validators/all-paths-readable cm user all-paths)
+              (validators/all-paths-readable cm user all-paths))
+        {:paths (into {} (map (juxt keyword (partial path-stat cm user)) paths))
+         :ids (into {} (map (juxt first #(path-stat cm user (second %))) uuid-paths))}))))
 
 (with-pre-hook! #'do-stat
   (fn [params body]

--- a/services/data-info/src/data_info/services/tickets.clj
+++ b/services/data-info/src/data_info/services/tickets.clj
@@ -10,6 +10,7 @@
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [data-info.util.logging :as dul]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.validators :as validators])
   (:import [java.util UUID]))
 
@@ -49,30 +50,32 @@
 
 (defn- add-tickets
   [user paths public?]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (let [new-uuids (gen-uuids cm user (count paths))]
-      (validators/user-exists cm user)
-      (validators/all-paths-exist cm paths)
-      (validators/all-paths-writeable cm user paths)
-      (doseq [[path uuid] (map list paths new-uuids)]
-        (log/warn "[add-tickets] adding ticket for " path "as" uuid)
-        (create-ticket cm (:username cm) path uuid)
-        (when public?
-          (log/warn "[add-tickets] making ticket" uuid "public")
-          (publicize-ticket cm uuid)))
-      {:user    user
-       :tickets (mapv (partial returnable-ticket-map cm) new-uuids)})))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (let [new-uuids (gen-uuids cm user (count paths))]
+        (validators/user-exists cm user)
+        (validators/all-paths-exist cm paths)
+        (validators/all-paths-writeable cm user paths)
+        (doseq [[path uuid] (map list paths new-uuids)]
+          (log/warn "[add-tickets] adding ticket for " path "as" uuid)
+          (create-ticket cm (:username cm) path uuid)
+          (when public?
+            (log/warn "[add-tickets] making ticket" uuid "public")
+            (publicize-ticket cm uuid)))
+        {:user    user
+         :tickets (mapv (partial returnable-ticket-map cm) new-uuids)}))))
 
 (defn- remove-tickets
   [user ticket-ids]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (validators/all-tickets-exist cm user ticket-ids)
-    (let [all-paths (mapv #(.getIrodsAbsolutePath (ticket-by-id cm (:username cm) %)) ticket-ids)]
-      (validators/all-paths-writeable cm user all-paths)
-      (doseq [ticket-id ticket-ids]
-        (delete-ticket cm (:username cm) ticket-id))
-      {:user user :tickets ticket-ids})))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/user-exists cm user)
+      (validators/all-tickets-exist cm user ticket-ids)
+      (let [all-paths (mapv #(.getIrodsAbsolutePath (ticket-by-id cm (:username cm) %)) ticket-ids)]
+        (validators/all-paths-writeable cm user all-paths)
+        (doseq [ticket-id ticket-ids]
+          (delete-ticket cm (:username cm) ticket-id))
+        {:user user :tickets ticket-ids}))))
 
 (defn- tickets-for-path
   [cm path]
@@ -84,12 +87,13 @@
 
 (defn- list-tickets-for-paths
   [user paths]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (validators/all-paths-exist cm paths)
-    (validators/all-paths-readable cm user paths)
-    {:tickets
-     (apply merge (mapv #(hash-map %1 (returnable-tickets-for-path cm %1)) paths))}))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/user-exists cm user)
+      (validators/all-paths-exist cm paths)
+      (validators/all-paths-readable cm user paths)
+      {:tickets
+       (apply merge (mapv #(hash-map %1 (returnable-tickets-for-path cm %1)) paths))})))
 
 (defn do-add-tickets
   [{public? :public user :user} {paths :paths}]

--- a/services/data-info/src/data_info/services/trash.clj
+++ b/services/data-info/src/data_info/services/trash.clj
@@ -1,6 +1,5 @@
 (ns data-info.services.trash
   (:use [clojure-commons.error-codes]
-        [clj-jargon.init :only [with-jargon]]
         [clj-jargon.item-ops]
         [clj-jargon.item-info]
         [clj-jargon.metadata]
@@ -52,9 +51,8 @@
 
 (defn- delete-paths
   ([user paths]
-   (irods/catch-jargon-io-exceptions
-     (with-jargon (cfg/jargon-cfg) [cm]
-       (delete-paths cm user paths))))
+   (irods/with-jargon-exceptions [cm]
+     (delete-paths cm user paths)))
   ([cm user paths]
      (let [paths (mapv ft/rm-last-slash paths)
            trash-paths (atom (hash-map))]
@@ -93,13 +91,12 @@
 (defn- delete-uuid-contents
   "Delete contents by UUID: given a user and a data item UUID, delete the contents, returning a list of filenames deleted."
   [user source-uuid]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (let [source (ft/rm-last-slash (uuids/path-for-uuid cm user source-uuid))]
-        (validators/validate-num-paths-under-folder user source)
-        (validators/path-is-dir cm source)
-        (let [paths (directory/get-paths-in-folder user source)]
-          (delete-paths cm user paths))))))
+  (irods/with-jargon-exceptions [cm]
+    (let [source (ft/rm-last-slash (uuids/path-for-uuid cm user source-uuid))]
+      (validators/validate-num-paths-under-folder user source)
+      (validators/path-is-dir cm source)
+      (let [paths (directory/get-paths-in-folder user source)]
+        (delete-paths cm user paths)))))
 
 (defn- list-in-dir
   [{^IRODSFileSystemAO cm-ao :fileSystemAO :as cm} fixed-path]
@@ -112,15 +109,14 @@
 (defn- delete-trash
   "Permanently delete the contents of a user's trash directory."
   [user]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (let [trash-dir  (paths/user-trash-path user)
-            trash-list (mapv (fn [^IRODSFile file] (.getAbsolutePath file)) (list-in-dir cm (ft/rm-last-slash trash-dir)))]
-        (doseq [trash-path trash-list]
-          (delete cm trash-path true))
-        {:trash trash-dir
-         :paths trash-list}))))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (let [trash-dir  (paths/user-trash-path user)
+          trash-list (mapv (fn [^IRODSFile file] (.getAbsolutePath file)) (list-in-dir cm (ft/rm-last-slash trash-dir)))]
+      (doseq [trash-path trash-list]
+        (delete cm trash-path true))
+      {:trash trash-dir
+       :paths trash-list})))
 
 (defn- restore-to-homedir?
   "Whether to restore a given file to the home directory.
@@ -181,41 +177,40 @@
 
 (defn- restore-path
   [{:keys [user paths user-trash]}]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (let [paths (mapv ft/rm-last-slash paths)]
-        (if (seq paths)
-          (do
-            (validators/user-exists cm user)
-            (validators/all-paths-exist cm paths)
-            (validators/all-paths-writeable cm user paths)
+  (irods/with-jargon-exceptions [cm]
+    (let [paths (mapv ft/rm-last-slash paths)]
+      (if (seq paths)
+        (do
+          (validators/user-exists cm user)
+          (validators/all-paths-exist cm paths)
+          (validators/all-paths-writeable cm user paths)
 
-            (let [retval (atom (hash-map))]
-              (doseq [path paths]
-                (let [fully-restored      (ft/rm-last-slash (restoration-path cm user path))
-                      restored-to-homedir (restore-to-homedir? cm user path)]
-                  (log/warn "Restoring " path " to " fully-restored)
+          (let [retval (atom (hash-map))]
+            (doseq [path paths]
+              (let [fully-restored      (ft/rm-last-slash (restoration-path cm user path))
+                    restored-to-homedir (restore-to-homedir? cm user path)]
+                (log/warn "Restoring " path " to " fully-restored)
 
-                  (validators/path-not-exists cm fully-restored)
-                  (log/warn fully-restored " does not exist. That's good.")
+                (validators/path-not-exists cm fully-restored)
+                (log/warn fully-restored " does not exist. That's good.")
 
-                  (restore-parent-dirs cm user fully-restored)
-                  (log/warn "Done restoring parent dirs for " fully-restored)
+                (restore-parent-dirs cm user fully-restored)
+                (log/warn "Done restoring parent dirs for " fully-restored)
 
-                  (validators/path-writeable cm user (ft/dirname fully-restored))
-                  (log/warn fully-restored "is writeable. That's good.")
+                (validators/path-writeable cm user (ft/dirname fully-restored))
+                (log/warn fully-restored "is writeable. That's good.")
 
-                  (log/warn "Moving " path " to " fully-restored)
-                  (validators/path-not-exists cm fully-restored)
+                (log/warn "Moving " path " to " fully-restored)
+                (validators/path-not-exists cm fully-restored)
 
-                  (log/warn fully-restored " does not exist. That's good.")
-                  (move cm path fully-restored :user user :admin-users (cfg/irods-admins))
-                  (log/warn "Done moving " path " to " fully-restored)
+                (log/warn fully-restored " does not exist. That's good.")
+                (move cm path fully-restored :user user :admin-users (cfg/irods-admins))
+                (log/warn "Done moving " path " to " fully-restored)
 
-                  (swap! retval assoc path {:restored-path fully-restored
-                                            :partial-restore restored-to-homedir})))
-              {:restored @retval}))
-          {:restored {}})))))
+                (swap! retval assoc path {:restored-path fully-restored
+                                          :partial-restore restored-to-homedir})))
+            {:restored @retval}))
+        {:restored {}}))))
 
 (defn do-delete
   [{user :user} {paths :paths}]

--- a/services/data-info/src/data_info/services/users.clj
+++ b/services/data-info/src/data_info/services/users.clj
@@ -4,6 +4,7 @@
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [data-info.services.permissions :as perms]
             [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
             [data-info.util.logging :as dul]
             [data-info.util.validators :as validators]))
 
@@ -14,11 +15,12 @@
 
 (defn- list-perms
   [user abspaths]
-  (with-jargon (cfg/jargon-cfg) [cm]
-    (validators/user-exists cm user)
-    (validators/all-paths-exist cm abspaths)
-    (validators/user-owns-paths cm user abspaths)
-    (mapv (partial list-perm cm user) abspaths)))
+  (irods/catch-jargon-io-exceptions
+    (with-jargon (cfg/jargon-cfg) [cm]
+      (validators/user-exists cm user)
+      (validators/all-paths-exist cm abspaths)
+      (validators/user-owns-paths cm user abspaths)
+      (mapv (partial list-perm cm user) abspaths))))
 
 (defn do-user-permissions
   [{user :user} {paths :paths}]

--- a/services/data-info/src/data_info/services/users.clj
+++ b/services/data-info/src/data_info/services/users.clj
@@ -1,9 +1,7 @@
 (ns data-info.services.users
-  (:use [clj-jargon.init :only [with-jargon]])
   (:require [clojure.tools.logging :as log]
             [dire.core :refer [with-pre-hook! with-post-hook!]]
             [data-info.services.permissions :as perms]
-            [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.logging :as dul]
             [data-info.util.validators :as validators]))
@@ -15,12 +13,11 @@
 
 (defn- list-perms
   [user abspaths]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (validators/user-exists cm user)
-      (validators/all-paths-exist cm abspaths)
-      (validators/user-owns-paths cm user abspaths)
-      (mapv (partial list-perm cm user) abspaths))))
+  (irods/with-jargon-exceptions [cm]
+    (validators/user-exists cm user)
+    (validators/all-paths-exist cm abspaths)
+    (validators/user-owns-paths cm user abspaths)
+    (mapv (partial list-perm cm user) abspaths)))
 
 (defn do-user-permissions
   [{user :user} {paths :paths}]

--- a/services/data-info/src/data_info/services/uuids.clj
+++ b/services/data-info/src/data_info/services/uuids.clj
@@ -5,9 +5,7 @@
             [clj-icat-direct.icat :as icat]
             [data-info.services.stat :as stat]
             [clj-jargon.by-uuid :as uuid]
-            [clj-jargon.init :as init]
             [clojure-commons.error-codes :as error]
-            [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.validators :as valid])
   (:import [java.util UUID]
@@ -26,9 +24,8 @@
   ([^IPersistentMap cm ^String user ^UUID uuid]
    (uuid/get-path cm uuid))
   ([^String user ^UUID uuid]
-   (irods/catch-jargon-io-exceptions
-     (init/with-jargon (cfg/jargon-cfg) [cm]
-       (path-for-uuid cm user uuid)))))
+   (irods/with-jargon-exceptions [cm]
+       (path-for-uuid cm user uuid))))
 
 (defn ^IPersistentMap path-stat-for-uuid
   "Resolves a stat info for the entity with a given UUID.
@@ -45,21 +42,19 @@
       (throw+ {:error_code error/ERR_DOES_NOT_EXIST :uuid uuid})))
 
   ([^String user ^UUID uuid]
-   (irods/catch-jargon-io-exceptions
-     (init/with-jargon (cfg/jargon-cfg) [cm]
-       (path-stat-for-uuid cm user uuid)))))
+   (irods/with-jargon-exceptions [cm]
+     (path-stat-for-uuid cm user uuid))))
 
 
 (defn paths-for-uuids
   [user uuids]
   (letfn [(id-type [type entity] (merge entity {:id (:path entity) :type type}))]
-    (irods/catch-jargon-io-exceptions
-      (init/with-jargon (cfg/jargon-cfg) [cm]
-        (valid/user-exists cm user)
-        (->> (concat (map (partial id-type :dir) (icat/select-folders-with-uuids uuids))
-                     (map (partial id-type :file) (icat/select-files-with-uuids uuids)))
-          (mapv (partial stat/decorate-stat cm user))
-          (remove #(nil? (:permission %))))))))
+    (irods/with-jargon-exceptions [cm]
+      (valid/user-exists cm user)
+      (->> (concat (map (partial id-type :dir) (icat/select-folders-with-uuids uuids))
+                   (map (partial id-type :file) (icat/select-files-with-uuids uuids)))
+        (mapv (partial stat/decorate-stat cm user))
+        (remove #(nil? (:permission %)))))))
 
 (defn ^IPersistentMap uuid-for-path
   "Retrieves the path stat info for a given entity. It attaches the UUID in a additional :uuid
@@ -78,21 +73,19 @@
 
 (defn uuids-for-paths
   [user paths]
-  (irods/catch-jargon-io-exceptions
-    (init/with-jargon (cfg/jargon-cfg) [cm]
-      (valid/user-exists cm user)
-      (valid/all-paths-exist cm paths)
-      (valid/all-paths-readable cm user paths)
-      (remove nil? (mapv (partial uuid-for-path cm user) paths)))))
+  (irods/with-jargon-exceptions [cm]
+    (valid/user-exists cm user)
+    (valid/all-paths-exist cm paths)
+    (valid/all-paths-readable cm user paths)
+    (remove nil? (mapv (partial uuid-for-path cm user) paths))))
 
 (defn do-simple-uuid-for-path
   [{:keys [user path]}]
-  (irods/catch-jargon-io-exceptions
-    (init/with-jargon (cfg/jargon-cfg) [cm]
-      (valid/user-exists cm user)
-      (valid/path-exists cm path)
-      (valid/path-readable cm user path)
-      {:id (irods/lookup-uuid cm path)})))
+  (irods/with-jargon-exceptions [cm]
+    (valid/user-exists cm user)
+    (valid/path-exists cm path)
+    (valid/path-readable cm user path)
+    {:id (irods/lookup-uuid cm path)}))
 
 (defn ^Boolean uuid-accessible?
   "Indicates if a data item is readable by a given user.
@@ -104,7 +97,6 @@
    Returns:
      It returns true if the user can access the data item, otherwise false"
   [^String user ^UUID data-id]
-  (irods/catch-jargon-io-exceptions
-    (init/with-jargon (cfg/jargon-cfg) [cm]
-      (let [data-path (uuid/get-path cm (str data-id))]
-        (and data-path (is-readable? cm user data-path))))))
+  (irods/with-jargon-exceptions [cm]
+    (let [data-path (uuid/get-path cm (str data-id))]
+      (and data-path (is-readable? cm user data-path)))))

--- a/services/data-info/src/data_info/services/write.clj
+++ b/services/data-info/src/data_info/services/write.clj
@@ -1,5 +1,4 @@
 (ns data-info.services.write
-  (:use [clj-jargon.init :only [with-jargon]])
   (:require [clojure-commons.file-utils :as ft]
             [clojure-commons.error-codes :as ce]
             [clj-jargon.item-info :as info]
@@ -7,7 +6,6 @@
             [ring.middleware.multipart-params :as multipart]
             [data-info.services.stat :as stat]
             [data-info.services.uuids :as uuids]
-            [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.validators :as validators]))
 
@@ -45,10 +43,9 @@
    ring.middleware.multipart-params/multipart-params-request which stores the file in iRODS."
   [user dest-dir {istream :stream filename :filename}]
   (validators/good-pathname filename)
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (let [dest-path (ft/path-join dest-dir filename)]
-        (create-at-path cm istream user dest-path)))))
+  (irods/with-jargon-exceptions [cm]
+    (let [dest-path (ft/path-join dest-dir filename)]
+      (create-at-path cm istream user dest-path))))
 
 (defn wrap-multipart-create
   "Middleware which saves a new file from a multipart request."
@@ -60,10 +57,9 @@
   "When partially applied, creates a storage handler for
    ring.middleware.multipart-params/multipart-params-request which overwrites the file in iRODS."
   [user data-id {istream :stream}]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      (let [path (ft/rm-last-slash (uuids/path-for-uuid cm user data-id))]
-        (overwrite-path cm istream user path)))))
+  (irods/with-jargon-exceptions [cm]
+    (let [path (ft/rm-last-slash (uuids/path-for-uuid cm user data-id))]
+      (overwrite-path cm istream user path))))
 
 (defn wrap-multipart-overwrite
   "Middleware which overwrites a file's contents from a multipart request."
@@ -74,6 +70,5 @@
 (defn do-upload
   "Returns a path stat after a file has been uploaded. Intended to only be used with wrap-multipart-* middlewares."
   [{:keys [user]} file]
-  (irods/catch-jargon-io-exceptions
-    (with-jargon (cfg/jargon-cfg) [cm]
-      {:file (stat/path-stat cm user file)})))
+  (irods/with-jargon-exceptions [cm]
+    {:file (stat/path-stat cm user file)}))

--- a/services/data-info/src/data_info/util/irods.clj
+++ b/services/data-info/src/data_info/util/irods.clj
@@ -25,6 +25,11 @@
                   :reason (str "iRODS is unavailable: " e#)})
          (throw+)))))
 
+(defmacro with-jargon-exceptions
+  [[cm-sym] & body]
+  `(catch-jargon-io-exceptions
+     (init/with-jargon (cfg/jargon-cfg) [~cm-sym] (do ~@body))))
+
 (defn ^String abs-path
   "Resolves a path relative to a zone into its absolute path.
 
@@ -72,5 +77,5 @@
        path-type)))
 
   ([^String path]
-   (init/with-jargon (cfg/jargon-cfg) [cm]
+   (with-jargon-exceptions [cm]
      (detect-media-type cm path))))


### PR DESCRIPTION
NOTE: most of this PR is indentation changes. I'd recommend adding `w=1` to the URL to exclude those lines.

This adds a macro which is intended for wrapping `with-jargon` and which catches `JargonException`s and adds some extra info/a sensible error code when the error is an `IOException`, which I believe should be what happens in these cases (and, hopefully, not in other cases). When it catches these errors, the error that comes out looks like: 

```json
{
  "error_code": "ERR_UNAVAILABLE",
  "reason": "iRODS is unavailable: org.irods.jargon.core.exception.JargonException: java.net.UnknownHostException: ..."
}
```
(UnknownHostException is a type of IOException)

I'm not that happy with this right now because of how many changes it seems to require. But, I'm not happy with putting it into `clj-jargon` directly (too low-level, using our error codes would be adding dependencies to `clj-jargon` and we aren't entirely consistent about how we throw errors right now anyway), nor with what I'd need to do to create a single macro that does both this and what `with-jargon` does (even calling out to `with-jargon`, I'd need to copy a decent chunk of its argument-handling, symbol-manipulating, logic, which is complex enough I'd rather not). I'd appreciate if others have clever ideas on how to do this better, because I bet I'm missing something.