### PR TITLE
CORE-8112 Loading mask fix for App Catalog and Categorize dialog fix

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -50,7 +50,7 @@ public interface OntologiesView extends IsWidget,
                                         RefreshPreviewButtonClicked.HasRefreshPreviewButtonClickedHandlers,
                                         RestoreAppButtonClicked.HasRestoreAppButtonClickedHandlers {
 
-    enum TreeType {
+    enum ViewType {
         ALL, EDITOR, PREVIEW
     }
 
@@ -67,21 +67,21 @@ public interface OntologiesView extends IsWidget,
 
     Ontology getSelectedOntology();
 
-    void clearTreeStore(TreeType type);
+    void clearTreeStore(ViewType type);
 
-    void addToTreeStore(TreeType type, List<OntologyHierarchy> children);
+    void addToTreeStore(ViewType type, List<OntologyHierarchy> children);
 
-    void addToTreeStore(TreeType type, OntologyHierarchy parent, List<OntologyHierarchy> children);
+    void addToTreeStore(ViewType type, OntologyHierarchy parent, List<OntologyHierarchy> children);
 
-    void maskTree(TreeType type);
+    void maskTree(ViewType type);
 
     void selectHierarchy(OntologyHierarchy hierarchy);
 
     void selectActiveOntology(Ontology activeOntology);
 
-    void deselectHierarchies(TreeType type);
+    void deselectHierarchies(ViewType type);
 
-    void reSortTree(TreeType type);
+    void reSortTree(ViewType type);
 
     void updateButtonStatus();
 
@@ -93,7 +93,7 @@ public interface OntologiesView extends IsWidget,
 
     void deselectAll();
 
-    void unmaskTree(TreeType type);
+    void unmaskTree(ViewType type);
 
 
     interface OntologiesViewAppearance {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -85,9 +85,9 @@ public interface OntologiesView extends IsWidget,
 
     void updateButtonStatus();
 
-    void maskGrids(String loadingMask);
+    void maskGrid(ViewType type);
 
-    void unmaskGrids();
+    void unmaskGrid(ViewType type);
 
     void removeApp(App selectedApp);
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -54,6 +54,7 @@ public interface OntologiesView extends IsWidget,
         ALL, EDITOR, PREVIEW
     }
 
+    String TRASH_CATEGORY = "Trash";
 
     void showOntologyVersions(List<Ontology> result);
 

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/HierarchySelectedEvent.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/HierarchySelectedEvent.java
@@ -31,13 +31,13 @@ public class HierarchySelectedEvent extends GwtEvent<HierarchySelectedEvent.Hier
 
     private OntologyHierarchy hierarchy;
     private Ontology editedOntology;
-    OntologiesView.TreeType treeType;
+    OntologiesView.ViewType viewType;
 
     public HierarchySelectedEvent(OntologyHierarchy hierarchy, Ontology editedOntology,
-                                  OntologiesView.TreeType treeType){
+                                  OntologiesView.ViewType viewType){
         this.hierarchy = hierarchy;
         this.editedOntology = editedOntology;
-        this.treeType = treeType;
+        this.viewType = viewType;
     }
 
     public OntologyHierarchy getHierarchy() {
@@ -53,8 +53,8 @@ public class HierarchySelectedEvent extends GwtEvent<HierarchySelectedEvent.Hier
         return Lists.newArrayList(tag.split("/"));
     }
 
-    public OntologiesView.TreeType getTreeType() {
-        return treeType;
+    public OntologiesView.ViewType getViewType() {
+        return viewType;
     }
 
     public Type<HierarchySelectedEventHandler> getAssociatedType() {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/PreviewHierarchySelectedEvent.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/events/PreviewHierarchySelectedEvent.java
@@ -31,13 +31,13 @@ public class PreviewHierarchySelectedEvent extends GwtEvent<PreviewHierarchySele
 
     private OntologyHierarchy hierarchy;
     private Ontology editedOntology;
-    OntologiesView.TreeType treeType;
+    OntologiesView.ViewType viewType;
 
     public PreviewHierarchySelectedEvent(OntologyHierarchy hierarchy,
-                                         Ontology editedOntology, OntologiesView.TreeType treeType){
+                                         Ontology editedOntology, OntologiesView.ViewType viewType){
         this.hierarchy = hierarchy;
         this.editedOntology = editedOntology;
-        this.treeType = treeType;
+        this.viewType = viewType;
     }
 
     public OntologyHierarchy getHierarchy() {
@@ -53,8 +53,8 @@ public class PreviewHierarchySelectedEvent extends GwtEvent<PreviewHierarchySele
         return Lists.newArrayList(tag.split("/"));
     }
 
-    public OntologiesView.TreeType getTreeType() {
-        return treeType;
+    public OntologiesView.ViewType getViewType() {
+        return viewType;
     }
 
     public Type<PreviewHierarchySelectedEventHandler> getAssociatedType() {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -658,6 +658,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         view.maskGrids(appearance.loadingMask());
         adminAppService.deleteApp(selectedApp,
                                   new AsyncCallback<Void>() {
+        if (!selectedApp.isDeleted()) {
 
                                       @Override
                                       public void onFailure(Throwable caught) {
@@ -671,6 +672,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                                           view.unmaskGrids();
                                       }
                                   });
+        }
     }
 
     void displayErrorToAdmin() {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -124,7 +124,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         @Override
         public void onFailure(Throwable caught) {
             ErrorHandler.post(caught);
-            view.unmaskTree(OntologiesView.TreeType.EDITOR);
+            view.unmaskTree(OntologiesView.ViewType.EDITOR);
         }
 
         @Override
@@ -134,7 +134,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
             } else {
                 announcer.schedule(new ErrorAnnouncementConfig(
                         appearance.invalidHierarchySubmitted(iri)));
-                view.unmaskTree(OntologiesView.TreeType.EDITOR);
+                view.unmaskTree(OntologiesView.ViewType.EDITOR);
             }
         }
     }
@@ -150,12 +150,12 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         @Override
         public void onFailure(Throwable caught) {
             ErrorHandler.post(caught);
-            view.unmaskTree(OntologiesView.TreeType.EDITOR);
+            view.unmaskTree(OntologiesView.ViewType.EDITOR);
         }
 
         @Override
         public void onSuccess(List<OntologyHierarchy> result) {
-            view.clearTreeStore(OntologiesView.TreeType.EDITOR);
+            view.clearTreeStore(OntologiesView.ViewType.EDITOR);
             if (result.size() == 0) {
                 view.showEmptyTreePanel();
             } else {
@@ -163,12 +163,12 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                 if (!isValid) {
                     displayErrorToAdmin();
                 }
-                view.maskTree(OntologiesView.TreeType.EDITOR);
-                addHierarchies(OntologiesView.TreeType.EDITOR, null, result);
+                view.maskTree(OntologiesView.ViewType.EDITOR);
+                addHierarchies(OntologiesView.ViewType.EDITOR, null, result);
                 addTrashCategory();
                 getFilteredOntologyHierarchies(version, result);
             }
-            view.unmaskTree(OntologiesView.TreeType.EDITOR);
+            view.unmaskTree(OntologiesView.ViewType.EDITOR);
             view.updateButtonStatus();
         }
     }
@@ -364,19 +364,19 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
     void getOntologies(final boolean selectActiveOntology) {
         editorGridPresenter.getView().clearAndAdd(null);
         previewGridPresenter.getView().clearAndAdd(null);
-        view.clearTreeStore(OntologiesView.TreeType.ALL);
+        view.clearTreeStore(OntologiesView.ViewType.ALL);
         serviceFacade.getOntologies(new AsyncCallback<List<Ontology>>() {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);
-                view.unmaskTree(OntologiesView.TreeType.EDITOR);
+                view.unmaskTree(OntologiesView.ViewType.EDITOR);
             }
 
             @Override
             public void onSuccess(List<Ontology> result) {
                 Collections.reverse(result);
                 view.showOntologyVersions(result);
-                view.unmaskTree(OntologiesView.TreeType.EDITOR);
+                view.unmaskTree(OntologiesView.ViewType.EDITOR);
                 if (selectActiveOntology) {
                     for (Ontology ontology : result) {
                         if (ontology.isActive()){
@@ -391,13 +391,13 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
     @Override
     public void onSelectOntologyVersion(SelectOntologyVersionEvent event) {
-        view.clearTreeStore(OntologiesView.TreeType.ALL);
+        view.clearTreeStore(OntologiesView.ViewType.ALL);
         editorGridPresenter.getView().clearAndAdd(null);
         previewGridPresenter.getView().clearAndAdd(null);
         iriToHierarchyMap.clear();
 
         view.showTreePanel();
-        view.maskTree(OntologiesView.TreeType.EDITOR);
+        view.maskTree(OntologiesView.ViewType.EDITOR);
 
         getOntologyHierarchies(event.getSelectedOntology().getVersion());
 
@@ -410,9 +410,9 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
 
     void getFilteredOntologyHierarchies(String version, List<OntologyHierarchy> result) {
-        view.clearTreeStore(OntologiesView.TreeType.PREVIEW);
+        view.clearTreeStore(OntologiesView.ViewType.PREVIEW);
         for (OntologyHierarchy hierarchy: result) {
-            view.maskTree(OntologiesView.TreeType.PREVIEW);
+            view.maskTree(OntologiesView.ViewType.PREVIEW);
             String attr = ontologyUtil.getAttr(hierarchy);
             if (Strings.isNullOrEmpty(attr)) {
                 continue;
@@ -421,23 +421,23 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
                 @Override
                 public void onFailure(Throwable caught) {
                     ErrorHandler.post(caught);
-                    view.unmaskTree(OntologiesView.TreeType.PREVIEW);
+                    view.unmaskTree(OntologiesView.ViewType.PREVIEW);
                 }
 
                 @Override
                 public void onSuccess(OntologyHierarchy result) {
                     if (result != null) {
                         List<OntologyHierarchy> hierarchies = Lists.newArrayList(result);
-                        addHierarchies(OntologiesView.TreeType.PREVIEW, null, hierarchies);
-                        view.reSortTree(OntologiesView.TreeType.PREVIEW);
-                        view.unmaskTree(OntologiesView.TreeType.PREVIEW);
+                        addHierarchies(OntologiesView.ViewType.PREVIEW, null, hierarchies);
+                        view.reSortTree(OntologiesView.ViewType.PREVIEW);
+                        view.unmaskTree(OntologiesView.ViewType.PREVIEW);
                     }
                 }
             });
         }
     }
 
-    void addHierarchies(OntologiesView.TreeType type,
+    void addHierarchies(OntologiesView.ViewType type,
                         OntologyHierarchy parent,
                         List<OntologyHierarchy> children) {
         if ((children == null)
@@ -483,7 +483,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         List<String> iris = event.getIris();
         String ontologyVersion = event.getOntology().getVersion();
         for (String iri : iris) {
-            view.maskTree(OntologiesView.TreeType.EDITOR);
+            view.maskTree(OntologiesView.ViewType.EDITOR);
             serviceFacade.saveOntologyHierarchy(ontologyVersion,
                                                 iri, new SaveHierarchyAsyncCallback(ontologyVersion, iri));
         }
@@ -692,7 +692,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
     @Override
     public void onAppSearchResultLoad(AppSearchResultLoadEvent event) {
-        view.deselectHierarchies(OntologiesView.TreeType.ALL);
+        view.deselectHierarchies(OntologiesView.ViewType.ALL);
     }
 
     public void onRestoreAppButtonClicked(RestoreAppButtonClicked event) {

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -173,7 +173,6 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         }
     }
 
-    static final String TRASH_CATEGORY = "Trash";
     @Inject AppAdminServiceFacade adminAppService;
     @Inject DEProperties properties;
     @Inject IplantAnnouncer announcer;
@@ -312,7 +311,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
             return;
         }
 
-        if (hierarchy.getIri().equalsIgnoreCase(TRASH_CATEGORY)) {
+        if (hierarchy.getIri().equalsIgnoreCase(OntologiesView.TRASH_CATEGORY)) {
             deleteApp(targetApp);
             return;
         }
@@ -461,8 +460,8 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
 
     void addTrashCategory() {
         OntologyHierarchy trash = ontologyUtil.getHierarchyObject();
-        trash.setLabel(TRASH_CATEGORY);
-        trash.setIri(TRASH_CATEGORY);
+        trash.setLabel(OntologiesView.TRASH_CATEGORY);
+        trash.setIri(OntologiesView.TRASH_CATEGORY);
         editorTreeStore.add(trash);
     }
 
@@ -494,7 +493,8 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
     @Override
     public void onCategorizeButtonClicked(CategorizeButtonClickedEvent event) {
         final App selectedApp = event.getSelectedApp();
-        final List<OntologyHierarchy> hierarchyRoots = event.getHierarchyRoots();
+        final List<OntologyHierarchy> hierarchyRoots = Lists.newArrayList();
+        hierarchyRoots.addAll(event.getHierarchyRoots());
         serviceFacade.getAppAVUs(selectedApp, new CategorizeCallback(selectedApp, hierarchyRoots));
     }
 
@@ -544,7 +544,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
             return;
         }
 
-        if (hierarchy.getIri().equalsIgnoreCase(TRASH_CATEGORY)) {
+        if (hierarchy.getIri().equalsIgnoreCase(OntologiesView.TRASH_CATEGORY)) {
             getTrashItems();
             return;
         }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -655,23 +655,22 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
     }
 
     void deleteApp(final App selectedApp) {
-        view.maskGrids(appearance.loadingMask());
-        adminAppService.deleteApp(selectedApp,
-                                  new AsyncCallback<Void>() {
         if (!selectedApp.isDeleted()) {
+            view.maskGrid(OntologiesView.ViewType.ALL);
+            adminAppService.deleteApp(selectedApp, new AsyncCallback<Void>() {
 
-                                      @Override
-                                      public void onFailure(Throwable caught) {
-                                          view.unmaskGrids();
-                                          ErrorHandler.post(caught);
-                                      }
+                @Override
+                public void onFailure(Throwable caught) {
+                    view.unmaskGrid(OntologiesView.ViewType.ALL);
+                    ErrorHandler.post(caught);
+                }
 
-                                      @Override
-                                      public void onSuccess(Void result) {
-                                          view.removeApp(selectedApp);
-                                          view.unmaskGrids();
-                                      }
-                                  });
+                @Override
+                public void onSuccess(Void result) {
+                    view.removeApp(selectedApp);
+                    view.unmaskGrid(OntologiesView.ViewType.ALL);
+                }
+            });
         }
     }
 
@@ -702,11 +701,11 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         Preconditions.checkNotNull(app);
         Preconditions.checkArgument(app.isDeleted());
 
-        view.maskGrids(appearance.loadingMask());
+        view.maskGrid(OntologiesView.ViewType.EDITOR);
         adminAppService.restoreApp(app, new AsyncCallback<App>() {
             @Override
             public void onFailure(Throwable caught) {
-                view.unmaskGrids();
+                view.unmaskGrid(OntologiesView.ViewType.EDITOR);
                 JSONObject obj = jsonUtil.getObject(caught.getMessage());
                 String reason = jsonUtil.getString(obj, "reason");
                 if (reason.contains("orphaned")) {
@@ -719,7 +718,7 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
             @Override
             public void onSuccess(App result) {
                 editorGridPresenter.getView().removeApp(result);
-                view.unmaskGrids();
+                view.unmaskGrid(OntologiesView.ViewType.EDITOR);
                 List<String> hierarchyNames = Lists.newArrayList();
                 for(OntologyHierarchy hierarchy : result.getHierarchies()){
                     hierarchyNames.add(hierarchy.getLabel());
@@ -738,18 +737,18 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
     public void getTrashItems() {
         String id = properties.getDefaultTrashAppCategoryId();
         Preconditions.checkNotNull(id);
-        view.maskGrids(appearance.loadingMask());
+        view.maskGrid(OntologiesView.ViewType.EDITOR);
         appService.getApps(id, new AsyncCallback<List<App>>() {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);
-                view.unmaskGrids();
+                view.unmaskGrid(OntologiesView.ViewType.EDITOR);
             }
 
             @Override
             public void onSuccess(List<App> result) {
                 editorGridPresenter.getView().clearAndAdd(result);
-                view.unmaskGrids();
+                view.unmaskGrid(OntologiesView.ViewType.EDITOR);
             }
         });
     }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/AppCategorizeViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/AppCategorizeViewImpl.java
@@ -125,9 +125,9 @@ public class AppCategorizeViewImpl implements AppCategorizeView {
         addHierarchies(null, hierarchies);
     }
 
-    private void removeUnclassifieds(List<OntologyHierarchy> hierarchies) {
+    private void removeUnclassifiedsAndTrash(List<OntologyHierarchy> hierarchies) {
         for (OntologyHierarchy hierarchy : hierarchies) {
-            if (ontologyUtil.isUnclassified(hierarchy)) {
+            if (ontologyUtil.isUnclassified(hierarchy) || hierarchy.getIri().equalsIgnoreCase(OntologiesView.TRASH_CATEGORY)) {
                 hierarchies.remove(hierarchy);
             }
         }
@@ -138,7 +138,7 @@ public class AppCategorizeViewImpl implements AppCategorizeView {
             return;
         }
         
-        removeUnclassifieds(children);
+        removeUnclassifiedsAndTrash(children);
 
         if (parent == null) {
             treeStore.add(children);

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -450,14 +450,22 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     public void updateButtonStatus() {
-        publishButton.setEnabled(selectedOntology != null && selectedOntology != activeOntology);
-        saveHierarchy.setEnabled(selectedOntology != null);
-        deleteButton.setEnabled(selectedOntology != null && selectedOntology != activeOntology);
-        deleteHierarchy.setEnabled(selectedOntology != null && editorTree.getSelectionModel().getSelectedItem() != null);
-        categorize.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
-        deleteApp.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP) && !targetApp.isDeleted());
-        refreshPreview.setEnabled(selectedOntology != null && editorTreeStore.getRootItems() != null && editorTreeStore.getRootItems().size() > 0);
-        restoreApp.setEnabled(targetApp != null && targetApp.isDeleted());
+        boolean ontologySelected = selectedOntology != null;
+        boolean isActiveOntology = selectedOntology == activeOntology;
+        boolean editorTreeHasSelection = editorTree.getSelectionModel().getSelectedItem() != null;
+        boolean hasAppSelected = targetApp != null;
+        boolean isExternalApp = hasAppSelected && targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP);
+        boolean isDeletedApp = hasAppSelected && targetApp.isDeleted();
+        boolean editorTreeHasHierarchies = editorTreeStore.getRootItems() != null && editorTreeStore.getRootItems().size() > 0;
+
+        publishButton.setEnabled(ontologySelected && !isActiveOntology);
+        saveHierarchy.setEnabled(ontologySelected);
+        deleteButton.setEnabled(ontologySelected && !isActiveOntology);
+        deleteHierarchy.setEnabled(ontologySelected && editorTreeHasSelection);
+        categorize.setEnabled(ontologySelected && hasAppSelected && !isExternalApp);
+        deleteApp.setEnabled(ontologySelected && hasAppSelected && !isExternalApp && !isDeletedApp);
+        refreshPreview.setEnabled(ontologySelected && editorTreeHasHierarchies);
+        restoreApp.setEnabled(isDeletedApp);
     }
 
     @Override

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -144,7 +144,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
             @Override
             public void onSelectionChanged(SelectionChangedEvent<OntologyHierarchy> event) {
                 if (event.getSelection().size() == 1) {
-                    fireEvent(new HierarchySelectedEvent(event.getSelection().get(0), ontologyDropDown.getCurrentValue(), TreeType.EDITOR));
+                    fireEvent(new HierarchySelectedEvent(event.getSelection().get(0), ontologyDropDown.getCurrentValue(), ViewType.EDITOR));
                 }
                 updateButtonStatus();
             }
@@ -154,7 +154,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
             @Override
             public void onSelectionChanged(SelectionChangedEvent<OntologyHierarchy> event) {
                 if (event.getSelection().size() == 1) {
-                    fireEvent(new PreviewHierarchySelectedEvent(event.getSelection().get(0), ontologyDropDown.getCurrentValue(), TreeType.PREVIEW));
+                    fireEvent(new PreviewHierarchySelectedEvent(event.getSelection().get(0), ontologyDropDown.getCurrentValue(), ViewType.PREVIEW));
                 }
                 updateButtonStatus();
             }
@@ -284,7 +284,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void clearTreeStore(TreeType type) {
+    public void clearTreeStore(ViewType type) {
         switch(type){
             case EDITOR:
                 editorTreeStore.clear();
@@ -300,7 +300,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void addToTreeStore(TreeType type, List<OntologyHierarchy> children) {
+    public void addToTreeStore(ViewType type, List<OntologyHierarchy> children) {
         switch(type) {
             case EDITOR:
                 editorTreeStore.add(children);
@@ -316,7 +316,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void addToTreeStore(TreeType type, OntologyHierarchy parent, List<OntologyHierarchy> children) {
+    public void addToTreeStore(ViewType type, OntologyHierarchy parent, List<OntologyHierarchy> children) {
         switch(type) {
             case EDITOR:
                 editorTreeStore.add(parent, children);
@@ -332,7 +332,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void maskTree(TreeType type) {
+    public void maskTree(ViewType type) {
         switch(type) {
             case EDITOR:
                 editorTreePanel.mask(appearance.loadingMask());
@@ -348,7 +348,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void unmaskTree(TreeType type) {
+    public void unmaskTree(ViewType type) {
         switch(type) {
             case EDITOR:
                 editorTreePanel.unmask();
@@ -382,7 +382,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void deselectHierarchies(TreeType type) {
+    public void deselectHierarchies(ViewType type) {
         switch(type) {
             case EDITOR:
                 editorTree.getSelectionModel().deselectAll();
@@ -398,7 +398,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void reSortTree(TreeType type) {
+    public void reSortTree(ViewType type) {
         switch(type) {
             case EDITOR:
                 editorTreeStore.applySort(false);

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -455,7 +455,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
         deleteButton.setEnabled(selectedOntology != null && selectedOntology != activeOntology);
         deleteHierarchy.setEnabled(selectedOntology != null && editorTree.getSelectionModel().getSelectedItem() != null);
         categorize.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
-        deleteApp.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP));
+        deleteApp.setEnabled(selectedOntology != null && targetApp != null && !targetApp.getAppType().equalsIgnoreCase(App.EXTERNAL_APP) && !targetApp.isDeleted());
         refreshPreview.setEnabled(selectedOntology != null && editorTreeStore.getRootItems() != null && editorTreeStore.getRootItems().size() > 0);
         restoreApp.setEnabled(targetApp != null && targetApp.isDeleted());
     }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -461,15 +461,35 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     }
 
     @Override
-    public void maskGrids(String loadingMask) {
-        previewGridView.mask(loadingMask);
-        editorGridView.mask(loadingMask);
+    public void maskGrid(ViewType type) {
+        switch(type) {
+            case EDITOR:
+                editorGridView.mask(appearance.loadingMask());
+                break;
+            case PREVIEW:
+                previewGridView.mask(appearance.loadingMask());
+                break;
+            case ALL:
+                editorGridView.mask(appearance.loadingMask());
+                previewGridView.mask(appearance.loadingMask());
+                break;
+        }
     }
 
     @Override
-    public void unmaskGrids() {
-        previewGridView.unmask();
-        editorGridView.unmask();
+    public void unmaskGrid(ViewType type) {
+        switch(type) {
+            case EDITOR:
+                editorGridView.unmask();
+                break;
+            case PREVIEW:
+                previewGridView.unmask();
+                break;
+            case ALL:
+                editorGridView.unmask();
+                previewGridView.unmask();
+                break;
+        }
     }
 
     @Override

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
@@ -657,13 +657,13 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.onDeleteAppsSelected(eventMock);
 
-        verify(viewMock).maskGrids(eq(appearanceMock.loadingMask()));
+        verify(viewMock).maskGrid(eq(OntologiesView.ViewType.ALL));
         verify(adminAppServiceMock).deleteApp(eq(appMock), asyncVoidCaptor.capture());
 
         asyncVoidCaptor.getValue().onSuccess(null);
 
         verify(viewMock).removeApp(appMock);
-        verify(viewMock).unmaskGrids();
+        verify(viewMock).unmaskGrid(OntologiesView.ViewType.ALL);
     }
 
     @Test
@@ -697,7 +697,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.onRestoreAppButtonClicked(eventMock);
 
-        verify(viewMock).maskGrids(eq(appearanceMock.loadingMask()));
+        verify(viewMock).maskGrid(eq(OntologiesView.ViewType.EDITOR));
         verify(adminAppServiceMock).restoreApp(eq(appMock), asyncAppCaptor.capture());
 
         asyncAppCaptor.getValue().onSuccess(appMock);
@@ -711,7 +711,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.getTrashItems();
 
-        verify(viewMock).maskGrids(eq(appearanceMock.loadingMask()));
+        verify(viewMock).maskGrid(eq(OntologiesView.ViewType.EDITOR));
         verify(appServiceMock).getApps(anyString(), asyncAppListCaptor.capture());
 
         asyncAppListCaptor.getValue().onSuccess(appListMock);

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImplTest.java
@@ -41,11 +41,9 @@ import org.iplantc.de.client.models.ontologies.Ontology;
 import org.iplantc.de.client.models.ontologies.OntologyAutoBeanFactory;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 import org.iplantc.de.client.models.ontologies.OntologyVersionDetail;
-import org.iplantc.de.client.services.AppServiceFacade;
 import org.iplantc.de.client.util.OntologyUtil;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
-import org.iplantc.de.shared.DEProperties;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -253,12 +251,12 @@ public class OntologiesPresenterImplTest {
 
         verify(editorGridViewMock).clearAndAdd(null);
         verify(previewGridViewMock).clearAndAdd(null);
-        verify(viewMock).clearTreeStore(isA(OntologiesView.TreeType.class));
+        verify(viewMock).clearTreeStore(isA(OntologiesView.ViewType.class));
         verify(serviceFacadeMock).getOntologies(asyncCallbackOntologyListCaptor.capture());
 
         asyncCallbackOntologyListCaptor.getValue().onSuccess(listOntologyMock);
         verify(viewMock).showOntologyVersions(eq(listOntologyMock));
-        verify(viewMock).unmaskTree(isA(OntologiesView.TreeType.class));
+        verify(viewMock).unmaskTree(isA(OntologiesView.ViewType.class));
         verifyNoMoreInteractions(viewMock);
     }
 
@@ -272,7 +270,7 @@ public class OntologiesPresenterImplTest {
 
         asyncCallbackOntologyListCaptor.getValue().onSuccess(listOntologyMock);
         verify(viewMock).showOntologyVersions(eq(listOntologyMock));
-        verify(viewMock).unmaskTree(isA(OntologiesView.TreeType.class));
+        verify(viewMock).unmaskTree(isA(OntologiesView.ViewType.class));
         verify(ontologyMock).isActive();
         verify(activeOntologyMock).isActive();
         verify(viewMock).selectActiveOntology(activeOntologyMock);
@@ -389,7 +387,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.onSelectOntologyVersion(eventMock);
 
-        verify(viewMock).clearTreeStore(isA(OntologiesView.TreeType.class));
+        verify(viewMock).clearTreeStore(isA(OntologiesView.ViewType.class));
 
         verify(serviceFacadeMock).getOntologyHierarchies(eq(eventMock.getSelectedOntology()
                                                                      .getVersion()),
@@ -418,7 +416,7 @@ public class OntologiesPresenterImplTest {
                                           editorGridPresenterMock,
                                           categorizeViewMock) {
             @Override
-            void addHierarchies(OntologiesView.TreeType type,
+            void addHierarchies(OntologiesView.ViewType type,
                                 OntologyHierarchy parent,
                                 List<OntologyHierarchy> children) {
             }
@@ -435,7 +433,7 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.onSelectOntologyVersion(eventMock);
 
-        verify(viewMock).clearTreeStore(isA(OntologiesView.TreeType.class));
+        verify(viewMock).clearTreeStore(isA(OntologiesView.ViewType.class));
 
         verify(serviceFacadeMock).getOntologyHierarchies(eq(eventMock.getSelectedOntology()
                                                                      .getVersion()),
@@ -466,7 +464,7 @@ public class OntologiesPresenterImplTest {
                                           editorGridPresenterMock,
                                           categorizeViewMock) {
             @Override
-            void addHierarchies(OntologiesView.TreeType type,
+            void addHierarchies(OntologiesView.ViewType type,
                                 OntologyHierarchy parent,
                                 List<OntologyHierarchy> children) {
             }
@@ -496,10 +494,10 @@ public class OntologiesPresenterImplTest {
 
         asyncOntologyHierarchyListCaptor.getValue().onSuccess(ontologyHierarchyListMock);
 
-        verify(viewMock, times(2)).clearTreeStore(isA(OntologiesView.TreeType.class));
+        verify(viewMock, times(2)).clearTreeStore(isA(OntologiesView.ViewType.class));
         verify(utilMock).createIriToAttrMap(eq(ontologyHierarchyListMock));
-        verify(viewMock, times(5)).maskTree(isA(OntologiesView.TreeType.class));
-        verify(viewMock).unmaskTree(isA(OntologiesView.TreeType.class));
+        verify(viewMock, times(5)).maskTree(isA(OntologiesView.ViewType.class));
+        verify(viewMock).unmaskTree(isA(OntologiesView.ViewType.class));
         verify(viewMock).updateButtonStatus();
 
         verify(viewMock).showTreePanel();
@@ -676,8 +674,8 @@ public class OntologiesPresenterImplTest {
         /** CALL METHOD UNDER TEST **/
         uut.getFilteredOntologyHierarchies("version", ontologyHierarchyListMock);
 
-        verify(viewMock).clearTreeStore(isA(OntologiesView.TreeType.class));
-        verify(viewMock, times(2)).maskTree(isA(OntologiesView.TreeType.class));
+        verify(viewMock).clearTreeStore(isA(OntologiesView.ViewType.class));
+        verify(viewMock, times(2)).maskTree(isA(OntologiesView.ViewType.class));
 
         verify(serviceFacadeMock, times(2)).getFilteredOntologyHierarchy(anyString(),
                                                                          anyString(),
@@ -686,8 +684,8 @@ public class OntologiesPresenterImplTest {
 
         asyncOntologyHierarchyCaptor.getValue().onSuccess(hierarchyMock);
 
-        verify(viewMock).reSortTree(isA(OntologiesView.TreeType.class));
-        verify(viewMock).unmaskTree(isA(OntologiesView.TreeType.class));
+        verify(viewMock).reSortTree(isA(OntologiesView.ViewType.class));
+        verify(viewMock).unmaskTree(isA(OntologiesView.ViewType.class));
 
     }
 
@@ -718,6 +716,6 @@ public class OntologiesPresenterImplTest {
 
         asyncAppListCaptor.getValue().onSuccess(appListMock);
         verify(editorGridViewMock).clearAndAdd(eq(appListMock));
-        verify(viewMock).unmaskGrids();
+        verify(viewMock).unmaskGrid(OntologiesView.ViewType.EDITOR);
     }
 }


### PR DESCRIPTION
Currently, if you click on the Trash category in the App Catalog tab, both the editor grid and the preview grid get masked when only the editor grid should get masked.

Also, when you try to categorize an app, the Trash category is listed when it should not be.  Deleting an app should be done through either drag-and-drop to the Trash category or clicking the Delete App button.

I also renamed TreeType to ViewType (most of the modifications in this PR), since I needed a way to choose which grid to mask and selecting the grid based on a "TreeType" did not make sense.