### PR TITLE
Use temporary tables rather than CTEs to speed up certain paged directory listing queries

### DIFF
--- a/libs/clj-icat-direct/src/clj_icat_direct/icat.clj
+++ b/libs/clj-icat-direct/src/clj_icat_direct/icat.clj
@@ -3,7 +3,6 @@
   (:require [clojure.string :as string]
             [korma.db :as db]
             [korma.core :as k]
-            [clojure.java.jdbc :as jdbc]
             [clj-icat-direct.queries :as q])
   (:import [clojure.lang ISeq Keyword]))
 
@@ -48,8 +47,8 @@
     (let [side-effects (drop-last 1 queries)
           final-query-and-args (last queries)]
       (doseq [q side-effects]
-        ; uses jdbc/execute! because this can run DDL statements like CREATE TEMPORARY TABLE
-        (jdbc/execute! db/*current-conn* q))
+        ; uses exec-raw directly here to exclude :results so this can run DDL statements
+        (k/exec-raw icat q))
       (apply run-query-string final-query-and-args))))
 
 (defn number-of-files-in-folder

--- a/libs/clj-icat-direct/src/clj_icat_direct/icat.clj
+++ b/libs/clj-icat-direct/src/clj_icat_direct/icat.clj
@@ -80,12 +80,12 @@
      info types."
   [^String user ^String zone ^String folder-path ^Keyword entity-type & [info-types]]
   (let [type-cond (q/mk-file-type-cond info-types)
-        query     (case entity-type
+        queries   (case entity-type
                     :any    (q/mk-count-items-in-folder user zone folder-path type-cond)
                     :file   (q/mk-count-files-in-folder user zone folder-path type-cond)
                     :folder (q/mk-count-folders-in-folder user zone folder-path)
                             (throw (Exception. (str "invalid entity type " entity-type))))]
-    (-> (run-query-string query) first :total)))
+    (-> (apply run-transaction queries) first :total)))
 
 
 (defn number-of-all-items-under-folder

--- a/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
+++ b/libs/clj-icat-direct/src/clj_icat_direct/queries.clj
@@ -145,7 +145,7 @@
 
 (defn- mk-obj-avus
   [obj-ids-query]
-  (str "SELECT *
+  (str "SELECT object_id, meta_attr_value, meta_attr_name
           FROM r_objt_metamap AS o JOIN r_meta_main AS m ON o.meta_id = m.meta_id
           WHERE o.object_id = ANY(ARRAY(" obj-ids-query "))"))
 
@@ -316,7 +316,7 @@
   (let [group-query "SELECT group_user_id FROM groups"]
     [[(mk-temp-table "groups" (mk-groups user zone))]
      [(mk-temp-table "objs" (mk-unique-objs-in-coll parent-path))]
-     [(mk-temp-table "file_avus" (str "SELECT object_id, meta_attr_value, meta_attr_name FROM (" (mk-obj-avus "SELECT data_id FROM objs") ") obj_avus"))]
+     [(mk-temp-table "file_avus" (mk-obj-avus "SELECT data_id FROM objs"))]
      [(str (mk-count-objs-of-type "objs" "file_avus" group-query info-type-cond))]]))
 
 
@@ -355,7 +355,7 @@
         files-query   (mk-count-objs-of-type "objs" "file_avus" group-query info-type-cond)]
     [[(mk-temp-table "groups" (mk-groups user zone))]
      [(mk-temp-table "objs" (mk-unique-objs-in-coll parent-path))]
-     [(mk-temp-table "file_avus" (str "SELECT object_id, meta_attr_value, meta_attr_name FROM (" (mk-obj-avus "SELECT data_id FROM objs") ") obj_avus"))]
+     [(mk-temp-table "file_avus" (mk-obj-avus "SELECT data_id FROM objs"))]
      [(str "SELECT ((" folders-query ") + (" files-query ")) AS total")]]))
 
 
@@ -392,7 +392,7 @@
   (let [group-query "SELECT group_user_id FROM groups"]
     [[(mk-temp-table "groups" (mk-groups user zone))]
      [(mk-temp-table "objs" (mk-unique-objs-in-coll parent-path))]
-     [(mk-temp-table "file_avus" (str "SELECT object_id, meta_attr_value, meta_attr_name FROM (" (mk-obj-avus "SELECT data_id FROM objs") ") obj_avus"))]
+     [(mk-temp-table "file_avus" (mk-obj-avus "SELECT data_id FROM objs"))]
      [(str (mk-files-in-folder parent-path group-query info-type-cond "objs" "file_avus") "
            ORDER BY " sort-column " " sort-direction "
            LIMIT ?
@@ -472,7 +472,7 @@
                                           "file_avus")]
     [[(mk-temp-table "groups" (mk-groups user zone))]
      [(mk-temp-table "objs" (mk-unique-objs-in-coll parent-path))]
-     [(mk-temp-table "file_avus" (str "SELECT object_id, meta_attr_value, meta_attr_name FROM (" (mk-obj-avus "SELECT data_id FROM objs") ") obj_avus"))]
+     [(mk-temp-table "file_avus" (mk-obj-avus "SELECT data_id FROM objs"))]
      [(str "SELECT *
             FROM (" folders-query " UNION " files-query ") AS t
             ORDER BY type ASC, " sort-column " " sort-direction "


### PR DESCRIPTION
PostgreSQL is rubbish at predicting the number of rows for CTE Scans, which goes really badly when the answer is 16000 and it guesses 25.

It doesn't have this issue with temporary tables being created instead, so this does that.