### PR TITLE
CORE-8155: fix call signatures for job sharing validations

### DIFF
--- a/services/apps/src/apps/service/apps/job_listings.clj
+++ b/services/apps/src/apps/service/apps/job_listings.clj
@@ -58,7 +58,7 @@
     :parent_id       parent-id
     :batch           (:is-batch job)
     :batch_status    (when (:is-batch job) (format-batch-status id))
-    :can_share       (and (nil? parent-id) (job-permissions/supports-job-sharing? apps-client (rep-steps id)))}))
+    :can_share       (and (nil? parent-id) (job-permissions/job-steps-support-job-sharing? apps-client (rep-steps id)))}))
 
 (defn- list-jobs*
   [{:keys [username]} search-params types analysis-ids]

--- a/services/apps/src/apps/service/apps/jobs/permissions.clj
+++ b/services/apps/src/apps/service/apps/jobs/permissions.clj
@@ -7,14 +7,18 @@
             [clojure.tools.logging :as log]
             [clojure-commons.exception-util :as cxu]))
 
-(defn supports-job-sharing?
+(defn job-steps-support-job-sharing?
   [apps-client job-steps]
   (every? #(.supportsJobSharing apps-client %) job-steps))
+
+(defn job-supports-job-sharing?
+  [apps-client job-id]
+  (job-steps-support-job-sharing? apps-client (jp/list-representative-job-steps [job-id])))
 
 (defn- validate-job-sharing-support
   [apps-client job-ids]
   (doseq [job-id job-ids]
-    (when-not (supports-job-sharing? apps-client job-id)
+    (when-not (job-supports-job-sharing? apps-client job-id)
       (cxu/bad-request (str "analysis sharing not supported for " job-id)))))
 
 (defn- verify-not-subjobs

--- a/services/apps/src/apps/service/apps/jobs/sharing.clj
+++ b/services/apps/src/apps/service/apps/jobs/sharing.clj
@@ -77,7 +77,7 @@
 
 (defn- verify-support
   [apps-client job-id]
-  (when-not (job-permissions/supports-job-sharing? apps-client job-id)
+  (when-not (job-permissions/job-supports-job-sharing? apps-client job-id)
     (job-sharing-msg :not-supported job-id)))
 
 (defn- share-app-for-job


### PR DESCRIPTION
`supports-job-sharing?` was changed in 0e5aae1abac55d609d51b6070307f0e5b1e8fd64 to take a list of job steps rather than a job ID, but not all of the places it was called were updated.

This adds another function which does the lookup of job steps from job ID that the old function did, and renames both functions to be more descriptive, updating their call sites as appropriate.