### PR TITLE
Use futures to parallelize/speed up the terrain bootstrap endpoint

### DIFF
--- a/services/terrain/src/terrain/services/metadata/apps.clj
+++ b/services/terrain/src/terrain/services/metadata/apps.clj
@@ -48,13 +48,14 @@
   (assert-valid user-agent "Missing or empty request parameter: user-agent")
   (let [username    (:username current-user)
         user        (:shortUsername current-user)
-        workspace   (dm/get-workspace)
-        preferences (user-prefs (:username current-user))
-        login-time  (:login_time (dm/record-login ip-address user-agent))]
+        workspace   (future (dm/get-workspace))
+        preferences (future (user-prefs (:username current-user)))
+        login-record (future (dm/record-login ip-address user-agent))
+        auth-redirect (future (dm/get-auth-redirect-uris))]
     (success-response
-      {:workspaceId   (:id workspace)
-       :newWorkspace  (:new_workspace workspace)
-       :loginTime     (str login-time)
+      {:workspaceId   (:id @workspace)
+       :newWorkspace  (:new_workspace @workspace)
+       :loginTime     (str (:login_time @login-record))
        :username      user
        :full_username username
        :email         (:email current-user)
@@ -63,8 +64,8 @@
        :userHomePath  (di/user-home-folder user)
        :userTrashPath (di/user-trash-folder user)
        :baseTrashPath (di/base-trash-folder)
-       :preferences   preferences
-       :auth-redirect (dm/get-auth-redirect-uris)})))
+       :preferences   @preferences
+       :auth-redirect @auth-redirect})))
 
 (defn logout
   "This service records the fact that the user logged out."


### PR DESCRIPTION
This probably isn't _that_ important but it did speed things up a noticeable amount in my local testing, from 4.5 to 1.2s for first call, and from ~0.4 to ~0.15s for subsequent calls. It'll hit the apps service a tiny bit harder since it means three simultaneous calls rather than three serial calls, but the get-workspace one is the hardest hitting call anyway.
