### PR TITLE
CORE-7544 Fix reference genome path/name validation.

### DIFF
--- a/services/apps/src/apps/metadata/reference_genomes.clj
+++ b/services/apps/src/apps/metadata/reference_genomes.clj
@@ -50,11 +50,6 @@
       (where {:id [in uuids]}))
     (select (reference-genome-base-query))))
 
-(defn get-all-reference-genomes
-  "Lists all of the reference genomes in the database, including those marked as deleted."
-  []
-  (select (reference-genome-base-query)))
-
 (defn list-reference-genomes
   "Lists the reference genomes in the database."
   ([]
@@ -71,7 +66,7 @@
 (defn- validate-reference-genome-path
   "Verifies that a reference genome with the same path doesn't already exist."
   ([path id]
-     (if (seq (get-reference-genomes-where {:path path :id [not= id]}))
+     (if (seq (get-reference-genomes-where {:path path :id ['not= id]}))
        (cxu/exists "Another reference genome with the given path already exists." :path path)))
   ([path]
      (if (seq (get-reference-genomes-where {:path path}))
@@ -80,7 +75,7 @@
 (defn- validate-reference-genome-name
   "Verifies that a reference genome with the same name doesn't already exist."
   ([name id]
-     (if (seq (get-reference-genomes-where {:name name :id [not= id]}))
+     (if (seq (get-reference-genomes-where {:name name :id ['not= id]}))
        (cxu/exists "Another reference genome with the given name already exists." :name name)))
   ([name]
      (if (seq (get-reference-genomes-where {:name name}))


### PR DESCRIPTION
When attempting to rename or update the path of a reference genome, the `PATCH /admin/reference-genomes/` endpoint would return an error like
```json
{"error_code":"ERR_EXISTS","reason":"Another reference genome with the given name already exists."}

```

The `not=` symbol needs to be quoted when used outside of the korma `where` macro.
Otherwise the path and name validation conditionals were parsed as queries like
```sql
WHERE (? AND "genome_reference"."path" = ?)
```
which always found a match when attempting to update just the path or name of an existing reference genome.

Also removed the unused `apps.metadata.reference-genomes/get-all-reference-genomes` function.