### PR TITLE
CORE-7644 Show non-public apps with green text

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/grid/cells/AppNameCell.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/apps/client/views/grid/cells/AppNameCell.java
@@ -39,6 +39,10 @@ public class AppNameCell extends AbstractCell<App> {
 
         String appBetaNameClass();
 
+        String appPrivate();
+
+        String appPrivateNameClass();
+
         void render(SafeHtmlBuilder sb, App value, String textClassName, String searchPattern,
                     String textToolTip, String debugId);
 
@@ -74,6 +78,9 @@ public class AppNameCell extends AbstractCell<App> {
         } else if (value.isBeta() != null && value.isBeta()) {
             textClassName = appearance.appBetaNameClass();
             textToolTip = appearance.appBeta();
+        } else if (!value.isPublic()) {
+            textClassName = appearance.appPrivateNameClass();
+            textToolTip = appearance.appPrivate();
         } else {
             textClassName = appearance.appHyperlinkNameClass();
             textToolTip = appearance.run();

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/apps/AdminAppNameCellDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/apps/AdminAppNameCellDefaultAppearance.java
@@ -34,6 +34,13 @@ public class AdminAppNameCellDefaultAppearance extends AppNameCellDefaultAppeara
                          searchPattern,
                          displayStrings.editApp(),
                          null);
+        } else if (!value.isPublic()) {
+            super.render(sb,
+                         value,
+                         resources.css().appPrivate(),
+                         searchPattern,
+                         displayStrings.editApp(),
+                         null);
         } else {
             super.render(sb,
                          value,

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
@@ -135,4 +135,6 @@ public interface AppsMessages extends Messages {
     String betaToolTip();
 
     String ontologyAttrMatchingFailure();
+
+    String privateToolTip();
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
@@ -62,3 +62,4 @@ hpcTab = HPC
 viewCategoriesHeader = Categories
 betaToolTip = This app is currently in the Beta phase and has not yet been reviewed by the CyVerse science team.
 ontologyAttrMatchingFailure = Unable to fetch all app listings.  Please try again later.
+privateToolTip = This is a private app you created or a private app someone shared with you.

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCell.css
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCell.css
@@ -31,11 +31,19 @@
 
 .appBeta {
     color: blue;
+    font-size: 12px;
+    height: 15px;
+    padding-top: 2px;
+    padding-bottom: 2px;
 }
 
 .appBetaHyperlink {
     cursor: pointer;
     color: blue;
+    font-size: 12px;
+    height: 15px;
+    padding-top: 2px;
+    padding-bottom: 2px;
 }
 
 .appBetaHyperlink:hover {
@@ -44,6 +52,10 @@
 
 .appPrivate {
     color: green;
+    font-size: 12px;
+    height: 15px;
+    padding-top: 2px;
+    padding-bottom: 2px;
 }
 
 .appPrivate:hover {

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCell.css
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCell.css
@@ -41,3 +41,11 @@
 .appBetaHyperlink:hover {
     text-decoration: underline;
 }
+
+.appPrivate {
+    color: green;
+}
+
+.appPrivate:hover {
+    text-decoration: underline;
+}

--- a/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCellDefaultAppearance.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppNameCellDefaultAppearance.java
@@ -31,6 +31,8 @@ public class AppNameCellDefaultAppearance implements AppNameCell.AppNameCellAppe
         String appBeta();
 
         String appBetaHyperlink();
+
+        String appPrivate();
     }
 
     public interface Resources extends ClientBundle {
@@ -97,6 +99,16 @@ public class AppNameCellDefaultAppearance implements AppNameCell.AppNameCellAppe
     @Override
     public String appBetaNameClass() {
         return resources.css().appBetaHyperlink();
+    }
+
+    @Override
+    public String appPrivate() {
+        return appsMessages.privateToolTip();
+    }
+
+    @Override
+    public String appPrivateNameClass() {
+        return resources.css().appPrivate();
     }
 
     @Override


### PR DESCRIPTION
This PR is to address an issue where private apps might have the same name as public apps, which could be confusing for users to figure out which app they intended to use.

Private apps will now be green.

Also, this makes sure that beta apps (blue) and private apps (green) are the same size font as public apps (they were slightly smaller).