### PR TITLE
Remove extraneous imports of jargon, import log4j properly in facepalm

### DIFF
--- a/services/clockwork/project.clj
+++ b/services/clockwork/project.clj
@@ -30,9 +30,6 @@
                  [com.mchange/c3p0 "0.9.5.1"]
                  [korma "0.3.0-RC5"
                   :exclusions [c3p0]]
-                 [org.iplantc/clj-jargon "5.2.8.0"
-                   :exclusions [[org.slf4j/slf4j-log4j12]
-                                [log4j]]]
                  [org.iplantc/clojure-commons "5.2.8.0"]
                  [org.iplantc/common-cli "5.2.8.0"]
                  [org.iplantc/kameleon "5.2.8.0"]

--- a/services/clockwork/src/clockwork/config.clj
+++ b/services/clockwork/src/clockwork/config.clj
@@ -1,7 +1,6 @@
 (ns clockwork.config
   (:use [slingshot.slingshot :only [throw+]])
-  (:require [clj-jargon.init :as jargon]
-            [clojure-commons.config :as cc]
+  (:require [clojure-commons.config :as cc]
             [clojure-commons.error-codes :as ce]))
 
 (def ^:private props
@@ -113,9 +112,3 @@
   (cc/load-config-from-file cfg-path props)
   (cc/log-config props)
   (validate-config))
-
-(defn jargon-config
-  "Obtains a Jargon configuration map."
-  []
-  (jargon/init (irods-host) (irods-port) (irods-user) (irods-password) (irods-home) (irods-zone)
-               (irods-resource)))

--- a/tools/facepalm/project.clj
+++ b/tools/facepalm/project.clj
@@ -28,7 +28,7 @@
                  [korma "0.4.0"
                   :exclusions [c3p0]]
                  [me.raynes/fs "1.4.6"]
-                 [org.iplantc/clj-jargon "5.2.8.0"]
+                 [log4j "1.2.16"]
                  [org.iplantc/clojure-commons "5.2.8.0"]
                  [org.iplantc/kameleon "5.2.8.0"]
                  [postgresql "9.1-901-1.jdbc4"]


### PR DESCRIPTION
This won't go into 2.8. Depending how repository splitting etc. goes we can either re-do this in new repos or merge this, either way.
