### PR TITLE
CORE-8130 Add Workshop Admin tests

### DIFF
--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/workshopAdmin/presenter/WorkshopAdminPresenterImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/workshopAdmin/presenter/WorkshopAdminPresenterImpl.java
@@ -1,11 +1,5 @@
 package org.iplantc.de.admin.desktop.client.workshopAdmin.presenter;
 
-import com.google.common.base.Strings;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.HasOneWidget;
-import com.google.gwt.util.tools.shared.StringUtils;
-import com.google.inject.Inject;
-import com.sencha.gxt.data.shared.ListStore;
 import org.iplantc.de.admin.desktop.client.workshopAdmin.WorkshopAdminView;
 import org.iplantc.de.admin.desktop.client.workshopAdmin.events.DeleteMembersClickedEvent;
 import org.iplantc.de.admin.desktop.client.workshopAdmin.events.RefreshMembersClickedEvent;
@@ -21,6 +15,12 @@ import org.iplantc.de.client.models.groups.MemberSaveResult;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.commons.client.ErrorHandler;
 
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.inject.Inject;
+
+import com.sencha.gxt.data.shared.ListStore;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,9 +33,9 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
     private final WorkshopAdminServiceFacade serviceFacade;
     private final GroupAutoBeanFactory groupAutoBeanFactory;
     private final WorkshopAdminView.WorkshopAdminViewAppearance appearance;
-    private final ListStore<Member> listStore;
+    ListStore<Member> listStore;
 
-    private final class UserSearchResultSelectedEventHandler
+    final class UserSearchResultSelectedEventHandler
             implements UserSearchResultSelected.UserSearchResultSelectedEventHandler {
 
         private Member memberFromCollaborator(Collaborator collaborator) {
@@ -66,7 +66,7 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
         public void onUserSearchResultSelected(UserSearchResultSelected event) {
 
             // Ignore the event if it wasn't initiated by the workshop admin panel.
-            if (!event.matchesTag(view.userSearchEventTag)) {
+            if (!event.matchesTag(WorkshopAdminView.userSearchEventTag)) {
                 return;
             }
 
@@ -78,7 +78,7 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
         }
     }
 
-    private final class DeleteMembersClickedEventHandler
+    final class DeleteMembersClickedEventHandler
             implements DeleteMembersClickedEvent.DeleteMembersClickedEventHandler {
 
         @Override
@@ -89,7 +89,7 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
         }
     }
 
-    private final class SaveMembersClickedEventHandler
+    final class SaveMembersClickedEventHandler
             implements SaveMembersClickedEvent.SaveMembersClickedEventHandler {
 
         @Override
@@ -98,7 +98,7 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
         }
     }
 
-    private final class RefreshMembersClickedEventHandler
+    final class RefreshMembersClickedEventHandler
             implements RefreshMembersClickedEvent.RefreshMembersClickedEventHandler {
 
         @Override
@@ -113,15 +113,12 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
                                       final GroupAutoBeanFactory groupAutoBeanFactory,
                                       final MemberProperties memberProperties,
                                       final WorkshopAdminView.WorkshopAdminViewAppearance appearance) {
-        listStore = new ListStore<>(memberProperties.id());
+        listStore = getMemberListStore(memberProperties);
         view = viewFactory.create(listStore);
         this.serviceFacade = serviceFacade;
         this.groupAutoBeanFactory = groupAutoBeanFactory;
         this.appearance = appearance;
-        registerEventHandlers();
-    }
 
-    private void registerEventHandlers() {
         view.addGlobalEventHandler(UserSearchResultSelected.TYPE, new UserSearchResultSelectedEventHandler());
         view.addLocalEventHandler(DeleteMembersClickedEvent.TYPE, new DeleteMembersClickedEventHandler());
         view.addLocalEventHandler(SaveMembersClickedEvent.TYPE, new SaveMembersClickedEventHandler());
@@ -139,7 +136,7 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
         view.asWidget().ensureDebugId(baseId + Belphegor.WorkshopAdminIds.VIEW);
     }
 
-    private void updateView() {
+    void updateView() {
         view.mask(appearance.loadingMask());
         serviceFacade.getMembers(new AsyncCallback<List<Member>>() {
             @Override
@@ -156,7 +153,7 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
         });
     }
 
-    private void saveMembers(List<Member> members) {
+    void saveMembers(List<Member> members) {
         view.mask(appearance.loadingMask());
         serviceFacade.saveMembers(members, new AsyncCallback<MemberSaveResult>() {
             @Override
@@ -174,5 +171,9 @@ public class WorkshopAdminPresenterImpl implements WorkshopAdminView.Presenter {
                 view.unmask();
             }
         });
+    }
+
+    ListStore<Member> getMemberListStore(MemberProperties memberProperties) {
+        return new ListStore<>(memberProperties.id());
     }
 }

--- a/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/workshopAdmin/view/WorkshopAdminViewImpl.java
+++ b/ui/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/workshopAdmin/view/WorkshopAdminViewImpl.java
@@ -1,5 +1,14 @@
 package org.iplantc.de.admin.desktop.client.workshopAdmin.view;
 
+import org.iplantc.de.admin.desktop.client.workshopAdmin.WorkshopAdminView;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.events.DeleteMembersClickedEvent;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.events.RefreshMembersClickedEvent;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.events.SaveMembersClickedEvent;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.model.MemberProperties;
+import org.iplantc.de.client.events.EventBus;
+import org.iplantc.de.client.models.groups.Member;
+import org.iplantc.de.collaborators.client.util.UserSearchField;
+
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.EventHandler;
@@ -12,6 +21,7 @@ import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+
 import com.sencha.gxt.core.client.Style;
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.Composite;
@@ -20,14 +30,6 @@ import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
-import org.iplantc.de.admin.desktop.client.workshopAdmin.WorkshopAdminView;
-import org.iplantc.de.admin.desktop.client.workshopAdmin.events.DeleteMembersClickedEvent;
-import org.iplantc.de.admin.desktop.client.workshopAdmin.events.RefreshMembersClickedEvent;
-import org.iplantc.de.admin.desktop.client.workshopAdmin.events.SaveMembersClickedEvent;
-import org.iplantc.de.admin.desktop.client.workshopAdmin.model.MemberProperties;
-import org.iplantc.de.client.events.EventBus;
-import org.iplantc.de.client.models.groups.Member;
-import org.iplantc.de.collaborators.client.util.UserSearchField;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +48,7 @@ public class WorkshopAdminViewImpl extends Composite implements WorkshopAdminVie
     @UiField(provided = true) WorkshopAdminViewAppearance appearance;
 
     private MemberProperties memberProperties;
-    private final ArrayList<HandlerRegistration> globalHandlerRegistrations = new ArrayList<>();
+    ArrayList<HandlerRegistration> globalHandlerRegistrations = new ArrayList<>();
 
     private static WorkshopAdminViewImplUiBinder uiBinder = GWT.create(WorkshopAdminViewImplUiBinder.class);
 

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/workshopAdmin/presenter/WorkshopAdminPresenterImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/workshopAdmin/presenter/WorkshopAdminPresenterImplTest.java
@@ -1,0 +1,148 @@
+package org.iplantc.de.admin.desktop.client.workshopAdmin.presenter;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.admin.desktop.client.workshopAdmin.WorkshopAdminView;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.events.DeleteMembersClickedEvent;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.events.RefreshMembersClickedEvent;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.events.SaveMembersClickedEvent;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.gin.factory.WorkshopAdminViewFactory;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.model.MemberProperties;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.service.WorkshopAdminServiceFacade;
+import org.iplantc.de.client.models.collaborators.Collaborator;
+import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
+import org.iplantc.de.client.models.groups.Member;
+import org.iplantc.de.client.models.groups.MemberSaveResult;
+import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import com.sencha.gxt.data.shared.ListStore;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class WorkshopAdminPresenterImplTest {
+
+    @Mock WorkshopAdminView viewMock;
+    @Mock WorkshopAdminViewFactory viewFactoryMock;
+    @Mock WorkshopAdminServiceFacade serviceFacadeMock;
+    @Mock GroupAutoBeanFactory factoryMock;
+    @Mock WorkshopAdminView.WorkshopAdminViewAppearance appearanceMock;
+    @Mock ListStore<Member> listStoreMock;
+    @Mock List<Member> memberListMock;
+    @Mock MemberSaveResult memberSaveResultMock;
+    @Mock MemberProperties propertiesMock;
+    @Mock List<String> stringListMock;
+    @Mock Collaborator collaboratorMock;
+    @Mock Iterator<Member> memberIteratorMock;
+    @Mock Member memberMock;
+
+    @Captor ArgumentCaptor<AsyncCallback<MemberSaveResult>> memberSaveCallbackCaptor;
+    @Captor ArgumentCaptor<AsyncCallback<List<Member>>> memberListCallbackCaptor;
+
+    private WorkshopAdminPresenterImpl uut;
+
+    @Before
+    public void setUp() throws Exception {
+        when(appearanceMock.loadingMask()).thenReturn("mask");
+        when(appearanceMock.partialGroupSaveMsg()).thenReturn("partial");
+        when(viewFactoryMock.create(listStoreMock)).thenReturn(viewMock);
+
+        uut = new WorkshopAdminPresenterImpl(viewFactoryMock,
+                                             serviceFacadeMock,
+                                             factoryMock,
+                                             propertiesMock,
+                                             appearanceMock) {
+            @Override
+            ListStore<Member> getMemberListStore(MemberProperties memberProperties) {
+                return listStoreMock;
+            }
+
+        };
+
+        uut.listStore = listStoreMock;
+    }
+
+    @Test
+    public void verifyConstructor() {
+        verify(viewFactoryMock).create(eq(listStoreMock));
+
+        verify(viewMock).addGlobalEventHandler(eq(UserSearchResultSelected.TYPE), isA(
+                WorkshopAdminPresenterImpl.UserSearchResultSelectedEventHandler.class));
+
+        verify(viewMock).addLocalEventHandler(eq(DeleteMembersClickedEvent.TYPE), isA(
+                WorkshopAdminPresenterImpl.DeleteMembersClickedEventHandler.class));
+
+        verify(viewMock).addLocalEventHandler(eq(SaveMembersClickedEvent.TYPE), isA(
+                WorkshopAdminPresenterImpl.SaveMembersClickedEventHandler.class));
+
+        verify(viewMock).addLocalEventHandler(eq(RefreshMembersClickedEvent.TYPE), isA(
+                RefreshMembersClickedEvent.RefreshMembersClickedEventHandler.class));
+
+        verifyNoMoreInteractions(viewMock, viewFactoryMock, listStoreMock);
+    }
+
+    @Test
+    public void testGo() throws Exception {
+        HasOneWidget containerMock = mock(HasOneWidget.class);
+        WorkshopAdminPresenterImpl spy = spy(uut);
+
+        spy.go(containerMock);
+        verify(containerMock).setWidget(viewMock);
+        verify(spy).updateView();
+    }
+
+    @Test
+    public void testUpdateView() throws Exception {
+
+        /** CALL METHOD UNDER TEST **/
+        uut.updateView();
+
+        verify(viewMock).mask(eq(appearanceMock.loadingMask()));
+        verify(serviceFacadeMock).getMembers(memberListCallbackCaptor.capture());
+
+        memberListCallbackCaptor.getValue().onSuccess(memberListMock);
+        verify(listStoreMock).replaceAll(eq(memberListMock));
+        verify(viewMock).unmask();
+
+    }
+
+    @Test
+    public void testSaveMembers_NoFailures() {
+
+        when(stringListMock.isEmpty()).thenReturn(true);
+        when(memberSaveResultMock.getFailures()).thenReturn(stringListMock);
+        when(memberSaveResultMock.getMembers()).thenReturn(memberListMock);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.saveMembers(memberListMock);
+
+        verify(viewMock).mask(eq(appearanceMock.loadingMask()));
+        verify(serviceFacadeMock).saveMembers(eq(memberListMock), memberSaveCallbackCaptor.capture());
+
+        memberSaveCallbackCaptor.getValue().onSuccess(memberSaveResultMock);
+
+        verify(listStoreMock).replaceAll(eq(memberListMock));
+        verify(viewMock).unmask();
+    }
+}

--- a/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/workshopAdmin/view/WorkshopAdminViewImplTest.java
+++ b/ui/de-lib/src/test/java/org/iplantc/de/admin/desktop/client/workshopAdmin/view/WorkshopAdminViewImplTest.java
@@ -1,0 +1,61 @@
+package org.iplantc.de.admin.desktop.client.workshopAdmin.view;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.admin.desktop.client.workshopAdmin.WorkshopAdminView;
+import org.iplantc.de.admin.desktop.client.workshopAdmin.model.MemberProperties;
+import org.iplantc.de.client.models.groups.Member;
+import org.iplantc.de.collaborators.client.util.UserSearchField;
+
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwtmockito.GxtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+
+import com.sencha.gxt.data.shared.ListStore;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+/**
+ * @author aramseyds
+ */
+@RunWith(GxtMockitoTestRunner.class)
+@WithClassesToStub(UserSearchField.class)
+public class WorkshopAdminViewImplTest {
+
+    @Mock WorkshopAdminView.WorkshopAdminViewAppearance appearanceMock;
+    @Mock MemberProperties propertiesMock;
+    @Mock ListStore<Member> listStoreMock;
+    @Mock ArrayList<HandlerRegistration> globalRegistrationMock;
+    @Mock Iterator<HandlerRegistration> registrationIteratorMock;
+    @Mock HandlerRegistration handlerMock;
+
+    private WorkshopAdminViewImpl uut;
+
+    @Before
+    public void setUp() {
+        when(globalRegistrationMock.size()).thenReturn(2);
+        when(globalRegistrationMock.iterator()).thenReturn(registrationIteratorMock);
+        when(registrationIteratorMock.hasNext()).thenReturn(true, true, false);
+        when(registrationIteratorMock.next()).thenReturn(handlerMock, handlerMock);
+
+        uut = new WorkshopAdminViewImpl(appearanceMock, propertiesMock, listStoreMock);
+        uut.globalHandlerRegistrations = globalRegistrationMock;
+    }
+
+    @Test
+    public void testOnUnload() {
+        /** CALL METHOD UNDER TEST **/
+        uut.onUnload();
+
+        verify(handlerMock, times(2)).removeHandler();
+        verify(globalRegistrationMock).clear();
+    }
+}


### PR DESCRIPTION
Some small mods to the WorkAdmin code in order to get Mockito to be happy.

I couldn't get Mockito to properly test the methods within the inner event handler classes.  If we later decide to refactor to implementing the event handler interfaces in the presenter, then we can add tests for those handler methods as well.