### PR TITLE
CORE-8125 Switch to DE hierarchy preview instead of AppCategory listing in App Catalog tab

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/apps/client/AdminAppsGridView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/apps/client/AdminAppsGridView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.admin.apps.client;
 
 import org.iplantc.de.admin.apps.client.events.selection.RestoreAppSelected;
 import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
 import org.iplantc.de.apps.client.AppsGridView;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.BeforeAppSearchEvent;
@@ -31,7 +32,8 @@ public interface AdminAppsGridView extends IsWidget,
                                            AppCategorySelectionChangedEvent.AppCategorySelectionChangedEventHandler,
                                            AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
                                            BeforeAppSearchEvent.BeforeAppSearchEventHandler,
-                                           HierarchySelectedEvent.HierarchySelectedEventHandler {
+                                           HierarchySelectedEvent.HierarchySelectedEventHandler,
+                                           PreviewHierarchySelectedEvent.PreviewHierarchySelectedEventHandler {
 
     interface Appearance extends AppsGridView.AppsGridAppearance {
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/apps/client/AdminAppsGridView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/apps/client/AdminAppsGridView.java
@@ -3,6 +3,7 @@ package org.iplantc.de.admin.apps.client;
 import org.iplantc.de.admin.apps.client.events.selection.RestoreAppSelected;
 import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
 import org.iplantc.de.apps.client.AppsGridView;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.BeforeAppSearchEvent;
@@ -33,7 +34,8 @@ public interface AdminAppsGridView extends IsWidget,
                                            AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
                                            BeforeAppSearchEvent.BeforeAppSearchEventHandler,
                                            HierarchySelectedEvent.HierarchySelectedEventHandler,
-                                           PreviewHierarchySelectedEvent.PreviewHierarchySelectedEventHandler {
+                                           PreviewHierarchySelectedEvent.PreviewHierarchySelectedEventHandler,
+                                           SelectOntologyVersionEvent.SelectOntologyVersionEventHandler {
 
     interface Appearance extends AppsGridView.AppsGridAppearance {
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsGridImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsGridImpl.java
@@ -3,6 +3,7 @@ package org.iplantc.de.admin.apps.client.views.grid;
 import org.iplantc.de.admin.apps.client.AdminAppsGridView;
 import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.BeforeAppSearchEvent;
@@ -153,5 +154,10 @@ public class AdminAppsGridImpl extends ContentPanel implements AdminAppsGridView
         if (app != null) {
             listStore.remove(app);
         }
+    }
+
+    @Override
+    public void onSelectOntologyVersion(SelectOntologyVersionEvent event) {
+        setHeadingHtml("&nbsp;");
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsGridImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsGridImpl.java
@@ -2,6 +2,7 @@ package org.iplantc.de.admin.apps.client.views.grid;
 
 import org.iplantc.de.admin.apps.client.AdminAppsGridView;
 import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.BeforeAppSearchEvent;
@@ -89,6 +90,11 @@ public class AdminAppsGridImpl extends ContentPanel implements AdminAppsGridView
 
     @Override
     public void onHierarchySelected(HierarchySelectedEvent event) {
+        setHeadingText(Joiner.on(" >> ").join(event.getPath()));
+    }
+
+    @Override
+    public void onPreviewHierarchySelected(PreviewHierarchySelectedEvent event) {
         setHeadingText(Joiner.on(" >> ").join(event.getPath()));
     }
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -64,11 +64,11 @@ public interface OntologiesView extends IsWidget,
 
     Ontology getSelectedOntology();
 
-    void clearStore(TreeType type);
+    void clearTreeStore(TreeType type);
 
-    void addToStore(TreeType type, List<OntologyHierarchy> children);
+    void addToTreeStore(TreeType type, List<OntologyHierarchy> children);
 
-    void addToStore(TreeType type, OntologyHierarchy parent, List<OntologyHierarchy> children);
+    void addToTreeStore(TreeType type, OntologyHierarchy parent, List<OntologyHierarchy> children);
 
     void maskTree(TreeType type);
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -76,6 +76,8 @@ public interface OntologiesView extends IsWidget,
 
     void selectActiveOntology(Ontology activeOntology);
 
+    void deselectHierarchies(TreeType type);
+
     void reSortTree(TreeType type);
 
     void updateButtonStatus();

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -4,6 +4,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.events.CategorizeButtonCli
 import org.iplantc.de.admin.desktop.client.ontologies.events.DeleteHierarchyEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.DeleteOntologyButtonClickedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.PublishOntologyClickEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshOntologiesEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarchyEvent;
@@ -34,6 +35,7 @@ public interface OntologiesView extends IsWidget,
                                         RefreshOntologiesEvent.HasViewOntologyVersionEventHandlers,
                                         SelectOntologyVersionEvent.HasSelectOntologyVersionEventHandlers,
                                         HierarchySelectedEvent.HasHierarchySelectedEventHandlers,
+                                        PreviewHierarchySelectedEvent.HasPreviewHierarchySelectedEventHandlers,
                                         SaveOntologyHierarchyEvent.HasSaveOntologyHierarchyEventHandlers,
                                         PublishOntologyClickEvent.HasPublishOntologyClickEventHandlers,
                                         CategorizeButtonClickedEvent.HasCategorizeButtonClickedEventHandlers,
@@ -43,6 +45,10 @@ public interface OntologiesView extends IsWidget,
                                         DeleteAppsSelected.HasDeleteAppsSelectedHandlers,
                                         BeforeAppSearchEvent.HasBeforeAppSearchEventHandlers,
                                         AppSearchResultLoadEvent.HasAppSearchResultLoadEventHandlers {
+
+    enum TreeType {
+        ALL, EDITOR, PREVIEW
+    }
 
     void showOntologyVersions(List<Ontology> result);
 
@@ -54,21 +60,21 @@ public interface OntologiesView extends IsWidget,
 
     OntologyHierarchy getSelectedHierarchy();
 
-    void clearStore();
+    Ontology getSelectedOntology();
 
-    void addToStore(List<OntologyHierarchy> children);
+    void clearStore(TreeType type);
 
-    void addToStore(OntologyHierarchy parent, List<OntologyHierarchy> children);
+    void addToStore(TreeType type, List<OntologyHierarchy> children);
 
-    void maskHierarchyTree();
+    void addToStore(TreeType type, OntologyHierarchy parent, List<OntologyHierarchy> children);
 
-    void unMaskHierarchyTree();
-    
+    void maskTree(TreeType type);
+
     void selectHierarchy(OntologyHierarchy hierarchy);
 
     void selectActiveOntology(Ontology activeOntology);
 
-    void reSortHierarchies();
+    void reSortTree(TreeType type);
 
     void updateButtonStatus();
 
@@ -79,6 +85,8 @@ public interface OntologiesView extends IsWidget,
     void removeApp(App selectedApp);
 
     void deselectAll();
+
+    void unmaskTree(TreeType type);
 
 
     interface OntologiesViewAppearance {
@@ -215,6 +223,12 @@ public interface OntologiesView extends IsWidget,
         String ontologyAttrMatchingError();
 
         String emptySearchFieldText();
+
+        String westPanelHeader();
+
+        String eastPanelHeader();
+
+        String treePanelHeader();
     }
 
     interface Presenter {
@@ -229,5 +243,7 @@ public interface OntologiesView extends IsWidget,
         void appsDNDtoHierarchy(List<App> apps, OntologyHierarchy hierarchy);
 
         OntologyHierarchy getSelectedHierarchy();
+
+        Ontology getSelectedOntology();
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -7,6 +7,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEv
 import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.PublishOntologyClickEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshOntologiesEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshPreviewButtonClicked;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarchyEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
@@ -44,7 +45,8 @@ public interface OntologiesView extends IsWidget,
                                         DeleteHierarchyEvent.HasDeleteHierarchyEventHandlers,
                                         DeleteAppsSelected.HasDeleteAppsSelectedHandlers,
                                         BeforeAppSearchEvent.HasBeforeAppSearchEventHandlers,
-                                        AppSearchResultLoadEvent.HasAppSearchResultLoadEventHandlers {
+                                        AppSearchResultLoadEvent.HasAppSearchResultLoadEventHandlers,
+                                        RefreshPreviewButtonClicked.HasRefreshPreviewButtonClickedHandlers {
 
     enum TreeType {
         ALL, EDITOR, PREVIEW
@@ -229,6 +231,8 @@ public interface OntologiesView extends IsWidget,
         String eastPanelHeader();
 
         String treePanelHeader();
+
+        String refresh();
     }
 
     interface Presenter {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/PreviewHierarchySelectedEvent.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/PreviewHierarchySelectedEvent.java
@@ -16,25 +16,25 @@ import java.util.List;
 /**
  * @author aramsey
  */
-public class HierarchySelectedEvent extends GwtEvent<HierarchySelectedEvent.HierarchySelectedEventHandler> {
+public class PreviewHierarchySelectedEvent extends GwtEvent<PreviewHierarchySelectedEvent.PreviewHierarchySelectedEventHandler> {
     private static final String HIERARCHY_MODEL_KEY = "model_key";
 
-    public static interface HierarchySelectedEventHandler extends EventHandler {
-        void onHierarchySelected(HierarchySelectedEvent event);
+    public static interface PreviewHierarchySelectedEventHandler extends EventHandler {
+        void onPreviewHierarchySelected(PreviewHierarchySelectedEvent event);
     }
 
-    public interface HasHierarchySelectedEventHandlers {
-        HandlerRegistration addHierarchySelectedEventHandler(HierarchySelectedEventHandler handler);
+    public interface HasPreviewHierarchySelectedEventHandlers {
+        HandlerRegistration addPreviewHierarchySelectedEventHandler(PreviewHierarchySelectedEventHandler handler);
     }
 
-    public static Type<HierarchySelectedEventHandler> TYPE = new Type<HierarchySelectedEventHandler>();
+    public static Type<PreviewHierarchySelectedEventHandler> TYPE = new Type<PreviewHierarchySelectedEventHandler>();
 
     private OntologyHierarchy hierarchy;
     private Ontology editedOntology;
     OntologiesView.TreeType treeType;
 
-    public HierarchySelectedEvent(OntologyHierarchy hierarchy, Ontology editedOntology,
-                                  OntologiesView.TreeType treeType){
+    public PreviewHierarchySelectedEvent(OntologyHierarchy hierarchy,
+                                         Ontology editedOntology, OntologiesView.TreeType treeType){
         this.hierarchy = hierarchy;
         this.editedOntology = editedOntology;
         this.treeType = treeType;
@@ -57,12 +57,12 @@ public class HierarchySelectedEvent extends GwtEvent<HierarchySelectedEvent.Hier
         return treeType;
     }
 
-    public Type<HierarchySelectedEventHandler> getAssociatedType() {
+    public Type<PreviewHierarchySelectedEventHandler> getAssociatedType() {
         return TYPE;
     }
 
-    protected void dispatch(HierarchySelectedEventHandler handler) {
-        handler.onHierarchySelected(this);
+    protected void dispatch(PreviewHierarchySelectedEventHandler handler) {
+        handler.onPreviewHierarchySelected(this);
     }
 
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/RefreshPreviewButtonClicked.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/RefreshPreviewButtonClicked.java
@@ -1,0 +1,51 @@
+package org.iplantc.de.admin.desktop.client.ontologies.events;
+
+import org.iplantc.de.client.models.ontologies.Ontology;
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public class RefreshPreviewButtonClicked
+        extends GwtEvent<RefreshPreviewButtonClicked.RefreshPreviewButtonClickedHandler> {
+
+    public static interface RefreshPreviewButtonClickedHandler extends EventHandler {
+        void onRefreshPreviewButtonClicked(RefreshPreviewButtonClicked event);
+    }
+
+    public interface HasRefreshPreviewButtonClickedHandlers {
+        HandlerRegistration addRefreshPreviewButtonClickedHandler(RefreshPreviewButtonClickedHandler handler);
+    }
+    public static Type<RefreshPreviewButtonClickedHandler> TYPE =
+            new Type<RefreshPreviewButtonClickedHandler>();
+
+    private Ontology editedOntology;
+    private List<OntologyHierarchy> roots;
+
+    public RefreshPreviewButtonClicked(Ontology editedOntology, List<OntologyHierarchy> roots) {
+        this.editedOntology = editedOntology;
+        this.roots = roots;
+    }
+
+    public Type<RefreshPreviewButtonClickedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(RefreshPreviewButtonClickedHandler handler) {
+        handler.onRefreshPreviewButtonClicked(this);
+    }
+
+    public Ontology getEditedOntology() {
+        return editedOntology;
+    }
+
+    public List<OntologyHierarchy> getRoots() {
+        return roots;
+    }
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/gin/factory/OntologiesViewFactory.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/gin/factory/OntologiesViewFactory.java
@@ -22,8 +22,8 @@ public interface OntologiesViewFactory {
     OntologiesView create(@Assisted("editorTreeStore") TreeStore<OntologyHierarchy> treeStore,
                           @Assisted("previewTreeStore") TreeStore<OntologyHierarchy> previewTreeStore,
                           PagingLoader<FilterPagingLoadConfig, PagingLoadResult<App>> loader,
-                          @Assisted("oldGridView") AdminAppsGridView oldGridView,
-                          @Assisted("newGridView") AdminAppsGridView newGridView,
+                          @Assisted("previewGridView") AdminAppsGridView oldGridView,
+                          @Assisted("editorGridView") AdminAppsGridView newGridView,
                           OntologyHierarchyToAppDND dndHandler,
                           AppToOntologyHierarchyDND appDndHandler);
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/gin/factory/OntologiesViewFactory.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/gin/factory/OntologiesViewFactory.java
@@ -4,7 +4,6 @@ import org.iplantc.de.admin.apps.client.AdminAppsGridView;
 import org.iplantc.de.admin.desktop.client.ontologies.OntologiesView;
 import org.iplantc.de.admin.desktop.client.ontologies.views.AppToOntologyHierarchyDND;
 import org.iplantc.de.admin.desktop.client.ontologies.views.OntologyHierarchyToAppDND;
-import org.iplantc.de.apps.client.AppCategoriesView;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 
@@ -20,9 +19,9 @@ import com.sencha.gxt.data.shared.loader.PagingLoader;
  */
 public interface OntologiesViewFactory {
 
-    OntologiesView create(TreeStore<OntologyHierarchy> treeStore,
+    OntologiesView create(@Assisted("editorTreeStore") TreeStore<OntologyHierarchy> treeStore,
+                          @Assisted("previewTreeStore") TreeStore<OntologyHierarchy> previewTreeStore,
                           PagingLoader<FilterPagingLoadConfig, PagingLoadResult<App>> loader,
-                          AppCategoriesView categoriesView,
                           @Assisted("oldGridView") AdminAppsGridView oldGridView,
                           @Assisted("newGridView") AdminAppsGridView newGridView,
                           OntologyHierarchyToAppDND dndHandler,

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -510,14 +510,14 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
             return;
         }
 
-        String avu = ontologyUtil.getAttr(hierarchy);
-        if (Strings.isNullOrEmpty(avu)) {
+        String attr = ontologyUtil.getAttr(hierarchy);
+        if (Strings.isNullOrEmpty(attr)) {
             displayErrorToAdmin();
             return;
         }
 
         gridView.mask(appearance.loadingMask());
-        serviceFacade.getAppsByHierarchy(editedOntology.getVersion(), hierarchy.getIri(), avu, new AsyncCallback<List<App>>() {
+        serviceFacade.getAppsByHierarchy(editedOntology.getVersion(), hierarchy.getIri(), attr, new AsyncCallback<List<App>>() {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -455,7 +455,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         Avu avu = ontologyUtil.convertHierarchyToAvu(hierarchy);
 
         newGridPresenter.getView().mask(appearance.loadingMask());
-        serviceFacade.getAppsByHierarchy(hierarchy.getIri(), avu, new AsyncCallback<List<App>>() {
+        serviceFacade.getAppsByHierarchy(editedOntology.getVersion(), hierarchy.getIri(), avu, new AsyncCallback<List<App>>() {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -220,6 +220,8 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
         view.addRefreshOntologiesEventHandler(this);
         view.addSelectOntologyVersionEventHandler(this);
+        view.addSelectOntologyVersionEventHandler(oldGridPresenter.getView());
+        view.addSelectOntologyVersionEventHandler(newGridPresenter.getView());
         view.addHierarchySelectedEventHandler(this);
         view.addHierarchySelectedEventHandler(newGridPresenter.getView());
         view.addPreviewHierarchySelectedEventHandler(this);

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -1,13 +1,13 @@
 package org.iplantc.de.admin.desktop.client.ontologies.presenter;
 
 import org.iplantc.de.admin.apps.client.AdminAppsGridView;
-import org.iplantc.de.admin.apps.client.AdminCategoriesView;
 import org.iplantc.de.admin.desktop.client.ontologies.OntologiesView;
 import org.iplantc.de.admin.desktop.client.ontologies.events.CategorizeButtonClickedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.CategorizeHierarchiesToAppEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.DeleteHierarchyEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.DeleteOntologyButtonClickedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.PublishOntologyClickEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshOntologiesEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarchyEvent;
@@ -21,7 +21,6 @@ import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.CategorizeDi
 import org.iplantc.de.admin.desktop.client.services.AppAdminServiceFacade;
 import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.presenter.toolBar.proxy.AppSearchRpcProxy;
-import org.iplantc.de.client.models.HasId;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.avu.Avu;
 import org.iplantc.de.client.models.avu.AvuAutoBeanFactory;
@@ -30,7 +29,6 @@ import org.iplantc.de.client.models.ontologies.Ontology;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 import org.iplantc.de.client.models.ontologies.OntologyVersionDetail;
 import org.iplantc.de.client.services.AppServiceFacade;
-import org.iplantc.de.client.util.CommonModelUtils;
 import org.iplantc.de.client.util.OntologyUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
@@ -39,6 +37,7 @@ import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.shared.DEProperties;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -64,6 +63,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                                                 SaveOntologyHierarchyEvent.SaveOntologyHierarchyEventHandler,
                                                 PublishOntologyClickEvent.PublishOntologyClickEventHandler,
                                                 HierarchySelectedEvent.HierarchySelectedEventHandler,
+                                                PreviewHierarchySelectedEvent.PreviewHierarchySelectedEventHandler,
                                                 CategorizeButtonClickedEvent.CategorizeButtonClickedEventHandler,
                                                 DeleteOntologyButtonClickedEvent.DeleteOntologyButtonClickedEventHandler,
                                                 DeleteHierarchyEvent.DeleteHierarchyEventHandler,
@@ -115,31 +115,38 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         @Override
         public void onFailure(Throwable caught) {
             ErrorHandler.post(caught);
-            view.unMaskHierarchyTree();
+            view.unmaskTree(OntologiesView.TreeType.EDITOR);
         }
 
         @Override
         public void onSuccess(OntologyHierarchy result) {
             if (isValidHierarchy(result)) {
-                serviceFacade.getOntologyHierarchies(ontologyVersion, new HierarchiesCallback());
+                serviceFacade.getOntologyHierarchies(ontologyVersion, new HierarchiesCallback(ontologyVersion));
             } else {
                 announcer.schedule(new ErrorAnnouncementConfig(
                         appearance.invalidHierarchySubmitted(iri)));
-                view.unMaskHierarchyTree();
+                view.unmaskTree(OntologiesView.TreeType.EDITOR);
             }
         }
     }
 
     class HierarchiesCallback implements AsyncCallback<List<OntologyHierarchy>> {
+
+        final String version;
+
+        public HierarchiesCallback(String version) {
+            this.version = version;
+        }
+
         @Override
         public void onFailure(Throwable caught) {
             ErrorHandler.post(caught);
-            view.unMaskHierarchyTree();
+            view.unmaskTree(OntologiesView.TreeType.EDITOR);
         }
 
         @Override
         public void onSuccess(List<OntologyHierarchy> result) {
-            view.clearStore();
+            view.clearStore(OntologiesView.TreeType.EDITOR);
             if (result.size() == 0) {
                 view.showEmptyTreePanel();
             } else {
@@ -147,10 +154,11 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                 if (!isValid) {
                     displayErrorToAdmin();
                 }
-                view.maskHierarchyTree();
-                addHierarchies(null, result);
+                view.maskTree(OntologiesView.TreeType.EDITOR);
+                addHierarchies(OntologiesView.TreeType.EDITOR, null, result);
+                getFilteredOntologyHierarchies(version, result);
             }
-            view.unMaskHierarchyTree();
+            view.unmaskTree(OntologiesView.TreeType.EDITOR);
             view.updateButtonStatus();
         }
     }
@@ -163,9 +171,9 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
     PagingLoader<FilterPagingLoadConfig, PagingLoadResult<App>> loader;
     private OntologiesView view;
     private OntologyServiceFacade serviceFacade;
-    private final TreeStore<OntologyHierarchy> treeStore;
+    private final TreeStore<OntologyHierarchy> editorTreeStore;
+    private final TreeStore<OntologyHierarchy> previewTreeStore;
     private OntologiesView.OntologiesViewAppearance appearance;
-    private AdminCategoriesView.Presenter categoriesPresenter;
     private AdminAppsGridView.Presenter oldGridPresenter;
     private AdminAppsGridView.Presenter newGridPresenter;
     private AppCategorizeView categorizeView;
@@ -175,21 +183,21 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
     @Inject
     public OntologiesPresenterImpl(OntologyServiceFacade serviceFacade,
                                    AppServiceFacade appService,
-                                   final TreeStore<OntologyHierarchy> treeStore,
+                                   final TreeStore<OntologyHierarchy> editorTreeStore,
+                                   final TreeStore<OntologyHierarchy> previewTreeStore,
                                    OntologiesViewFactory factory,
                                    AvuAutoBeanFactory avuFactory,
                                    OntologiesView.OntologiesViewAppearance appearance,
-                                   AdminCategoriesView.Presenter categoriesPresenter,
                                    AdminAppsGridView.Presenter oldGridPresenter,
                                    AdminAppsGridView.Presenter newGridPresenter,
                                    AppCategorizeView categorizeView) {
         this.serviceFacade = serviceFacade;
         this.avuFactory = avuFactory;
-        this.treeStore = treeStore;
+        this.editorTreeStore = editorTreeStore;
+        this.previewTreeStore = previewTreeStore;
         this.appearance = appearance;
         this.ontologyUtil = OntologyUtil.getInstance();
 
-        this.categoriesPresenter = categoriesPresenter;
         this.oldGridPresenter = oldGridPresenter;
         this.newGridPresenter = newGridPresenter;
         this.categorizeView = categorizeView;
@@ -197,17 +205,14 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         proxy = getProxy(appService);
         loader = getPagingLoader();
 
-        this.view = factory.create(treeStore,
+        this.view = factory.create(editorTreeStore,
+                                   previewTreeStore,
                                    loader,
-                                   categoriesPresenter.getView(),
                                    oldGridPresenter.getView(),
                                    newGridPresenter.getView(),
                                    new OntologyHierarchyToAppDND(appearance, oldGridPresenter, newGridPresenter, this),
                                    new AppToOntologyHierarchyDND(appearance, oldGridPresenter, newGridPresenter, this));
 
-        categoriesPresenter.getView().addAppCategorySelectedEventHandler(oldGridPresenter);
-        categoriesPresenter.getView().addAppCategorySelectedEventHandler(oldGridPresenter.getView());
-        oldGridPresenter.addStoreRemoveHandler(categoriesPresenter);
         oldGridPresenter.getView().addAppSelectionChangedEventHandler(view);
         newGridPresenter.getView().addAppSelectionChangedEventHandler(view);
 
@@ -217,6 +222,8 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         view.addSelectOntologyVersionEventHandler(this);
         view.addHierarchySelectedEventHandler(this);
         view.addHierarchySelectedEventHandler(newGridPresenter.getView());
+        view.addPreviewHierarchySelectedEventHandler(this);
+        view.addPreviewHierarchySelectedEventHandler(oldGridPresenter.getView());
         view.addSaveOntologyHierarchyEventHandler(this);
         view.addPublishOntologyClickEventHandler(this);
         view.addCategorizeButtonClickedEventHandler(this);
@@ -224,7 +231,6 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         view.addDeleteHierarchyEventHandler(this);
         view.addDeleteAppsSelectedHandler(this);
 
-        view.addAppSearchResultLoadEventHandler(categoriesPresenter);
         view.addAppSearchResultLoadEventHandler(oldGridPresenter);
         view.addAppSearchResultLoadEventHandler(oldGridPresenter.getView());
         view.addBeforeAppSearchEventHandler(oldGridPresenter.getView());
@@ -241,9 +247,6 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
     @Override
     public void go(HasOneWidget container) {
-        HasId betaGroup = CommonModelUtils.getInstance().createHasIdFromString(DEProperties.getInstance().getDefaultBetaCategoryId());
-
-        categoriesPresenter.go(betaGroup);
         getOntologies(true);
         container.setWidget(view);
     }
@@ -300,8 +303,16 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                 announcer.schedule(new SuccessAnnouncementConfig(appearance.appClassified(targetApp.getName(), hierarchy.getLabel())));
                 view.selectHierarchy(hierarchy);
                 view.deselectAll();
+                if (!previewTreeHasHierarchy(hierarchy)) {
+                    getFilteredOntologyHierarchies(getSelectedOntology().getVersion(), editorTreeStore.getRootItems());
+                }
             }
         });
+    }
+
+    boolean previewTreeHasHierarchy(OntologyHierarchy hierarchy) {
+        String id = ontologyUtil.getOrCreateHierarchyPathTag(hierarchy);
+        return previewTreeStore.findModelWithKey(id) != null;
     }
 
     void clearAvus(final App targetApp) {
@@ -326,18 +337,19 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
     void getOntologies(final boolean selectActiveOntology) {
         newGridPresenter.getView().clearAndAdd(null);
+        oldGridPresenter.getView().clearAndAdd(null);
         serviceFacade.getOntologies(new AsyncCallback<List<Ontology>>() {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);
-                view.unMaskHierarchyTree();
+                view.unmaskTree(OntologiesView.TreeType.EDITOR);
             }
 
             @Override
             public void onSuccess(List<Ontology> result) {
                 Collections.reverse(result);
                 view.showOntologyVersions(result);
-                view.unMaskHierarchyTree();
+                view.unmaskTree(OntologiesView.TreeType.EDITOR);
                 if (selectActiveOntology) {
                     for (Ontology ontology : result) {
                         if (ontology.isActive()){
@@ -352,12 +364,13 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
     @Override
     public void onSelectOntologyVersion(SelectOntologyVersionEvent event) {
-        view.clearStore();
+        view.clearStore(OntologiesView.TreeType.ALL);
         newGridPresenter.getView().clearAndAdd(null);
+        oldGridPresenter.getView().clearAndAdd(null);
         iriToHierarchyMap.clear();
 
         view.showTreePanel();
-        view.maskHierarchyTree();
+        view.maskTree(OntologiesView.TreeType.EDITOR);
 
         getOntologyHierarchies(event.getSelectedOntology().getVersion());
 
@@ -365,26 +378,57 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
     void getOntologyHierarchies(String version) {
         serviceFacade.getOntologyHierarchies(version,
-                                             new HierarchiesCallback());
+                                             new HierarchiesCallback(version));
     }
 
-    void addHierarchies(OntologyHierarchy parent, List<OntologyHierarchy> children) {
+
+    void getFilteredOntologyHierarchies(String version, List<OntologyHierarchy> result) {
+        view.clearStore(OntologiesView.TreeType.PREVIEW);
+        for (OntologyHierarchy hierarchy: result) {
+            view.maskTree(OntologiesView.TreeType.PREVIEW);
+            String attr = ontologyUtil.getAttr(hierarchy);
+            if (Strings.isNullOrEmpty(attr)) {
+                continue;
+            }
+            serviceFacade.getFilteredOntologyHierarchy(version, hierarchy.getIri(), attr, new AsyncCallback<OntologyHierarchy>() {
+                @Override
+                public void onFailure(Throwable caught) {
+                    ErrorHandler.post(caught);
+                    view.unmaskTree(OntologiesView.TreeType.PREVIEW);
+                }
+
+                @Override
+                public void onSuccess(OntologyHierarchy result) {
+                    if (result != null) {
+                        List<OntologyHierarchy> hierarchies = Lists.newArrayList(result);
+                        addHierarchies(OntologiesView.TreeType.PREVIEW, null, hierarchies);
+                        view.reSortTree(OntologiesView.TreeType.PREVIEW);
+                        view.unmaskTree(OntologiesView.TreeType.PREVIEW);
+                    }
+                }
+            });
+        }
+    }
+
+    void addHierarchies(OntologiesView.TreeType type,
+                        OntologyHierarchy parent,
+                        List<OntologyHierarchy> children) {
         if ((children == null)
             || children.isEmpty()) {
             return;
         }
         if (parent == null) {
             ontologyUtil.addUnclassifiedChild(children);
-            view.addToStore(children);
-
+            view.addToStore(type, children);
         } else {
-            view.addToStore(parent, children);
+            view.addToStore(type, parent, children);
+
         }
 
         helperMap(children);
 
         for (OntologyHierarchy hierarchy : children) {
-            addHierarchies(hierarchy, hierarchy.getSubclasses());
+            addHierarchies(type, hierarchy, hierarchy.getSubclasses());
         }
     }
 
@@ -405,7 +449,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         List<String> iris = event.getIris();
         String ontologyVersion = event.getOntology().getVersion();
         for (String iri : iris) {
-            view.maskHierarchyTree();
+            view.maskTree(OntologiesView.TreeType.EDITOR);
             serviceFacade.saveOntologyHierarchy(ontologyVersion,
                                                 iri, new SaveHierarchyAsyncCallback(ontologyVersion, iri));
         }
@@ -443,48 +487,68 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         });
     }
 
+
+    @Override
+    public void onPreviewHierarchySelected(PreviewHierarchySelectedEvent event) {
+        OntologyHierarchy hierarchy = event.getHierarchy();
+        Ontology editedOntology = event.getEditedOntology();
+        getAppsByHierarchy(oldGridPresenter.getView(), hierarchy, editedOntology);
+    }
+
     @Override
     public void onHierarchySelected(HierarchySelectedEvent event) {
         OntologyHierarchy hierarchy = event.getHierarchy();
         Ontology editedOntology = event.getEditedOntology();
+        getAppsByHierarchy(newGridPresenter.getView(), hierarchy, editedOntology);
+    }
+
+    void getAppsByHierarchy(final AdminAppsGridView gridView,
+                            OntologyHierarchy hierarchy,
+                            Ontology editedOntology) {
         if (ontologyUtil.isUnclassified(hierarchy)){
-            getUnclassifiedApps(hierarchy, editedOntology);
+            getUnclassifiedApps(gridView, hierarchy, editedOntology);
             return;
         }
 
-        Avu avu = ontologyUtil.convertHierarchyToAvu(hierarchy);
+        String avu = ontologyUtil.getAttr(hierarchy);
+        if (Strings.isNullOrEmpty(avu)) {
+            displayErrorToAdmin();
+            return;
+        }
 
-        newGridPresenter.getView().mask(appearance.loadingMask());
+        gridView.mask(appearance.loadingMask());
         serviceFacade.getAppsByHierarchy(editedOntology.getVersion(), hierarchy.getIri(), avu, new AsyncCallback<List<App>>() {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);
-                newGridPresenter.getView().unmask();
+                gridView.unmask();
             }
 
             @Override
             public void onSuccess(List<App> result) {
-                newGridPresenter.getView().clearAndAdd(result);
-                newGridPresenter.getView().unmask();
+                gridView.clearAndAdd(result);
+                gridView.unmask();
             }
         });
     }
 
-    void getUnclassifiedApps(OntologyHierarchy hierarchy, Ontology editedOntology) {
+    void getUnclassifiedApps(final AdminAppsGridView gridView,
+                             OntologyHierarchy hierarchy,
+                             Ontology editedOntology) {
         String parentIri = ontologyUtil.getUnclassifiedParentIri(hierarchy);
-        newGridPresenter.getView().mask(appearance.loadingMask());
+        gridView.mask(appearance.loadingMask());
         Avu avu = ontologyUtil.convertHierarchyToAvu(hierarchy);
         serviceFacade.getUnclassifiedApps(editedOntology.getVersion(), parentIri, avu, new AsyncCallback<List<App>>() {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);
-                newGridPresenter.getView().unmask();
+                gridView.unmask();
             }
 
             @Override
             public void onSuccess(List<App> result) {
-                newGridPresenter.getView().clearAndAdd(result);
-                newGridPresenter.getView().unmask();
+                gridView.clearAndAdd(result);
+                gridView.unmask();
             }
         });
     }
@@ -497,6 +561,11 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
     @Override
     public OntologyHierarchy getSelectedHierarchy() {
         return view.getSelectedHierarchy();
+    }
+
+    @Override
+    public Ontology getSelectedOntology() {
+        return view.getSelectedOntology();
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -20,6 +20,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.views.AppToOntologyHierarc
 import org.iplantc.de.admin.desktop.client.ontologies.views.OntologyHierarchyToAppDND;
 import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.CategorizeDialog;
 import org.iplantc.de.admin.desktop.client.services.AppAdminServiceFacade;
+import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.presenter.toolBar.proxy.AppSearchRpcProxy;
 import org.iplantc.de.client.models.apps.App;
@@ -69,7 +70,8 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                                                 DeleteOntologyButtonClickedEvent.DeleteOntologyButtonClickedEventHandler,
                                                 DeleteHierarchyEvent.DeleteHierarchyEventHandler,
                                                 DeleteAppsSelected.DeleteAppsSelectedHandler,
-                                                RefreshPreviewButtonClicked.RefreshPreviewButtonClickedHandler {
+                                                RefreshPreviewButtonClicked.RefreshPreviewButtonClickedHandler,
+                                                AppSearchResultLoadEvent.AppSearchResultLoadEventHandler {
 
     class CategorizeCallback implements AsyncCallback<List<Avu>> {
         private final App selectedApp;
@@ -239,6 +241,12 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         view.addDeleteHierarchyEventHandler(this);
         view.addDeleteAppsSelectedHandler(this);
         view.addRefreshPreviewButtonClickedHandler(this);
+
+        view.addAppSearchResultLoadEventHandler(this);
+        view.addAppSearchResultLoadEventHandler(previewGridPresenter);
+        view.addAppSearchResultLoadEventHandler(previewGridPresenter.getView());
+        view.addBeforeAppSearchEventHandler(previewGridPresenter.getView());
+
     }
 
     PagingLoader<FilterPagingLoadConfig, PagingLoadResult<App>> getPagingLoader() {
@@ -649,5 +657,10 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         String version = editedOntology.getVersion();
 
         getFilteredOntologyHierarchies(version, roots);
+    }
+
+    @Override
+    public void onAppSearchResultLoad(AppSearchResultLoadEvent event) {
+        view.deselectHierarchies(OntologiesView.TreeType.ALL);
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -10,6 +10,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEv
 import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.PublishOntologyClickEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshOntologiesEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshPreviewButtonClicked;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarchyEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.gin.factory.OntologiesViewFactory;
@@ -67,7 +68,8 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                                                 CategorizeButtonClickedEvent.CategorizeButtonClickedEventHandler,
                                                 DeleteOntologyButtonClickedEvent.DeleteOntologyButtonClickedEventHandler,
                                                 DeleteHierarchyEvent.DeleteHierarchyEventHandler,
-                                                DeleteAppsSelected.DeleteAppsSelectedHandler {
+                                                DeleteAppsSelected.DeleteAppsSelectedHandler,
+                                                RefreshPreviewButtonClicked.RefreshPreviewButtonClickedHandler {
 
     class CategorizeCallback implements AsyncCallback<List<Avu>> {
         private final App selectedApp;
@@ -232,6 +234,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         view.addDeleteOntologyButtonClickedEventHandler(this);
         view.addDeleteHierarchyEventHandler(this);
         view.addDeleteAppsSelectedHandler(this);
+        view.addRefreshPreviewButtonClickedHandler(this);
 
         view.addAppSearchResultLoadEventHandler(oldGridPresenter);
         view.addAppSearchResultLoadEventHandler(oldGridPresenter.getView());
@@ -340,6 +343,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
     void getOntologies(final boolean selectActiveOntology) {
         newGridPresenter.getView().clearAndAdd(null);
         oldGridPresenter.getView().clearAndAdd(null);
+        view.clearStore(OntologiesView.TreeType.ALL);
         serviceFacade.getOntologies(new AsyncCallback<List<Ontology>>() {
             @Override
             public void onFailure(Throwable caught) {
@@ -632,5 +636,18 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
     void displayErrorToAdmin() {
         ErrorHandler.post(appearance.ontologyAttrMatchingError());
+    }
+
+    @Override
+    public void onRefreshPreviewButtonClicked(RefreshPreviewButtonClicked event) {
+        Ontology editedOntology = event.getEditedOntology();
+        List<OntologyHierarchy> roots = event.getRoots();
+
+        Preconditions.checkNotNull(editedOntology);
+        Preconditions.checkNotNull(roots);
+
+        String version = editedOntology.getVersion();
+
+        getFilteredOntologyHierarchies(version, roots);
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/service/OntologyServiceFacade.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/service/OntologyServiceFacade.java
@@ -37,6 +37,8 @@ public interface OntologyServiceFacade {
      */
     void getOntologyHierarchies(String version, AsyncCallback<List<OntologyHierarchy>> callback);
 
+    void getFilteredOntologyHierarchy(String version, String root, String attr, AsyncCallback<OntologyHierarchy> callback);
+
     /**
      * Get the list of apps that are not tagged with the given root for the specified Ontology version
      * @param version
@@ -54,10 +56,10 @@ public interface OntologyServiceFacade {
     /**
      * Get the list of apps that belong to the specified class iri and metadata attribute
      * @param iri
-     * @param avu
+     * @param attr
      * @param callback
      */
-    void getAppsByHierarchy(String version, String iri, Avu avu, AsyncCallback<List<App>> callback);
+    void getAppsByHierarchy(String version, String iri, String attr, AsyncCallback<List<App>> callback);
 
     /**
      * Add/Append a list of metadata tags to an App

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/service/OntologyServiceFacade.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/service/OntologyServiceFacade.java
@@ -57,7 +57,7 @@ public interface OntologyServiceFacade {
      * @param avu
      * @param callback
      */
-    void getAppsByHierarchy(String iri, Avu avu, AsyncCallback<List<App>> callback);
+    void getAppsByHierarchy(String version, String iri, Avu avu, AsyncCallback<List<App>> callback);
 
     /**
      * Add/Append a list of metadata tags to an App

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/service/impl/OntologyServiceFacadeImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/service/impl/OntologyServiceFacadeImpl.java
@@ -84,8 +84,8 @@ public class OntologyServiceFacadeImpl implements OntologyServiceFacade {
     }
 
     @Override
-    public void getAppsByHierarchy(String version, String iri, Avu avu, AsyncCallback<List<App>> callback) {
-        String address = ONTOLOGY_ADMIN + "/" + URL.encodeQueryString(version) + "/" + URL.encodeQueryString(iri) + "/apps" + "?attr=" + URL.encodeQueryString(avu.getAttribute());
+    public void getAppsByHierarchy(String version, String iri, String attr, AsyncCallback<List<App>> callback) {
+        String address = ONTOLOGY_ADMIN + "/" + URL.encodeQueryString(version) + "/" + URL.encodeQueryString(iri) + "/apps" + "?attr=" + URL.encodeQueryString(attr);
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
         deService.getServiceData(wrapper, new AsyncCallbackConverter<String, List<App>>(callback) {
@@ -133,6 +133,18 @@ public class OntologyServiceFacadeImpl implements OntologyServiceFacade {
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
         deService.getServiceData(wrapper, new OntologyHierarchyListCallbackConverter(callback, factory));
 
+    }
+
+    @Override
+    public void getFilteredOntologyHierarchy(String version,
+                                             String iri,
+                                             String attr,
+                                             AsyncCallback<OntologyHierarchy> callback) {
+        String address = ONTOLOGY_ADMIN + "/" + URL.encodeQueryString(version) + "/" + URL.encodeQueryString(iri);
+        address += "?attr=" + URL.encodeQueryString(attr);
+
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
+        deService.getServiceData(wrapper, new OntologyHierarchyCallbackConverter(callback, factory));
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/service/impl/OntologyServiceFacadeImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/service/impl/OntologyServiceFacadeImpl.java
@@ -84,8 +84,8 @@ public class OntologyServiceFacadeImpl implements OntologyServiceFacade {
     }
 
     @Override
-    public void getAppsByHierarchy(String iri, Avu avu, AsyncCallback<List<App>> callback) {
-        String address = APPS_HIERARCHIES + "/" + URL.encodeQueryString(iri) + "/apps" + "?attr=" + URL.encodeQueryString(avu.getAttribute());
+    public void getAppsByHierarchy(String version, String iri, Avu avu, AsyncCallback<List<App>> callback) {
+        String address = ONTOLOGY_ADMIN + "/" + URL.encodeQueryString(version) + "/" + URL.encodeQueryString(iri) + "/apps" + "?attr=" + URL.encodeQueryString(avu.getAttribute());
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
         deService.getServiceData(wrapper, new AsyncCallbackConverter<String, List<App>>(callback) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/AppToOntologyHierarchyDND.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/AppToOntologyHierarchyDND.java
@@ -29,23 +29,23 @@ public class AppToOntologyHierarchyDND implements DndDragStartEvent.DndDragStart
                                                   DndDragEnterEvent.DndDragEnterHandler {
 
     OntologiesView.OntologiesViewAppearance appearance;
-    AdminAppsGridView.Presenter oldGridPresenter;
-    AdminAppsGridView.Presenter newGridPresenter;
-    Widget oldGridView;
-    Widget newGridView;
+    AdminAppsGridView.Presenter previewGridPresenter;
+    AdminAppsGridView.Presenter editorGridPresenter;
+    Widget previewGridView;
+    Widget editorGridView;
     OntologiesView.Presenter presenter;
     boolean moved;
 
     public AppToOntologyHierarchyDND(OntologiesView.OntologiesViewAppearance appearance,
-                                     AdminAppsGridView.Presenter oldGridPresenter,
-                                     AdminAppsGridView.Presenter newGridPresenter,
+                                     AdminAppsGridView.Presenter previewGridPresenter,
+                                     AdminAppsGridView.Presenter editorGridPresenter,
                                      OntologiesView.Presenter presenter) {
         this.appearance = appearance;
-        this.oldGridPresenter = oldGridPresenter;
-        this.newGridPresenter = newGridPresenter;
+        this.previewGridPresenter = previewGridPresenter;
+        this.editorGridPresenter = editorGridPresenter;
         this.presenter = presenter;
-        this.oldGridView = oldGridPresenter.getView().asWidget();
-        this.newGridView = newGridPresenter.getView().asWidget();
+        this.previewGridView = previewGridPresenter.getView().asWidget();
+        this.editorGridView = editorGridPresenter.getView().asWidget();
     }
 
     @Override
@@ -113,20 +113,20 @@ public class AppToOntologyHierarchyDND implements DndDragStartEvent.DndDragStart
 
     private List<App> getDragSources(Widget dragWidget) {
         if (isOldGridApp(dragWidget)) {
-            return oldGridPresenter.getSelectedApps();
+            return previewGridPresenter.getSelectedApps();
         }
         if (isNewGridApp(dragWidget)) {
-            return newGridPresenter.getSelectedApps();
+            return editorGridPresenter.getSelectedApps();
         }
         return null;
     }
 
     private boolean isOldGridApp(Widget dragSource) {
-        return dragSource == oldGridView;
+        return dragSource == previewGridView;
     }
 
     private boolean isNewGridApp(Widget dragSource) {
-        return dragSource == newGridView;
+        return dragSource == editorGridView;
     }
 
     private OntologyHierarchy getDropTargetHierarchy(Element eventTarget) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -376,6 +376,22 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
+    public void deselectHierarchies(TreeType type) {
+        switch(type) {
+            case EDITOR:
+                editorTree.getSelectionModel().deselectAll();
+                break;
+            case PREVIEW:
+                previewTree.getSelectionModel().deselectAll();
+                break;
+            case ALL:
+                editorTree.getSelectionModel().deselectAll();
+                previewTree.getSelectionModel().deselectAll();
+                break;
+        }
+    }
+
+    @Override
     public void reSortTree(TreeType type) {
         switch(type) {
             case EDITOR:

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -91,8 +91,8 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     @UiField(provided = true) OntologiesViewAppearance appearance;
     @UiField(provided = true) Tree<OntologyHierarchy, String> editorTree;
     @UiField(provided = true) Tree<OntologyHierarchy, String> previewTree;
-    @UiField(provided = true) AdminAppsGridView oldGridView;
-    @UiField(provided = true) AdminAppsGridView newGridView;
+    @UiField(provided = true) AdminAppsGridView previewGridView;
+    @UiField(provided = true) AdminAppsGridView editorGridView;
     @UiField CardLayoutContainer cards;
     @UiField CenterLayoutContainer noTreePanel, emptyTreePanel;
     @UiField ContentPanel editorTreePanel, previewTreePanel;
@@ -114,16 +114,16 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
                               @Assisted("editorTreeStore") TreeStore<OntologyHierarchy> editorTreeStore,
                               @Assisted("previewTreeStore") TreeStore<OntologyHierarchy> previewTreeStore,
                               @Assisted PagingLoader<FilterPagingLoadConfig, PagingLoadResult<App>> loader,
-                              @Assisted("oldGridView") AdminAppsGridView oldGridView,
-                              @Assisted("newGridView") AdminAppsGridView newGridView,
+                              @Assisted("previewGridView") AdminAppsGridView previewGridView,
+                              @Assisted("editorGridView") AdminAppsGridView editorGridView,
                               @Assisted OntologyHierarchyToAppDND hierarchyToAppDND,
                               @Assisted AppToOntologyHierarchyDND appToHierarchyDND) {
         this.appearance = appearance;
         this.loader = loader;
         this.editorTreeStore = editorTreeStore;
         this.previewTreeStore = previewTreeStore;
-        this.oldGridView = oldGridView;
-        this.newGridView = newGridView;
+        this.previewGridView = previewGridView;
+        this.editorGridView = editorGridView;
         this.hierarchyToAppDND = hierarchyToAppDND;
         this.appToHierarchyDND = appToHierarchyDND;
 
@@ -229,10 +229,10 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
         List<App> appSelection = event.getAppSelection();
         targetApp = null;
         if (appSelection != null && appSelection.size() != 0) {
-            if (event.getSource() == oldGridView) {
-                newGridView.deselectAll();
+            if (event.getSource() == previewGridView) {
+                editorGridView.deselectAll();
             } else {
-                oldGridView.deselectAll();
+                previewGridView.deselectAll();
             }
             targetApp = appSelection.get(0);
         }
@@ -278,7 +278,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void clearStore(TreeType type) {
+    public void clearTreeStore(TreeType type) {
         switch(type){
             case EDITOR:
                 editorTreeStore.clear();
@@ -294,7 +294,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void addToStore(TreeType type, List<OntologyHierarchy> children) {
+    public void addToTreeStore(TreeType type, List<OntologyHierarchy> children) {
         switch(type) {
             case EDITOR:
                 editorTreeStore.add(children);
@@ -310,7 +310,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void addToStore(TreeType type, OntologyHierarchy parent, List<OntologyHierarchy> children) {
+    public void addToTreeStore(TreeType type, OntologyHierarchy parent, List<OntologyHierarchy> children) {
         switch(type) {
             case EDITOR:
                 editorTreeStore.add(parent, children);
@@ -439,26 +439,26 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
 
     @Override
     public void maskGrids(String loadingMask) {
-        oldGridView.mask(loadingMask);
-        newGridView.mask(loadingMask);
+        previewGridView.mask(loadingMask);
+        editorGridView.mask(loadingMask);
     }
 
     @Override
     public void unmaskGrids() {
-        oldGridView.unmask();
-        newGridView.unmask();
+        previewGridView.unmask();
+        editorGridView.unmask();
     }
 
     @Override
     public void removeApp(App selectedApp) {
-        oldGridView.removeApp(selectedApp);
-        newGridView.removeApp(selectedApp);
+        previewGridView.removeApp(selectedApp);
+        editorGridView.removeApp(selectedApp);
     }
 
     @Override
     public void deselectAll() {
-        oldGridView.deselectAll();
-        newGridView.deselectAll();
+        previewGridView.deselectAll();
+        editorGridView.deselectAll();
     }
 
     @UiHandler("publishButton")
@@ -565,36 +565,36 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
 
     void setUpDND() {
         //App DND
-        DropTarget oldGridTarget = new DropTarget(oldGridView.asWidget());
-        oldGridTarget.setAllowSelfAsSource(false);
-        oldGridTarget.addDragEnterHandler(hierarchyToAppDND);
-        oldGridTarget.addDragMoveHandler(hierarchyToAppDND);
-        oldGridTarget.addDragEnterHandler(hierarchyToAppDND);
-        oldGridTarget.addDropHandler(hierarchyToAppDND);
+        DropTarget previewGridTarget = new DropTarget(previewGridView.asWidget());
+        previewGridTarget.setAllowSelfAsSource(false);
+        previewGridTarget.addDragEnterHandler(hierarchyToAppDND);
+        previewGridTarget.addDragMoveHandler(hierarchyToAppDND);
+        previewGridTarget.addDragEnterHandler(hierarchyToAppDND);
+        previewGridTarget.addDropHandler(hierarchyToAppDND);
 
-        DropTarget newGridTarget = new DropTarget(newGridView.asWidget());
-        newGridTarget.setAllowSelfAsSource(false);
-        newGridTarget.addDragEnterHandler(hierarchyToAppDND);
-        newGridTarget.addDragMoveHandler(hierarchyToAppDND);
-        newGridTarget.addDragEnterHandler(hierarchyToAppDND);
-        newGridTarget.addDropHandler(hierarchyToAppDND);
+        DropTarget editorGridTarget = new DropTarget(editorGridView.asWidget());
+        editorGridTarget.setAllowSelfAsSource(false);
+        editorGridTarget.addDragEnterHandler(hierarchyToAppDND);
+        editorGridTarget.addDragMoveHandler(hierarchyToAppDND);
+        editorGridTarget.addDragEnterHandler(hierarchyToAppDND);
+        editorGridTarget.addDropHandler(hierarchyToAppDND);
 
-        DragSource oldGridSource = new DragSource(oldGridView.asWidget());
-        oldGridSource.addDragStartHandler(appToHierarchyDND);
+        DragSource previewGridSource = new DragSource(previewGridView.asWidget());
+        previewGridSource.addDragStartHandler(appToHierarchyDND);
 
-        DragSource newGridSource = new DragSource(newGridView.asWidget());
-        newGridSource.addDragStartHandler(appToHierarchyDND);
+        DragSource editorGridSource = new DragSource(editorGridView.asWidget());
+        editorGridSource.addDragStartHandler(appToHierarchyDND);
 
         //Tree DND
-        DragSource treeDragSource = new DragSource(editorTree);
-        treeDragSource.addDragStartHandler(hierarchyToAppDND);
+        DragSource editorTreeSource = new DragSource(editorTree);
+        editorTreeSource.addDragStartHandler(hierarchyToAppDND);
 
-        DropTarget treeDropTarget = new DropTarget(editorTree);
-        treeDropTarget.setAllowSelfAsSource(false);
-        treeDropTarget.addDragEnterHandler(appToHierarchyDND);
-        treeDropTarget.addDragMoveHandler(appToHierarchyDND);
-        treeDropTarget.addDragEnterHandler(appToHierarchyDND);
-        treeDropTarget.addDropHandler(appToHierarchyDND);
+        DropTarget editorTreeTarget = new DropTarget(editorTree);
+        editorTreeTarget.setAllowSelfAsSource(false);
+        editorTreeTarget.addDragEnterHandler(appToHierarchyDND);
+        editorTreeTarget.addDragMoveHandler(appToHierarchyDND);
+        editorTreeTarget.addDragEnterHandler(appToHierarchyDND);
+        editorTreeTarget.addDropHandler(appToHierarchyDND);
     }
 
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -9,6 +9,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.events.HierarchySelectedEv
 import org.iplantc.de.admin.desktop.client.ontologies.events.PreviewHierarchySelectedEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.PublishOntologyClickEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshOntologiesEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshPreviewButtonClicked;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarchyEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.PublishOntologyDialog;
@@ -86,6 +87,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     @UiField TextButton categorize;
     @UiField TextButton deleteApp;
     @UiField AppSearchField appSearchField;
+    @UiField TextButton refreshPreview;
     @UiField(provided = true) OntologiesViewAppearance appearance;
     @UiField(provided = true) Tree<OntologyHierarchy, String> editorTree;
     @UiField(provided = true) Tree<OntologyHierarchy, String> previewTree;
@@ -215,6 +217,11 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
 
     public HandlerRegistration addPreviewHierarchySelectedEventHandler(PreviewHierarchySelectedEvent.PreviewHierarchySelectedEventHandler handler) {
         return addHandler(handler, PreviewHierarchySelectedEvent.TYPE);
+    }
+
+    @Override
+    public HandlerRegistration addRefreshPreviewButtonClickedHandler(RefreshPreviewButtonClicked.RefreshPreviewButtonClickedHandler handler) {
+        return addHandler(handler, RefreshPreviewButtonClicked.TYPE);
     }
 
     @Override
@@ -427,6 +434,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
         deleteHierarchy.setEnabled(selectedOntology != null && editorTree.getSelectionModel().getSelectedItem() != null);
         categorize.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
         deleteApp.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
+        refreshPreview.setEnabled(selectedOntology != null && editorTreeStore.getRootItems() != null && editorTreeStore.getRootItems().size() > 0);
     }
 
     @Override
@@ -523,6 +531,11 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
             }
         });
         msgBox.show();
+    }
+
+    @UiHandler("refreshPreview")
+    void refreshPreviewButtonClicked(SelectEvent event) {
+        fireEvent(new RefreshPreviewButtonClicked(ontologyDropDown.getCurrentValue(), editorTreeStore.getRootItems()));
     }
 
     Tree<OntologyHierarchy, String> createTree(TreeStore<OntologyHierarchy> store) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
@@ -3,7 +3,6 @@
              xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
              xmlns:toolbar="urn:import:com.sencha.gxt.widget.core.client.toolbar"
              xmlns:gxt="urn:import:com.sencha.gxt.widget.core.client"
-             xmlns:apps="urn:import:org.iplantc.de.apps.client"
              xmlns:g="urn:import:com.google.gwt.user.client.ui"
              xmlns:adminApps="urn:import:org.iplantc.de.admin.apps.client"
              xmlns:tree="urn:import:com.sencha.gxt.widget.core.client.tree"
@@ -43,6 +42,10 @@
         <ui:attributes flex="3"/>
     </ui:with>
 
+    <ui:with field="editorTreeStore"
+             type="com.sencha.gxt.data.shared.TreeStore"/>
+    <ui:with field="previewTreeStore"
+             type="com.sencha.gxt.data.shared.TreeStore"/>
 
     <container:BorderLayoutContainer borders="true">
         <container:north layoutData="{northData}">
@@ -94,7 +97,7 @@
             </toolbar:ToolBar>
         </container:north>
         <container:center layoutData="{centerData}">
-            <gxt:ContentPanel headingText="NEW">
+            <gxt:ContentPanel headingText="{appearance.westPanelHeader}">
                 <container:BorderLayoutContainer borders="true">
                     <container:north layoutData="{northData}">
                         <toolbar:ToolBar>
@@ -117,8 +120,8 @@
                             <container:CenterLayoutContainer ui:field="noTreePanel">
                                 <g:Label text="No ontology version selected."/>
                             </container:CenterLayoutContainer>
-                            <gxt:ContentPanel ui:field="treePanel">
-                                <tree:Tree ui:field="tree"/>
+                            <gxt:ContentPanel ui:field="editorTreePanel" headingText="{appearance.treePanelHeader}">
+                                <tree:Tree ui:field="editorTree" store="{editorTreeStore}"/>
                             </gxt:ContentPanel>
                             <container:CenterLayoutContainer ui:field="emptyTreePanel">
                                 <g:Label text="No hierarchies saved for this ontology version."/>
@@ -132,10 +135,12 @@
             </gxt:ContentPanel>
         </container:center>
         <container:east layoutData="{eastData}">
-            <gxt:ContentPanel headingText="CURRENT">
+            <gxt:ContentPanel headingText="{appearance.eastPanelHeader}">
                 <container:BorderLayoutContainer>
                     <container:center layoutData="{centerData}">
-                        <apps:AppCategoriesView ui:field="categoriesView"/>
+                        <gxt:ContentPanel ui:field="previewTreePanel" headingText="{appearance.treePanelHeader}">
+                            <tree:Tree ui:field="previewTree" store="{previewTreeStore}"/>
+                        </gxt:ContentPanel>
                     </container:center>
                     <container:west layoutData="{westData}">
                         <adminApps:AdminAppsGridView ui:field="oldGridView"/>

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
@@ -137,6 +137,15 @@
         <container:east layoutData="{eastData}">
             <gxt:ContentPanel headingText="{appearance.eastPanelHeader}">
                 <container:BorderLayoutContainer>
+                    <container:north layoutData="{northData}">
+                        <toolbar:ToolBar>
+                            <toolbar:child>
+                                <button:TextButton ui:field="refreshPreview"
+                                                   text="{appearance.refresh}"
+                                                   icon="{appearance.refreshIcon}"/>
+                            </toolbar:child>
+                        </toolbar:ToolBar>
+                    </container:north>
                     <container:center layoutData="{centerData}">
                         <gxt:ContentPanel ui:field="previewTreePanel" headingText="{appearance.treePanelHeader}">
                             <tree:Tree ui:field="previewTree" store="{previewTreeStore}"/>

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
@@ -129,7 +129,7 @@
                         </container:CardLayoutContainer>
                     </container:center>
                     <container:east layoutData="{eastData}">
-                        <adminApps:AdminAppsGridView ui:field="newGridView"/>
+                        <adminApps:AdminAppsGridView ui:field="editorGridView"/>
                     </container:east>
                 </container:BorderLayoutContainer>
             </gxt:ContentPanel>
@@ -152,7 +152,7 @@
                         </gxt:ContentPanel>
                     </container:center>
                     <container:west layoutData="{westData}">
-                        <adminApps:AdminAppsGridView ui:field="oldGridView"/>
+                        <adminApps:AdminAppsGridView ui:field="previewGridView"/>
                     </container:west>
                 </container:BorderLayoutContainer>
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologyHierarchyToAppDND.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologyHierarchyToAppDND.java
@@ -25,18 +25,18 @@ public class OntologyHierarchyToAppDND implements DndDragStartEvent.DndDragStart
                                                   DndDragEnterEvent.DndDragEnterHandler {
 
     OntologiesView.OntologiesViewAppearance appearance;
-    AdminAppsGridView.Presenter oldGridPresenter;
-    AdminAppsGridView.Presenter newGridPresenter;
+    AdminAppsGridView.Presenter previewGridPresenter;
+    AdminAppsGridView.Presenter editorGridPresenter;
     OntologiesView.Presenter presenter;
     boolean moved;
 
     public OntologyHierarchyToAppDND(OntologiesView.OntologiesViewAppearance appearance,
-                                     AdminAppsGridView.Presenter oldGridPresenter,
-                                     AdminAppsGridView.Presenter newGridPresenter,
+                                     AdminAppsGridView.Presenter previewGridPresenter,
+                                     AdminAppsGridView.Presenter editorGridPresenter,
                                      OntologiesView.Presenter presenter) {
         this.appearance = appearance;
-        this.oldGridPresenter = oldGridPresenter;
-        this.newGridPresenter = newGridPresenter;
+        this.previewGridPresenter = previewGridPresenter;
+        this.editorGridPresenter = editorGridPresenter;
         this.presenter = presenter;
     }
 
@@ -106,12 +106,12 @@ public class OntologyHierarchyToAppDND implements DndDragStartEvent.DndDragStart
     }
 
     private App getDropTargetApp(Element eventTarget, Widget dropTarget) {
-        if (dropTarget == oldGridPresenter.getView().asWidget()) {
-            return oldGridPresenter.getAppFromElement(eventTarget);
+        if (dropTarget == previewGridPresenter.getView().asWidget()) {
+            return previewGridPresenter.getAppFromElement(eventTarget);
         }
 
-        if (dropTarget == newGridPresenter.getView().asWidget()) {
-            return newGridPresenter.getAppFromElement(eventTarget);
+        if (dropTarget == editorGridPresenter.getView().asWidget()) {
+            return editorGridPresenter.getAppFromElement(eventTarget);
         }
 
         return null;

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
@@ -418,4 +418,9 @@ public class OntologiesViewDefaultAppearance implements OntologiesView.Ontologie
     public String treePanelHeader() {
         return displayStrings.treePanelHeader();
     }
+
+    @Override
+    public String refresh() {
+        return displayStrings.refresh();
+    }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologiesViewDefaultAppearance.java
@@ -271,7 +271,10 @@ public class OntologiesViewDefaultAppearance implements OntologiesView.Ontologie
     public String appClassified(String name, List<Avu> result) {
         List<String> tags = Lists.newArrayList();
         for (Avu avu : result) {
-            tags.add(avu.getUnit());
+            List<Avu> subAvus = avu.getAvus();
+            if (subAvus != null && subAvus.size() == 1) {
+                tags.add(subAvus.get(0).getValue());
+            }
         }
         return displayStrings.appClassifiedList(name, tags);
     }
@@ -391,11 +394,28 @@ public class OntologiesViewDefaultAppearance implements OntologiesView.Ontologie
         return displayStrings.externalAppDND(appLabels);
     }
 
+    @Override
     public String ontologyAttrMatchingError() {
         return displayStrings.ontologyAttrMatchingError();
     }
 
+    @Override
     public String emptySearchFieldText() {
         return displayStrings.emptySearchFieldText();
+    }
+
+    @Override
+    public String westPanelHeader() {
+        return displayStrings.westPanelHeader();
+    }
+
+    @Override
+    public String eastPanelHeader() {
+        return displayStrings.eastPanelHeader();
+    }
+
+    @Override
+    public String treePanelHeader() {
+        return displayStrings.treePanelHeader();
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
@@ -90,4 +90,6 @@ public interface OntologyDisplayStrings extends Messages{
     String eastPanelHeader();
 
     String treePanelHeader();
+
+    String refresh();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.java
@@ -84,4 +84,10 @@ public interface OntologyDisplayStrings extends Messages{
     String ontologyAttrMatchingError();
 
     String emptySearchFieldText();
+
+    String westPanelHeader();
+
+    String eastPanelHeader();
+
+    String treePanelHeader();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
@@ -39,3 +39,4 @@ emptySearchFieldText = Search Apps...
 westPanelHeader = Ontology Editor
 eastPanelHeader = DE Preview
 treePanelHeader = Hierarchies
+refresh = Refresh Preview

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/ontologies/OntologyDisplayStrings.properties
@@ -36,3 +36,6 @@ confirmDeleteAppWarning = Are you sure you want to delete the app `{0}`?
 externalAppDND = External app(s): {0}
 ontologyAttrMatchingError = A hierarchy root you have added does not match or has not been added to the DE configs attribute list.  Please contact the core software dev team to have the configs updated with the attribute values that correspond to the hierarchies you requested.
 emptySearchFieldText = Search Apps...
+westPanelHeader = Ontology Editor
+eastPanelHeader = DE Preview
+treePanelHeader = Hierarchies

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
@@ -75,15 +75,15 @@ public class OntologiesPresenterImplTest {
     @Mock IplantAnnouncer announcerMock;
     @Mock OntologiesView viewMock;
     @Mock OntologyServiceFacade serviceFacadeMock;
-    @Mock TreeStore<OntologyHierarchy> treeStoreMock;
+    @Mock TreeStore<OntologyHierarchy> editorStoreMock;
     @Mock TreeStore<OntologyHierarchy> previewStoreMock;
     @Mock OntologiesView.OntologiesViewAppearance appearanceMock;
-    @Mock AdminAppsGridView.Presenter oldGridPresenterMock;
-    @Mock AdminAppsGridView.Presenter newGridPresenterMock;
+    @Mock AdminAppsGridView.Presenter previewGridPresenterMock;
+    @Mock AdminAppsGridView.Presenter editorGridPresenterMock;
     @Mock OntologyAutoBeanFactory beanFactoryMock;
     @Mock Grid<App> oldGridMock;
-    @Mock AdminAppsGridView oldGridViewMock;
-    @Mock AdminAppsGridView newGridViewMock;
+    @Mock AdminAppsGridView previewGridViewMock;
+    @Mock AdminAppsGridView editorGridViewMock;
     @Mock AdminCategoriesView.Presenter categoriesPresenterMock;
     @Mock AdminCategoriesView categoriesViewMock;
     @Mock OntologiesViewFactory factoryMock;
@@ -136,9 +136,9 @@ public class OntologiesPresenterImplTest {
         when(appearanceMock.ontologyDeleted(anyString())).thenReturn("success");
         when(appearanceMock.hierarchyDeleted(anyString())).thenReturn("success");
         when(appearanceMock.ontologyAttrMatchingError()).thenReturn("fail");
-        when(oldGridViewMock.getGrid()).thenReturn(oldGridMock);
-        when(oldGridPresenterMock.getView()).thenReturn(oldGridViewMock);
-        when(newGridPresenterMock.getView()).thenReturn(newGridViewMock);
+        when(previewGridViewMock.getGrid()).thenReturn(oldGridMock);
+        when(previewGridPresenterMock.getView()).thenReturn(previewGridViewMock);
+        when(editorGridPresenterMock.getView()).thenReturn(editorGridViewMock);
         when(categoriesPresenterMock.getView()).thenReturn(categoriesViewMock);
         when(utilMock.convertHierarchiesToAvus(ontologyHierarchyListMock)).thenReturn(avuListBeanMock);
         when(utilMock.convertHierarchiesToAvus(hierarchyMock)).thenReturn(avuListBeanMock);
@@ -176,13 +176,12 @@ public class OntologiesPresenterImplTest {
 
         uut = new OntologiesPresenterImpl(serviceFacadeMock,
                                           appServiceMock,
-                                          treeStoreMock,
+                                          editorStoreMock,
                                           previewStoreMock,
                                           factoryMock,
                                           avuFactoryMock,
-                                          appearanceMock,
-                                          oldGridPresenterMock,
-                                          newGridPresenterMock,
+                                          appearanceMock, previewGridPresenterMock,
+                                          editorGridPresenterMock,
                                           categorizeViewMock) {
             @Override
             AppSearchRpcProxy getProxy(AppServiceFacade appService) {
@@ -207,19 +206,19 @@ public class OntologiesPresenterImplTest {
     }
 
     void verifyConstructor() {
-        verify(oldGridViewMock).addAppSelectionChangedEventHandler(eq(viewMock));
-        verify(newGridViewMock).addAppSelectionChangedEventHandler(eq(viewMock));
+        verify(previewGridViewMock).addAppSelectionChangedEventHandler(eq(viewMock));
+        verify(editorGridViewMock).addAppSelectionChangedEventHandler(eq(viewMock));
 
         verify(proxyMock).setHasHandlers(eq(viewMock));
 
         verify(viewMock).addRefreshOntologiesEventHandler(eq(uut));
         verify(viewMock).addSelectOntologyVersionEventHandler(eq(uut));
-        verify(viewMock).addSelectOntologyVersionEventHandler(eq(oldGridViewMock));
-        verify(viewMock).addSelectOntologyVersionEventHandler(eq(newGridViewMock));
+        verify(viewMock).addSelectOntologyVersionEventHandler(eq(previewGridViewMock));
+        verify(viewMock).addSelectOntologyVersionEventHandler(eq(editorGridViewMock));
         verify(viewMock).addHierarchySelectedEventHandler(eq(uut));
-        verify(viewMock).addHierarchySelectedEventHandler(eq(newGridViewMock));
+        verify(viewMock).addHierarchySelectedEventHandler(eq(editorGridViewMock));
         verify(viewMock).addPreviewHierarchySelectedEventHandler(eq(uut));
-        verify(viewMock).addPreviewHierarchySelectedEventHandler(eq(oldGridViewMock));
+        verify(viewMock).addPreviewHierarchySelectedEventHandler(eq(previewGridViewMock));
         verify(viewMock).addSaveOntologyHierarchyEventHandler(eq(uut));
         verify(viewMock).addPublishOntologyClickEventHandler(eq(uut));
         verify(viewMock).addCategorizeButtonClickedEventHandler(eq(uut));
@@ -227,10 +226,7 @@ public class OntologiesPresenterImplTest {
         verify(viewMock).addDeleteOntologyButtonClickedEventHandler(eq(uut));
         verify(viewMock).addDeleteAppsSelectedHandler(eq(uut));
 
-        verify(viewMock).addAppSearchResultLoadEventHandler(categoriesPresenterMock);
-        verify(viewMock).addAppSearchResultLoadEventHandler(oldGridPresenterMock);
-        verify(viewMock).addAppSearchResultLoadEventHandler(oldGridViewMock);
-        verify(viewMock).addBeforeAppSearchEventHandler(oldGridViewMock);
+        verify(viewMock).addRefreshPreviewButtonClickedHandler(eq(uut));
     }
 
     @Test
@@ -239,6 +235,9 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.getOntologies(false);
 
+        verify(editorGridViewMock).clearAndAdd(null);
+        verify(previewGridViewMock).clearAndAdd(null);
+        verify(viewMock).clearTreeStore(isA(OntologiesView.TreeType.class));
         verify(serviceFacadeMock).getOntologies(asyncCallbackOntologyListCaptor.capture());
 
         asyncCallbackOntologyListCaptor.getValue().onSuccess(listOntologyMock);
@@ -286,13 +285,12 @@ public class OntologiesPresenterImplTest {
 
         uut = new OntologiesPresenterImpl(serviceFacadeMock,
                                           appServiceMock,
-                                          treeStoreMock,
+                                          editorStoreMock,
                                           previewStoreMock,
                                           factoryMock,
                                           avuFactoryMock,
-                                          appearanceMock,
-                                          oldGridPresenterMock,
-                                          newGridPresenterMock,
+                                          appearanceMock, previewGridPresenterMock,
+                                          editorGridPresenterMock,
                                           categorizeViewMock) {
             @Override
             boolean previewTreeHasHierarchy(OntologyHierarchy hierarchy) {
@@ -330,14 +328,12 @@ public class OntologiesPresenterImplTest {
 
         uut = new OntologiesPresenterImpl(serviceFacadeMock,
                                           appServiceMock,
-                                          treeStoreMock,
-                                          previewStoreMock,
+                                          editorStoreMock, previewStoreMock,
                                           factoryMock,
                                           avuFactoryMock,
-                                          appearanceMock,
-                                          oldGridPresenterMock,
-                                          newGridPresenterMock,
-                                          categorizeViewMock) {
+                                          appearanceMock, previewGridPresenterMock,
+                                          editorGridPresenterMock,
+                                          categorizeViewMock){
             @Override
             void clearAvus(App targetApp) {}
         };
@@ -377,7 +373,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.onSelectOntologyVersion(eventMock);
 
-        verify(viewMock).clearStore(isA(OntologiesView.TreeType.class));
+        verify(viewMock).clearTreeStore(isA(OntologiesView.TreeType.class));
 
         verify(serviceFacadeMock).getOntologyHierarchies(eq(eventMock.getSelectedOntology()
                                                                      .getVersion()),
@@ -398,13 +394,12 @@ public class OntologiesPresenterImplTest {
 
         uut = new OntologiesPresenterImpl(serviceFacadeMock,
                                           appServiceMock,
-                                          treeStoreMock,
+                                          editorStoreMock,
                                           previewStoreMock,
                                           factoryMock,
                                           avuFactoryMock,
-                                          appearanceMock,
-                                          oldGridPresenterMock,
-                                          newGridPresenterMock,
+                                          appearanceMock, previewGridPresenterMock,
+                                          editorGridPresenterMock,
                                           categorizeViewMock) {
             @Override
             void addHierarchies(OntologiesView.TreeType type,
@@ -420,7 +415,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.onSelectOntologyVersion(eventMock);
 
-        verify(viewMock).clearStore(isA(OntologiesView.TreeType.class));
+        verify(viewMock).clearTreeStore(isA(OntologiesView.TreeType.class));
 
         verify(serviceFacadeMock).getOntologyHierarchies(eq(eventMock.getSelectedOntology()
                                                                      .getVersion()),
@@ -443,13 +438,12 @@ public class OntologiesPresenterImplTest {
 
         uut = new OntologiesPresenterImpl(serviceFacadeMock,
                                           appServiceMock,
-                                          treeStoreMock,
+                                          editorStoreMock,
                                           previewStoreMock,
                                           factoryMock,
                                           avuFactoryMock,
-                                          appearanceMock,
-                                          oldGridPresenterMock,
-                                          newGridPresenterMock,
+                                          appearanceMock, previewGridPresenterMock,
+                                          editorGridPresenterMock,
                                           categorizeViewMock) {
             @Override
             void addHierarchies(OntologiesView.TreeType type,
@@ -482,7 +476,7 @@ public class OntologiesPresenterImplTest {
 
         asyncOntologyHierarchyListCaptor.getValue().onSuccess(ontologyHierarchyListMock);
 
-        verify(viewMock, times(2)).clearStore(isA(OntologiesView.TreeType.class));
+        verify(viewMock, times(2)).clearTreeStore(isA(OntologiesView.TreeType.class));
         verify(utilMock).createIriToAttrMap(eq(ontologyHierarchyListMock));
         verify(viewMock, times(5)).maskTree(isA(OntologiesView.TreeType.class));
         verify(viewMock).unmaskTree(isA(OntologiesView.TreeType.class));
@@ -521,7 +515,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         spy.onHierarchySelected(eventMock);
 
-        verify(spy).getAppsByHierarchy(eq(newGridViewMock), eq(hierarchyMock), eq(ontologyMock));
+        verify(spy).getAppsByHierarchy(eq(editorGridViewMock), eq(hierarchyMock), eq(ontologyMock));
     }
 
     @Test
@@ -535,7 +529,7 @@ public class OntologiesPresenterImplTest {
         when(utilMock.isUnclassified(hierarchyMock)).thenReturn(false);
         when(ontologyMock.getVersion()).thenReturn("version");
 
-        uut.getAppsByHierarchy(newGridViewMock, hierarchyMock, ontologyMock);
+        uut.getAppsByHierarchy(editorGridViewMock, hierarchyMock, ontologyMock);
 
         verify(serviceFacadeMock).getAppsByHierarchy(eq(ontologyMock.getVersion()),
                                                      anyString(),
@@ -543,8 +537,8 @@ public class OntologiesPresenterImplTest {
                                                      asyncAppListCaptor.capture());
 
         asyncAppListCaptor.getValue().onSuccess(appListMock);
-        verify(newGridViewMock).clearAndAdd(appListMock);
-        verify(newGridViewMock).unmask();
+        verify(editorGridViewMock).clearAndAdd(appListMock);
+        verify(editorGridViewMock).unmask();
 
     }
 
@@ -555,16 +549,14 @@ public class OntologiesPresenterImplTest {
         when(hierarchyMock.getIri()).thenReturn("iri");
         when(utilMock.isUnclassified(hierarchyMock)).thenReturn(true);
 
-
         uut = new OntologiesPresenterImpl(serviceFacadeMock,
                                           appServiceMock,
-                                          treeStoreMock,
+                                          editorStoreMock,
                                           previewStoreMock,
                                           factoryMock,
                                           avuFactoryMock,
-                                          appearanceMock,
-                                          oldGridPresenterMock,
-                                          newGridPresenterMock,
+                                          appearanceMock, previewGridPresenterMock,
+                                          editorGridPresenterMock,
                                           categorizeViewMock) {
             @Override
             void getUnclassifiedApps(AdminAppsGridView gridView,
@@ -577,7 +569,7 @@ public class OntologiesPresenterImplTest {
         uut.ontologyUtil = utilMock;
 
         /** CALL METHOD UNDER TEST **/
-        uut.getAppsByHierarchy(newGridViewMock, hierarchyMock, ontologyMock);
+        uut.getAppsByHierarchy(editorGridViewMock, hierarchyMock, ontologyMock);
         //Testing the unclassifiedApps method separately
         verifyZeroInteractions(serviceFacadeMock);
     }
@@ -591,15 +583,15 @@ public class OntologiesPresenterImplTest {
         when(ontologyMock.getVersion()).thenReturn("version");
 
         /** CALL METHOD UNDER TEST **/
-        uut.getUnclassifiedApps(newGridViewMock, hierarchyMock, ontologyMock);
+        uut.getUnclassifiedApps(editorGridViewMock, hierarchyMock, ontologyMock);
 
-        verify(newGridViewMock).mask(anyString());
+        verify(editorGridViewMock).mask(anyString());
         verify(serviceFacadeMock).getUnclassifiedApps(eq(ontologyMock.getVersion()), anyString(), eq(avuMock), asyncAppListCaptor.capture());
 
         asyncAppListCaptor.getValue().onSuccess(appListMock);
 
-        verify(newGridViewMock).clearAndAdd(appListMock);
-        verify(newGridViewMock).unmask();
+        verify(editorGridViewMock).clearAndAdd(appListMock);
+        verify(editorGridViewMock).unmask();
     }
 
     @Test
@@ -664,7 +656,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.getFilteredOntologyHierarchies("version", ontologyHierarchyListMock);
 
-        verify(viewMock).clearStore(isA(OntologiesView.TreeType.class));
+        verify(viewMock).clearTreeStore(isA(OntologiesView.TreeType.class));
         verify(viewMock, times(2)).maskTree(isA(OntologiesView.TreeType.class));
 
         verify(serviceFacadeMock, times(2)).getFilteredOntologyHierarchy(anyString(),

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
@@ -214,6 +214,8 @@ public class OntologiesPresenterImplTest {
 
         verify(viewMock).addRefreshOntologiesEventHandler(eq(uut));
         verify(viewMock).addSelectOntologyVersionEventHandler(eq(uut));
+        verify(viewMock).addSelectOntologyVersionEventHandler(eq(oldGridViewMock));
+        verify(viewMock).addSelectOntologyVersionEventHandler(eq(newGridViewMock));
         verify(viewMock).addHierarchySelectedEventHandler(eq(uut));
         verify(viewMock).addHierarchySelectedEventHandler(eq(newGridViewMock));
         verify(viewMock).addPreviewHierarchySelectedEventHandler(eq(uut));

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
@@ -240,7 +240,7 @@ public class OntologiesPresenterImplTest {
 
         asyncCallbackOntologyListCaptor.getValue().onSuccess(listOntologyMock);
         verify(viewMock).showOntologyVersions(eq(listOntologyMock));
-        verify(viewMock).unMaskHierarchyTree();
+        verify(viewMock).unMaskTree();
         verifyNoMoreInteractions(viewMock);
     }
 
@@ -254,7 +254,7 @@ public class OntologiesPresenterImplTest {
 
         asyncCallbackOntologyListCaptor.getValue().onSuccess(listOntologyMock);
         verify(viewMock).showOntologyVersions(eq(listOntologyMock));
-        verify(viewMock).unMaskHierarchyTree();
+        verify(viewMock).unMaskTree();
         verify(ontologyMock).isActive();
         verify(activeOntologyMock).isActive();
         verify(viewMock).selectActiveOntology(activeOntologyMock);
@@ -346,7 +346,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.onSelectOntologyVersion(eventMock);
 
-        verify(viewMock).clearStore();
+        verify(viewMock).clearStores();
 
         verify(serviceFacadeMock).getOntologyHierarchies(eq(eventMock.getSelectedOntology()
                                                                      .getVersion()),
@@ -387,7 +387,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.onSelectOntologyVersion(eventMock);
 
-        verify(viewMock).clearStore();
+        verify(viewMock).clearStores();
 
         verify(serviceFacadeMock).getOntologyHierarchies(eq(eventMock.getSelectedOntology()
                                                                      .getVersion()),
@@ -447,10 +447,10 @@ public class OntologiesPresenterImplTest {
 
         asyncOntologyHierarchyListCaptor.getValue().onSuccess(ontologyHierarchyListMock);
 
-        verify(viewMock).clearStore();
+        verify(viewMock).clearStores();
         verify(utilMock).createIriToAttrMap(eq(ontologyHierarchyListMock));
-        verify(viewMock, times(3)).maskHierarchyTree();
-        verify(viewMock).unMaskHierarchyTree();
+        verify(viewMock, times(3)).maskTree();
+        verify(viewMock).unMaskTree();
         verify(viewMock).updateButtonStatus();
 
         verify(viewMock).showTreePanel();


### PR DESCRIPTION
The App Catalog tab was initially created to serve the transition period from 2.7 to 2.8 where the science team was tagging apps from the old app categories into the new ontology hierarchies.

This PR updates the App Catalog tab into a state where you no longer see the old app categories, instead you get a "preview" of what hierarchies the DE users would see.  Basically now the admins can edit an ontology and have a side-by-side "preview" of that ontology in the DE (which is basically the filtered-down list of hierarchies).