### PR TITLE
CORE-8128: Update /apps search endpoint to also search by category name

### DIFF
--- a/libs/metadata-client/src/metadata_client/core.clj
+++ b/libs/metadata-client/src/metadata_client/core.clj
@@ -62,6 +62,18 @@
                                 :as :json))
        :body))
 
+(defn filter-targets-by-ontology-search
+  [username ontology-version attrs search-term target-types target-ids]
+  (->> (http/post (metadata-url-encoded "ontologies" ontology-version "filter-targets")
+                  (post-options (json/encode {:attrs        attrs
+                                              :target-types target-types
+                                              :target-ids   target-ids})
+                                {:user username :label search-term}
+                                :as :json))
+       :body
+       :target-ids
+       (map uuidify)))
+
 (defn filter-hierarchy
   [username ontology-version root-iri attr target-types target-ids]
   (http/post (metadata-url-encoded "ontologies" ontology-version root-iri "filter")

--- a/services/apps/src/apps/routes/apps.clj
+++ b/services/apps/src/apps/routes/apps.clj
@@ -19,9 +19,15 @@
         :middlewares [wrap-metadata-base-url]
         :summary "Search Apps"
         :return AppListing
-        :description "This service allows users to search for Apps based on a part of the App name or
-        description. The response body contains an `apps` array that is in the same format as
-        the `apps` array in the /apps/categories/:category-id endpoint response."
+        :description (str
+"This service allows users to search for Apps based on a part of the App name, description, integrator's
+ name, tool name, or category name the app is under."
+(get-endpoint-delegate-block
+  "metadata"
+  "POST /avus/filter-targets")
+(get-endpoint-delegate-block
+  "metadata"
+  "POST /ontologies/{ontology-version}/filter-targets"))
         (ok (coerce! AppListing
                  (apps/search-apps current-user params))))
 

--- a/services/metadata/src/metadata/persistence/avu.clj
+++ b/services/metadata/src/metadata/persistence/avu.clj
@@ -11,16 +11,16 @@
   (where query {:target_id   target-id
                 :target_type (db/->enum-val target-type)}))
 
-(defn filter-targets-by-attr-values
-  "Finds the given targets that have the given attribute and any of the given values."
-  [target-types target-ids attribute values]
+(defn filter-targets-by-attrs-values
+  "Finds the given targets that have any of the given attributes and values."
+  [target-types target-ids attributes values]
   (select :avus
           (modifier "DISTINCT")
           (fields :target_id
                   :target_type)
           (where {:target_id   [in target-ids]
                   :target_type [in (map db/->enum-val target-types)]
-                  :attribute   attribute
+                  :attribute   [in attributes]
                   :value       [in values]})))
 
 (defn get-avu-by-id

--- a/services/metadata/src/metadata/persistence/ontologies.clj
+++ b/services/metadata/src/metadata/persistence/ontologies.clj
@@ -1,5 +1,6 @@
 (ns metadata.persistence.ontologies
-  (:use [korma.core :exclude [update]])
+  (:use [korma.core :exclude [update]]
+        [kameleon.util.search])
   (:require [korma.core :as sql]))
 
 (defn add-ontology-xml
@@ -53,6 +54,18 @@
                   :label
                   :description)
           (where {:ontology_version ontology-version})))
+
+(defn- search-classes-base
+  [ontology-version search-term]
+  (let [search-term (str "%" (format-query-wildcards search-term) "%")]
+    (-> (select* :ontology_classes)
+        (where {:ontology_version    ontology-version
+                (sqlfn lower :label) [like (sqlfn lower search-term)]}))))
+
+(defn search-classes-subselect
+  [ontology-version search-term]
+  (-> (search-classes-base ontology-version search-term)
+      (subselect (fields :iri))))
 
 (defn delete-classes
   [ontology-version class-iris]

--- a/services/metadata/src/metadata/routes/ontologies.clj
+++ b/services/metadata/src/metadata/routes/ontologies.clj
@@ -36,6 +36,17 @@
             returning only the hierarchy's leaf-classes that are associated with the given target."
            (ok (service/filter-target-hierarchies ontology-version attrs type id)))
 
+    (POST* "/:ontology-version/filter-targets" []
+           :path-params [ontology-version :- OntologyVersionParam]
+           :query [{:keys [user label]} OntologySearchParams]
+           :body [{:keys [target-types target-ids attrs]} OntologySearchFilterRequest]
+           :return TargetIDList
+           :summary "Filter Targets by Ontology Search"
+           :description
+           "Filters the given target IDs by returning only those that have any of the given `attrs`
+            and Ontology class IRIs as values whose labels match the given Ontology class `label`."
+           (ok (service/filter-targets-by-ontology-class-search ontology-version attrs label target-types target-ids)))
+
     (POST* "/:ontology-version/:root-iri/filter" []
            :path-params [ontology-version :- OntologyVersionParam
                          root-iri :- OntologyClassIRIParam]

--- a/services/metadata/src/metadata/routes/schemas/ontologies.clj
+++ b/services/metadata/src/metadata/routes/schemas/ontologies.clj
@@ -8,6 +8,10 @@
   (merge StandardUserQueryParams
          {:attr (describe String "The metadata attribute that stores class IRIs under the given root IRI")}))
 
+(s/defschema OntologySearchParams
+  (merge StandardUserQueryParams
+         {:label (describe String "The ontology class label search term")}))
+
 (s/defschema OntologyDetailsList
   {:ontologies (describe [OntologyDetails] "List of saved Ontologies")})
 
@@ -34,5 +38,10 @@
 
 (s/defschema TargetHierarchyFilterRequest
   (merge TargetItem
+         {:attrs
+          (describe [String] "The metadata attributes that store class IRIs for the given ontology")}))
+
+(s/defschema OntologySearchFilterRequest
+  (merge TargetFilterRequest
          {:attrs
           (describe [String] "The metadata attributes that store class IRIs for the given ontology")}))

--- a/services/metadata/src/metadata/services/avus.clj
+++ b/services/metadata/src/metadata/services/avus.clj
@@ -8,7 +8,7 @@
 
 (defn- filter-targets-by-attr-values
   [target-types target-ids [attr avus]]
-  (persistence/filter-targets-by-attr-values target-types target-ids attr (map :value avus)))
+  (persistence/filter-targets-by-attrs-values target-types target-ids [attr] (map :value avus)))
 
 (defn filter-targets-by-avus
   "Filters the given target IDs by returning a list of any that have the given attrs and values applied."

--- a/services/metadata/src/metadata/services/ontology.clj
+++ b/services/metadata/src/metadata/services/ontology.clj
@@ -150,37 +150,47 @@
   (let [iri-set (set (map :value (avu-db/get-avus-by-attrs target-types target-ids [attr])))]
     {:hierarchy (filter-root-hierarchy ontology-version iri-set root-iri)}))
 
-(defn- hierarchy-filtered-target-set
+(defn filter-targets-by-ontology-class-search
+  "Filters the given target IDs by returning only those that have any of the given attrs
+   and Ontology class IRIs as values whose labels match the given search-term."
+  [ontology-version attrs search-term target-types target-ids]
+  (let [values (ont-db/search-classes-subselect ontology-version search-term)]
+    {:target-ids (map :target_id (avu-db/filter-targets-by-attrs-values target-types
+                                                                        target-ids
+                                                                        attrs
+                                                                        values))}))
+
+(defn- filter-hierarchy-target-ids
   "Filters the given target IDs by returning only those that are associated with any Ontology classes of
    the hierarchy rooted at the given root-iri."
   [ontology-version root-iri attr target-types target-ids]
   (let [hierarchy (format-hierarchy ontology-version root-iri)
         iri-set   (set (map :iri (util/hierarchy->class-set hierarchy)))]
-    (set (map :target_id (avu-db/filter-targets-by-attr-values target-types
-                                                               target-ids
-                                                               attr
-                                                               iri-set)))))
+    (map :target_id (avu-db/filter-targets-by-attrs-values target-types
+                                                           target-ids
+                                                           [attr]
+                                                           iri-set))))
 
 (defn filter-hierarchy-targets
   "Filters the given target IDs by returning only those that are associated with any Ontology classes of
    the hierarchy rooted at the given root-iri."
   [ontology-version root-iri attr target-types target-ids]
-  {:target-ids (seq (hierarchy-filtered-target-set ontology-version
-                                                   root-iri
-                                                   attr
-                                                   target-types
-                                                   (set target-ids)))})
+  {:target-ids (filter-hierarchy-target-ids ontology-version
+                                            root-iri
+                                            attr
+                                            target-types
+                                            (set target-ids))})
 
 (defn filter-unclassified-targets
   "Filters the given target IDs by returning a list of any that are not associated with any Ontology
    classes of the hierarchy rooted at the given root-iri."
   [ontology-version root-iri attr target-types target-ids]
   (let [target-ids (set target-ids)
-        found-ids  (hierarchy-filtered-target-set ontology-version
-                                                  root-iri
-                                                  attr
-                                                  target-types
-                                                  target-ids)]
+        found-ids  (set (filter-hierarchy-target-ids ontology-version
+                                                     root-iri
+                                                     attr
+                                                     target-types
+                                                     target-ids))]
     {:target-ids (seq (sets/difference target-ids found-ids))}))
 
 (defn filter-target-hierarchies


### PR DESCRIPTION
This PR updates the /apps search endpoint to also search apps by category name.
So the search endpoint should still include the same search results as before, but now it will also include apps with ontology class AVUs attached whose label matches the search term (using the same wildcard logic to match the search term in other app fields).

The /apps search endpoint uses a new metadata service `POST /ontologies/{ontology-version}/filter-targets` endpoint to search apps with matching category labels to include in the /apps search results.